### PR TITLE
feat(cost): swipeable cost screen with 4 visualizations + tabbed settings

### DIFF
--- a/Sources/App.swift
+++ b/Sources/App.swift
@@ -26,6 +26,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // already has cached values the first time the user hovers, instead
         // of flashing "0%" while the first request lands.
         UsageStore.shared.startAutoRefresh()
+        CostStore.shared.startAutoRefresh()
 
         // Touch the shared updater so Sparkle starts its background scheduler.
         _ = UpdaterController.shared

--- a/Sources/Cost/ClaudeLogReader.swift
+++ b/Sources/Cost/ClaudeLogReader.swift
@@ -62,69 +62,110 @@ enum ClaudeLogReader {
         seen: inout Set<String>,
         into out: inout [TokenEvent]
     ) {
-        guard let data = try? Data(contentsOf: url),
-              let text = String(data: data, encoding: .utf8) else { return }
+        guard let handle = try? FileHandle(forReadingFrom: url) else { return }
+        defer { try? handle.close() }
 
         let formatter = ISO8601DateFormatter()
         formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
         let formatterNoFractional = ISO8601DateFormatter()
         formatterNoFractional.formatOptions = [.withInternetDateTime]
 
-        // Manual newline split rather than `enumerateLines` — its closure is
-        // escaping and can't capture our inout dedup/output buffers.
-        for line in text.split(whereSeparator: { $0.isNewline }) {
-            guard let lineData = line.data(using: .utf8),
-                  let raw = try? JSONSerialization.jsonObject(with: lineData) as? [String: Any]
-            else { continue }
+        // Stream the file in fixed-size chunks and parse one line at a time.
+        // Session JSONLs can reach 50+ MB and we walk 30 days of them, so
+        // loading entire files via `Data(contentsOf:)` blows up peak memory.
+        var buffer = Data()
+        let chunkSize = 64 * 1024
 
-            // Only assistant messages carry usage. The shape is consistent
-            // across Claude Code versions: top-level `type == "assistant"`,
-            // `message.usage`, `message.model`, `message.id`, top-level
-            // `requestId`, top-level `timestamp`.
-            guard (raw["type"] as? String) == "assistant",
-                  let message = raw["message"] as? [String: Any],
-                  let usage = message["usage"] as? [String: Any],
-                  let model = message["model"] as? String
-            else { continue }
+        while true {
+            let chunk = handle.readData(ofLength: chunkSize)
+            if chunk.isEmpty { break }
+            buffer.append(chunk)
 
-            // Skip synthetic placeholder models (ccusage parity).
-            if model == "<synthetic>" || model.hasPrefix("synthetic") { continue }
-
-            let messageId = message["id"] as? String ?? ""
-            let requestId = raw["requestId"] as? String ?? ""
-
-            // ccusage requires BOTH IDs for dedup; entries missing either
-            // are processed without dedup. Match that behavior so a partial
-            // log doesn't silently drop turns.
-            if !messageId.isEmpty && !requestId.isEmpty {
-                let key = "\(messageId):\(requestId)"
-                if seen.contains(key) { continue }
-                seen.insert(key)
+            while let nl = buffer.firstIndex(of: 0x0A) {
+                let lineData = buffer.subdata(in: buffer.startIndex..<nl)
+                buffer.removeSubrange(buffer.startIndex...nl)
+                if lineData.isEmpty { continue }
+                processLine(
+                    lineData,
+                    cutoff: cutoff,
+                    formatter: formatter,
+                    formatterNoFractional: formatterNoFractional,
+                    seen: &seen,
+                    into: &out
+                )
             }
-
-            let timestampString = raw["timestamp"] as? String ?? ""
-            let timestamp = formatter.date(from: timestampString)
-                ?? formatterNoFractional.date(from: timestampString)
-                ?? Date.distantPast
-            guard timestamp >= cutoff else { continue }
-
-            let input = (usage["input_tokens"] as? Int) ?? 0
-            let output = (usage["output_tokens"] as? Int) ?? 0
-            let cacheCreate = (usage["cache_creation_input_tokens"] as? Int) ?? 0
-            let cacheRead = (usage["cache_read_input_tokens"] as? Int) ?? 0
-
-            // Skip noop entries — ccusage filters these so totals match exactly.
-            if input == 0 && output == 0 && cacheCreate == 0 && cacheRead == 0 { continue }
-
-            out.append(TokenEvent(
-                provider: .claude,
-                timestamp: timestamp,
-                model: model,
-                inputTokens: input,
-                outputTokens: output,
-                cacheCreationTokens: cacheCreate,
-                cacheReadTokens: cacheRead
-            ))
         }
+        // Flush trailing line if the file did not end with a newline.
+        if !buffer.isEmpty {
+            processLine(
+                buffer,
+                cutoff: cutoff,
+                formatter: formatter,
+                formatterNoFractional: formatterNoFractional,
+                seen: &seen,
+                into: &out
+            )
+        }
+    }
+
+    private static func processLine(
+        _ lineData: Data,
+        cutoff: Date,
+        formatter: ISO8601DateFormatter,
+        formatterNoFractional: ISO8601DateFormatter,
+        seen: inout Set<String>,
+        into out: inout [TokenEvent]
+    ) {
+        guard let raw = try? JSONSerialization.jsonObject(with: lineData) as? [String: Any]
+        else { return }
+
+        // Only assistant messages carry usage. The shape is consistent
+        // across Claude Code versions: top-level `type == "assistant"`,
+        // `message.usage`, `message.model`, `message.id`, top-level
+        // `requestId`, top-level `timestamp`.
+        guard (raw["type"] as? String) == "assistant",
+              let message = raw["message"] as? [String: Any],
+              let usage = message["usage"] as? [String: Any],
+              let model = message["model"] as? String
+        else { return }
+
+        // Skip synthetic placeholder models (ccusage parity).
+        if model == "<synthetic>" || model.hasPrefix("synthetic") { return }
+
+        let messageId = message["id"] as? String ?? ""
+        let requestId = raw["requestId"] as? String ?? ""
+
+        // ccusage requires BOTH IDs for dedup; entries missing either
+        // are processed without dedup. Match that behavior so a partial
+        // log doesn't silently drop turns.
+        if !messageId.isEmpty && !requestId.isEmpty {
+            let key = "\(messageId):\(requestId)"
+            if seen.contains(key) { return }
+            seen.insert(key)
+        }
+
+        let timestampString = raw["timestamp"] as? String ?? ""
+        let timestamp = formatter.date(from: timestampString)
+            ?? formatterNoFractional.date(from: timestampString)
+            ?? Date.distantPast
+        guard timestamp >= cutoff else { return }
+
+        let input = (usage["input_tokens"] as? Int) ?? 0
+        let output = (usage["output_tokens"] as? Int) ?? 0
+        let cacheCreate = (usage["cache_creation_input_tokens"] as? Int) ?? 0
+        let cacheRead = (usage["cache_read_input_tokens"] as? Int) ?? 0
+
+        // Skip noop entries — ccusage filters these so totals match exactly.
+        if input == 0 && output == 0 && cacheCreate == 0 && cacheRead == 0 { return }
+
+        out.append(TokenEvent(
+            provider: .claude,
+            timestamp: timestamp,
+            model: model,
+            inputTokens: input,
+            outputTokens: output,
+            cacheCreationTokens: cacheCreate,
+            cacheReadTokens: cacheRead
+        ))
     }
 }

--- a/Sources/Cost/ClaudeLogReader.swift
+++ b/Sources/Cost/ClaudeLogReader.swift
@@ -1,0 +1,130 @@
+import Foundation
+
+/// Walks the local Claude Code session JSONL files and emits TokenEvents for
+/// every assistant message that recorded usage. Mirrors ccusage's data path:
+///   - reads from ~/.claude/projects/**/*.jsonl AND ~/.config/claude/projects/**/*.jsonl
+///   - honors CLAUDE_CONFIG_DIR (comma-separated) when set
+///   - dedupes by `messageId:requestId`
+///   - skips synthetic placeholder models
+enum ClaudeLogReader {
+    /// Walk the configured project roots and return every usage-bearing
+    /// assistant turn from the last `lookbackDays` days. Pure file IO; no
+    /// network. Safe to call from a background thread.
+    static func scan(lookbackDays: Int = 30) -> [TokenEvent] {
+        let cutoff = Date().addingTimeInterval(-Double(lookbackDays) * 86400)
+        var seen = Set<String>()
+        var out: [TokenEvent] = []
+
+        for root in projectRoots() {
+            for file in jsonlFiles(under: root, modifiedAfter: cutoff) {
+                parseFile(at: file, cutoff: cutoff, seen: &seen, into: &out)
+            }
+        }
+        return out
+    }
+
+    private static func projectRoots() -> [URL] {
+        if let env = ProcessInfo.processInfo.environment["CLAUDE_CONFIG_DIR"], !env.isEmpty {
+            return env.split(separator: ",").map {
+                URL(fileURLWithPath: String($0).trimmingCharacters(in: .whitespaces))
+                    .appendingPathComponent("projects", isDirectory: true)
+            }
+        }
+        let home = FileManager.default.homeDirectoryForCurrentUser
+        return [
+            home.appendingPathComponent(".claude/projects", isDirectory: true),
+            home.appendingPathComponent(".config/claude/projects", isDirectory: true),
+        ].filter { FileManager.default.fileExists(atPath: $0.path) }
+    }
+
+    private static func jsonlFiles(under root: URL, modifiedAfter cutoff: Date) -> [URL] {
+        let fm = FileManager.default
+        guard let enumerator = fm.enumerator(
+            at: root,
+            includingPropertiesForKeys: [.isRegularFileKey, .contentModificationDateKey],
+            options: [.skipsHiddenFiles, .skipsPackageDescendants]
+        ) else { return [] }
+
+        var hits: [URL] = []
+        for case let url as URL in enumerator {
+            guard url.pathExtension == "jsonl" else { continue }
+            let values = try? url.resourceValues(forKeys: [.isRegularFileKey, .contentModificationDateKey])
+            guard values?.isRegularFile == true else { continue }
+            if let mtime = values?.contentModificationDate, mtime < cutoff { continue }
+            hits.append(url)
+        }
+        return hits
+    }
+
+    private static func parseFile(
+        at url: URL,
+        cutoff: Date,
+        seen: inout Set<String>,
+        into out: inout [TokenEvent]
+    ) {
+        guard let data = try? Data(contentsOf: url),
+              let text = String(data: data, encoding: .utf8) else { return }
+
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let formatterNoFractional = ISO8601DateFormatter()
+        formatterNoFractional.formatOptions = [.withInternetDateTime]
+
+        // Manual newline split rather than `enumerateLines` — its closure is
+        // escaping and can't capture our inout dedup/output buffers.
+        for line in text.split(whereSeparator: { $0.isNewline }) {
+            guard let lineData = line.data(using: .utf8),
+                  let raw = try? JSONSerialization.jsonObject(with: lineData) as? [String: Any]
+            else { continue }
+
+            // Only assistant messages carry usage. The shape is consistent
+            // across Claude Code versions: top-level `type == "assistant"`,
+            // `message.usage`, `message.model`, `message.id`, top-level
+            // `requestId`, top-level `timestamp`.
+            guard (raw["type"] as? String) == "assistant",
+                  let message = raw["message"] as? [String: Any],
+                  let usage = message["usage"] as? [String: Any],
+                  let model = message["model"] as? String
+            else { continue }
+
+            // Skip synthetic placeholder models (ccusage parity).
+            if model == "<synthetic>" || model.hasPrefix("synthetic") { continue }
+
+            let messageId = message["id"] as? String ?? ""
+            let requestId = raw["requestId"] as? String ?? ""
+
+            // ccusage requires BOTH IDs for dedup; entries missing either
+            // are processed without dedup. Match that behavior so a partial
+            // log doesn't silently drop turns.
+            if !messageId.isEmpty && !requestId.isEmpty {
+                let key = "\(messageId):\(requestId)"
+                if seen.contains(key) { continue }
+                seen.insert(key)
+            }
+
+            let timestampString = raw["timestamp"] as? String ?? ""
+            let timestamp = formatter.date(from: timestampString)
+                ?? formatterNoFractional.date(from: timestampString)
+                ?? Date.distantPast
+            guard timestamp >= cutoff else { continue }
+
+            let input = (usage["input_tokens"] as? Int) ?? 0
+            let output = (usage["output_tokens"] as? Int) ?? 0
+            let cacheCreate = (usage["cache_creation_input_tokens"] as? Int) ?? 0
+            let cacheRead = (usage["cache_read_input_tokens"] as? Int) ?? 0
+
+            // Skip noop entries — ccusage filters these so totals match exactly.
+            if input == 0 && output == 0 && cacheCreate == 0 && cacheRead == 0 { continue }
+
+            out.append(TokenEvent(
+                provider: .claude,
+                timestamp: timestamp,
+                model: model,
+                inputTokens: input,
+                outputTokens: output,
+                cacheCreationTokens: cacheCreate,
+                cacheReadTokens: cacheRead
+            ))
+        }
+    }
+}

--- a/Sources/Cost/CodexLogReader.swift
+++ b/Sources/Cost/CodexLogReader.swift
@@ -1,0 +1,119 @@
+import Foundation
+
+/// Walks the local Codex CLI rollout files and emits a TokenEvent for every
+/// turn that recorded usage. Mirrors @ccusage/codex's data path:
+///   - reads from ~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl
+///   - tracks the most recent `turn_context.payload.model` as the active
+///     model for subsequent `event_msg.token_count` events
+///   - uses `last_token_usage` (per-turn delta) rather than diffing the
+///     accumulating `total_token_usage`, which is a known footgun for
+///     forked sessions
+enum CodexLogReader {
+    static func scan(lookbackDays: Int = 30) -> [TokenEvent] {
+        let cutoff = Date().addingTimeInterval(-Double(lookbackDays) * 86400)
+        var out: [TokenEvent] = []
+
+        for file in jsonlFiles(under: sessionsRoot(), modifiedAfter: cutoff) {
+            parseFile(at: file, cutoff: cutoff, into: &out)
+        }
+        return out
+    }
+
+    private static func sessionsRoot() -> URL {
+        let home = FileManager.default.homeDirectoryForCurrentUser
+        if let codexHome = ProcessInfo.processInfo.environment["CODEX_HOME"], !codexHome.isEmpty {
+            return URL(fileURLWithPath: codexHome).appendingPathComponent("sessions", isDirectory: true)
+        }
+        return home.appendingPathComponent(".codex/sessions", isDirectory: true)
+    }
+
+    private static func jsonlFiles(under root: URL, modifiedAfter cutoff: Date) -> [URL] {
+        let fm = FileManager.default
+        guard fm.fileExists(atPath: root.path),
+              let enumerator = fm.enumerator(
+                at: root,
+                includingPropertiesForKeys: [.isRegularFileKey, .contentModificationDateKey],
+                options: [.skipsHiddenFiles, .skipsPackageDescendants]
+              ) else { return [] }
+
+        var hits: [URL] = []
+        for case let url as URL in enumerator {
+            guard url.pathExtension == "jsonl",
+                  url.lastPathComponent.hasPrefix("rollout-") else { continue }
+            let values = try? url.resourceValues(forKeys: [.isRegularFileKey, .contentModificationDateKey])
+            guard values?.isRegularFile == true else { continue }
+            if let mtime = values?.contentModificationDate, mtime < cutoff { continue }
+            hits.append(url)
+        }
+        return hits
+    }
+
+    private static func parseFile(at url: URL, cutoff: Date, into out: inout [TokenEvent]) {
+        guard let data = try? Data(contentsOf: url),
+              let text = String(data: data, encoding: .utf8) else { return }
+
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let formatterNoFractional = ISO8601DateFormatter()
+        formatterNoFractional.formatOptions = [.withInternetDateTime]
+
+        // Codex rollouts can switch models mid-session via `/model`. Track
+        // the most recent `turn_context.payload.model` and attribute each
+        // following token_count event to it.
+        var currentModel: String?
+
+        // Manual newline split rather than `enumerateLines` — its closure is
+        // escaping and can't capture our inout `out` buffer or the
+        // `currentModel` we're threading through the file.
+        for line in text.split(whereSeparator: { $0.isNewline }) {
+            guard let lineData = line.data(using: .utf8),
+                  let raw = try? JSONSerialization.jsonObject(with: lineData) as? [String: Any],
+                  let type = raw["type"] as? String else { continue }
+
+            if type == "turn_context",
+               let payload = raw["payload"] as? [String: Any],
+               let model = payload["model"] as? String {
+                currentModel = model
+                continue
+            }
+
+            guard type == "event_msg",
+                  let payload = raw["payload"] as? [String: Any],
+                  (payload["type"] as? String) == "token_count",
+                  let info = payload["info"] as? [String: Any],
+                  let last = info["last_token_usage"] as? [String: Any]
+            else { continue }
+
+            let timestampString = raw["timestamp"] as? String ?? ""
+            let timestamp = formatter.date(from: timestampString)
+                ?? formatterNoFractional.date(from: timestampString)
+                ?? Date.distantPast
+            guard timestamp >= cutoff else { continue }
+
+            // Codex reports input_tokens INCLUDING the cached portion. Bill
+            // the non-cached delta at the input rate and the cached portion
+            // at the discounted cache_read rate.
+            let totalInput = (last["input_tokens"] as? Int) ?? 0
+            let cached = (last["cached_input_tokens"] as? Int) ?? 0
+            let nonCachedInput = max(0, totalInput - cached)
+            let output = (last["output_tokens"] as? Int) ?? 0
+
+            if nonCachedInput == 0 && cached == 0 && output == 0 { continue }
+
+            // Fall back to gpt-5.4 for sessions that emit token_count before
+            // any turn_context (early Codex CLI builds did this). Better
+            // approximation than billing $0.
+            let model = currentModel ?? "gpt-5.4"
+
+            out.append(TokenEvent(
+                provider: .codex,
+                timestamp: timestamp,
+                model: model,
+                inputTokens: nonCachedInput,
+                outputTokens: output,
+                cacheCreationTokens: 0,
+                cacheReadTokens: cached
+            ))
+        }
+    }
+}

--- a/Sources/Cost/CostBucketing.swift
+++ b/Sources/Cost/CostBucketing.swift
@@ -4,17 +4,6 @@ import Foundation
 /// "today" and "month-to-date" line up with what the user expects from a
 /// glance at the wall clock.
 enum CostBucketing {
-    /// Fixed-scale ceiling for the today bar. v1: shared between providers
-    /// for visual symmetry. Sized so a heavy Claude Code day (~$50-100 of
-    /// API-equivalent spend) lands in the upper half of the bar without
-    /// saturating immediately.
-    static let todayCap: Double = 100
-
-    /// Fixed-scale ceiling for the month-to-date bar. Sized to roughly match
-    /// 20-25 working days × todayCap so a power user's monthly spend stays
-    /// readable as a fill fraction.
-    static let monthCap: Double = 2000
-
     /// Filter to events whose timestamp falls between local midnight today
     /// and now.
     static func eventsForToday(_ events: [TokenEvent], in tz: TimeZone = .current) -> [TokenEvent] {

--- a/Sources/Cost/CostBucketing.swift
+++ b/Sources/Cost/CostBucketing.swift
@@ -33,9 +33,38 @@ enum CostBucketing {
         return f.string(from: Date())
     }
 
-    /// Caption for the today cell — always "resets at midnight" since the
-    /// reset is uniform.
-    static let todayResetCaption = "resets at midnight"
+    /// Compact "time remaining until next local midnight" — `5h`, `42m`,
+    /// `12s`. Computed on demand so the panel always shows the correct
+    /// countdown regardless of how stale the last refresh is.
+    static func todayResetIn() -> String {
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = .current
+        let now = Date()
+        guard let nextMidnight = cal.nextDate(
+            after: now,
+            matching: DateComponents(hour: 0, minute: 0, second: 0),
+            matchingPolicy: .nextTime
+        ) else { return "<1d" }
+        let interval = nextMidnight.timeIntervalSince(now)
+        if interval < 60 { return "\(Int(interval))s" }
+        if interval < 3600 { return "\(Int(interval / 60))m" }
+        return "\(Int(interval / 3600))h"
+    }
+
+    /// Compact days-until-end-of-month: `12d`, `1d`. Always uses the same
+    /// shape regardless of how close to month-end we are, so the cell
+    /// caption never reverts to a phrase like "tomorrow".
+    static func monthResetIn() -> String {
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = .current
+        let now = Date()
+        guard let range = cal.range(of: .day, in: .month, for: now),
+              let day = cal.dateComponents([.day], from: now).day else {
+            return "1d"
+        }
+        let remaining = max(1, range.count - day)
+        return "\(remaining)d"
+    }
 
     /// Cumulative dollar spend bucketed by hour from local midnight to now.
     /// Returns one entry per elapsed hour (1–24 entries depending on time
@@ -82,19 +111,4 @@ enum CostBucketing {
         return out
     }
 
-    /// Caption like "resets in 12d" — counts days remaining in the current
-    /// calendar month.
-    static func monthResetCaption() -> String {
-        var cal = Calendar(identifier: .gregorian)
-        cal.timeZone = .current
-        let now = Date()
-        guard let range = cal.range(of: .day, in: .month, for: now),
-              let day = cal.dateComponents([.day], from: now).day else {
-            return "resets next month"
-        }
-        let remaining = max(0, range.count - day)
-        if remaining == 0 { return "resets tomorrow" }
-        if remaining == 1 { return "resets in 1d" }
-        return "resets in \(remaining)d"
-    }
 }

--- a/Sources/Cost/CostBucketing.swift
+++ b/Sources/Cost/CostBucketing.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+/// Time-window helpers for the cost screen. All in calendar-local time so
+/// "today" and "month-to-date" line up with what the user expects from a
+/// glance at the wall clock.
+enum CostBucketing {
+    /// Fixed-scale ceiling for the today bar. v1: shared between providers
+    /// for visual symmetry. Sized so a heavy Claude Code day (~$50-100 of
+    /// API-equivalent spend) lands in the upper half of the bar without
+    /// saturating immediately.
+    static let todayCap: Double = 100
+
+    /// Fixed-scale ceiling for the month-to-date bar. Sized to roughly match
+    /// 20-25 working days × todayCap so a power user's monthly spend stays
+    /// readable as a fill fraction.
+    static let monthCap: Double = 2000
+
+    /// Filter to events whose timestamp falls between local midnight today
+    /// and now.
+    static func eventsForToday(_ events: [TokenEvent], in tz: TimeZone = .current) -> [TokenEvent] {
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = tz
+        let startOfDay = cal.startOfDay(for: Date())
+        return events.filter { $0.timestamp >= startOfDay }
+    }
+
+    /// Filter to events from the first instant of the current calendar month
+    /// (local) through now.
+    static func eventsForMonthToDate(_ events: [TokenEvent], in tz: TimeZone = .current) -> [TokenEvent] {
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = tz
+        let now = Date()
+        let comps = cal.dateComponents([.year, .month], from: now)
+        guard let start = cal.date(from: comps) else { return events }
+        return events.filter { $0.timestamp >= start }
+    }
+
+    /// Short month name for the current month in the user's locale, e.g. "Apr".
+    static func currentMonthLabel() -> String {
+        let f = DateFormatter()
+        f.locale = .current
+        f.timeZone = .current
+        f.setLocalizedDateFormatFromTemplate("MMM")
+        return f.string(from: Date())
+    }
+
+    /// Caption for the today cell — always "resets at midnight" since the
+    /// reset is uniform.
+    static let todayResetCaption = "resets at midnight"
+
+    /// Caption like "resets in 12d" — counts days remaining in the current
+    /// calendar month.
+    static func monthResetCaption() -> String {
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = .current
+        let now = Date()
+        guard let range = cal.range(of: .day, in: .month, for: now),
+              let day = cal.dateComponents([.day], from: now).day else {
+            return "resets next month"
+        }
+        let remaining = max(0, range.count - day)
+        if remaining == 0 { return "resets tomorrow" }
+        if remaining == 1 { return "resets in 1d" }
+        return "resets in \(remaining)d"
+    }
+}

--- a/Sources/Cost/CostBucketing.swift
+++ b/Sources/Cost/CostBucketing.swift
@@ -1,29 +1,12 @@
 import Foundation
 
-/// Time-window helpers for the cost screen. All in calendar-local time so
-/// "today" and "month-to-date" line up with what the user expects from a
-/// glance at the wall clock.
+/// Time-window helpers for the cost screen. Calendar-local so "today" and
+/// "this month" line up with the wall clock the user is glancing at.
+///
+/// Aggregation lives in `CostStore.summarize` (single-pass over all events).
+/// What's left here is the chrome the cell labels need: month name + reset
+/// countdowns.
 enum CostBucketing {
-    /// Filter to events whose timestamp falls between local midnight today
-    /// and now.
-    static func eventsForToday(_ events: [TokenEvent], in tz: TimeZone = .current) -> [TokenEvent] {
-        var cal = Calendar(identifier: .gregorian)
-        cal.timeZone = tz
-        let startOfDay = cal.startOfDay(for: Date())
-        return events.filter { $0.timestamp >= startOfDay }
-    }
-
-    /// Filter to events from the first instant of the current calendar month
-    /// (local) through now.
-    static func eventsForMonthToDate(_ events: [TokenEvent], in tz: TimeZone = .current) -> [TokenEvent] {
-        var cal = Calendar(identifier: .gregorian)
-        cal.timeZone = tz
-        let now = Date()
-        let comps = cal.dateComponents([.year, .month], from: now)
-        guard let start = cal.date(from: comps) else { return events }
-        return events.filter { $0.timestamp >= start }
-    }
-
     /// Short month name for the current month in the user's locale, e.g. "Apr".
     static func currentMonthLabel() -> String {
         let f = DateFormatter()
@@ -65,50 +48,4 @@ enum CostBucketing {
         let remaining = max(1, range.count - day)
         return "\(remaining)d"
     }
-
-    /// Cumulative dollar spend bucketed by hour from local midnight to now.
-    /// Returns one entry per elapsed hour (1–24 entries depending on time
-    /// of day). Always monotonically non-decreasing — feeds the sparkline
-    /// in the cost cell, which ascends as more spend accumulates.
-    static func cumulativeHourly(_ events: [TokenEvent], in tz: TimeZone = .current) -> [Double] {
-        var cal = Calendar(identifier: .gregorian); cal.timeZone = tz
-        let now = Date()
-        let startOfDay = cal.startOfDay(for: now)
-        let currentHour = cal.dateComponents([.hour], from: now).hour ?? 0
-        let buckets = currentHour + 1
-
-        var spend = Array(repeating: 0.0, count: buckets)
-        for event in events where event.timestamp >= startOfDay {
-            let h = cal.dateComponents([.hour], from: event.timestamp).hour ?? 0
-            if h < buckets { spend[h] += Pricing.cost(for: event) }
-        }
-        return runningSum(spend)
-    }
-
-    /// Cumulative dollar spend bucketed by day from the first of the month
-    /// to today. Returns one entry per elapsed day.
-    static func cumulativeDaily(_ events: [TokenEvent], in tz: TimeZone = .current) -> [Double] {
-        var cal = Calendar(identifier: .gregorian); cal.timeZone = tz
-        let now = Date()
-        let comps = cal.dateComponents([.year, .month], from: now)
-        guard let monthStart = cal.date(from: comps) else { return [] }
-        let currentDay = (cal.dateComponents([.day], from: now).day ?? 1) - 1
-        let buckets = currentDay + 1
-
-        var spend = Array(repeating: 0.0, count: buckets)
-        for event in events where event.timestamp >= monthStart {
-            let d = (cal.dateComponents([.day], from: event.timestamp).day ?? 1) - 1
-            if d < buckets { spend[d] += Pricing.cost(for: event) }
-        }
-        return runningSum(spend)
-    }
-
-    private static func runningSum(_ values: [Double]) -> [Double] {
-        var out: [Double] = []
-        out.reserveCapacity(values.count)
-        var sum = 0.0
-        for v in values { sum += v; out.append(sum) }
-        return out
-    }
-
 }

--- a/Sources/Cost/CostBucketing.swift
+++ b/Sources/Cost/CostBucketing.swift
@@ -37,6 +37,51 @@ enum CostBucketing {
     /// reset is uniform.
     static let todayResetCaption = "resets at midnight"
 
+    /// Cumulative dollar spend bucketed by hour from local midnight to now.
+    /// Returns one entry per elapsed hour (1–24 entries depending on time
+    /// of day). Always monotonically non-decreasing — feeds the sparkline
+    /// in the cost cell, which ascends as more spend accumulates.
+    static func cumulativeHourly(_ events: [TokenEvent], in tz: TimeZone = .current) -> [Double] {
+        var cal = Calendar(identifier: .gregorian); cal.timeZone = tz
+        let now = Date()
+        let startOfDay = cal.startOfDay(for: now)
+        let currentHour = cal.dateComponents([.hour], from: now).hour ?? 0
+        let buckets = currentHour + 1
+
+        var spend = Array(repeating: 0.0, count: buckets)
+        for event in events where event.timestamp >= startOfDay {
+            let h = cal.dateComponents([.hour], from: event.timestamp).hour ?? 0
+            if h < buckets { spend[h] += Pricing.cost(for: event) }
+        }
+        return runningSum(spend)
+    }
+
+    /// Cumulative dollar spend bucketed by day from the first of the month
+    /// to today. Returns one entry per elapsed day.
+    static func cumulativeDaily(_ events: [TokenEvent], in tz: TimeZone = .current) -> [Double] {
+        var cal = Calendar(identifier: .gregorian); cal.timeZone = tz
+        let now = Date()
+        let comps = cal.dateComponents([.year, .month], from: now)
+        guard let monthStart = cal.date(from: comps) else { return [] }
+        let currentDay = (cal.dateComponents([.day], from: now).day ?? 1) - 1
+        let buckets = currentDay + 1
+
+        var spend = Array(repeating: 0.0, count: buckets)
+        for event in events where event.timestamp >= monthStart {
+            let d = (cal.dateComponents([.day], from: event.timestamp).day ?? 1) - 1
+            if d < buckets { spend[d] += Pricing.cost(for: event) }
+        }
+        return runningSum(spend)
+    }
+
+    private static func runningSum(_ values: [Double]) -> [Double] {
+        var out: [Double] = []
+        out.reserveCapacity(values.count)
+        var sum = 0.0
+        for v in values { sum += v; out.append(sum) }
+        return out
+    }
+
     /// Caption like "resets in 12d" — counts days remaining in the current
     /// calendar month.
     static func monthResetCaption() -> String {

--- a/Sources/Cost/CostStore.swift
+++ b/Sources/Cost/CostStore.swift
@@ -113,7 +113,6 @@ final class CostStore: ObservableObject {
                 tokens: todayTokens,
                 series: todaySeries,
                 label: "Today",
-                resetCaption: CostBucketing.todayResetCaption,
                 error: nil
             ),
             month: CostWindow(
@@ -121,7 +120,6 @@ final class CostStore: ObservableObject {
                 tokens: monthTokens,
                 series: monthSeries,
                 label: CostBucketing.currentMonthLabel(),
-                resetCaption: CostBucketing.monthResetCaption(),
                 error: nil
             )
         )
@@ -176,21 +174,17 @@ final class CostStore: ObservableObject {
 
         self.claude = ProviderCost(
             today: CostWindow(dollars: claudeToday, tokens: claudeTodayTokens,
-                              series: claudeTodaySeries, label: "Today",
-                              resetCaption: CostBucketing.todayResetCaption, error: nil),
+                              series: claudeTodaySeries, label: "Today", error: nil),
             month: CostWindow(dollars: claudeMonth, tokens: claudeMonthTokens,
                               series: claudeMonthSeries,
-                              label: CostBucketing.currentMonthLabel(),
-                              resetCaption: CostBucketing.monthResetCaption(), error: nil)
+                              label: CostBucketing.currentMonthLabel(), error: nil)
         )
         self.codex = ProviderCost(
             today: CostWindow(dollars: codexToday, tokens: codexTodayTokens,
-                              series: codexTodaySeries, label: "Today",
-                              resetCaption: CostBucketing.todayResetCaption, error: nil),
+                              series: codexTodaySeries, label: "Today", error: nil),
             month: CostWindow(dollars: codexMonth, tokens: codexMonthTokens,
                               series: codexMonthSeries,
-                              label: CostBucketing.currentMonthLabel(),
-                              resetCaption: CostBucketing.monthResetCaption(), error: nil)
+                              label: CostBucketing.currentMonthLabel(), error: nil)
         )
         if let ts = snap["lastUpdated"] as? Double, ts > 0 {
             self.lastUpdated = Date(timeIntervalSinceReferenceDate: ts)

--- a/Sources/Cost/CostStore.swift
+++ b/Sources/Cost/CostStore.swift
@@ -22,7 +22,7 @@ final class CostStore: ObservableObject {
 
     var loading: Bool { claudeLoading || codexLoading }
 
-    private static let cacheKey = "MacIsland.costCache.v1"
+    private static let cacheKey = "MacIsland.costCache.v2"
     private var pollTimer: Timer?
     private var intervalCancellable: AnyCancellable?
 
@@ -94,100 +94,154 @@ final class CostStore: ObservableObject {
         }
     }
 
-    /// Pure aggregation. Lives as a static so the detached refresh task can
-    /// call it without touching @MainActor-isolated state.
+    /// Pure aggregation — single pass over events. Lives as a static so the
+    /// detached refresh task can call it without touching @MainActor state.
     nonisolated private static func summarize(events: [TokenEvent]) -> ProviderCost {
-        let todayEvents = CostBucketing.eventsForToday(events)
-        let monthEvents = CostBucketing.eventsForMonthToDate(events)
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = .current
+        let now = Date()
+        let startOfDay = cal.startOfDay(for: now)
+        let monthStart = cal.date(from: cal.dateComponents([.year, .month], from: now)) ?? startOfDay
+        let currentHour = cal.dateComponents([.hour], from: now).hour ?? 0
+        let currentDay = (cal.dateComponents([.day], from: now).day ?? 1) - 1
 
-        let todaySum = todayEvents.reduce(0.0) { $0 + Pricing.cost(for: $1) }
-        let monthSum = monthEvents.reduce(0.0) { $0 + Pricing.cost(for: $1) }
-        let todayTokens = todayEvents.reduce(0) { $0 + tokenCount(of: $1) }
-        let monthTokens = monthEvents.reduce(0) { $0 + tokenCount(of: $1) }
-        let todaySeries = CostBucketing.cumulativeHourly(todayEvents)
-        let monthSeries = CostBucketing.cumulativeDaily(monthEvents)
+        var todayDollars = 0.0, todayTokens = 0
+        var monthDollars = 0.0, monthTokens = 0
+        var hourlyBuckets = Array(repeating: 0.0, count: currentHour + 1)
+        var dailyBuckets = Array(repeating: 0.0, count: currentDay + 1)
+        // Filtered to non-zero token events so handshake/stub rows don't
+        // show up as "unpriced" warnings — the user only cares about
+        // models that actually moved tokens.
+        var todayUnknown: Set<String> = []
+        var monthUnknown: Set<String> = []
+
+        for event in events {
+            guard event.timestamp >= monthStart else { continue }
+            let cost = Pricing.cost(for: event)
+            let tokens = event.inputTokens + event.outputTokens
+                + event.cacheCreationTokens + event.cacheReadTokens
+            let isUnpriced = tokens > 0 && !Pricing.isKnown(event.model)
+
+            monthDollars += cost
+            monthTokens += tokens
+            let day = (cal.dateComponents([.day], from: event.timestamp).day ?? 1) - 1
+            if day < dailyBuckets.count { dailyBuckets[day] += cost }
+            if isUnpriced { monthUnknown.insert(event.model) }
+
+            // Today is a strict subset of month
+            if event.timestamp >= startOfDay {
+                todayDollars += cost
+                todayTokens += tokens
+                let hour = cal.dateComponents([.hour], from: event.timestamp).hour ?? 0
+                if hour < hourlyBuckets.count { hourlyBuckets[hour] += cost }
+                if isUnpriced { todayUnknown.insert(event.model) }
+            }
+        }
 
         return ProviderCost(
             today: CostWindow(
-                dollars: todaySum,
+                dollars: todayDollars,
                 tokens: todayTokens,
-                series: todaySeries,
+                series: runningSum(hourlyBuckets),
                 label: "Today",
-                error: nil
+                error: nil,
+                unknownModels: todayUnknown.sorted()
             ),
             month: CostWindow(
-                dollars: monthSum,
+                dollars: monthDollars,
                 tokens: monthTokens,
-                series: monthSeries,
+                series: runningSum(dailyBuckets),
                 label: CostBucketing.currentMonthLabel(),
-                error: nil
+                error: nil,
+                unknownModels: monthUnknown.sorted()
             )
         )
     }
 
-    /// Sum of every token bucket in a single event. Cache reads are usually
-    /// the dominant slice of any heavy Claude Code session and the user
-    /// chose to surface raw activity, so they're included.
-    nonisolated private static func tokenCount(of event: TokenEvent) -> Int {
-        event.inputTokens + event.outputTokens
-            + event.cacheCreationTokens + event.cacheReadTokens
+    nonisolated private static func runningSum(_ values: [Double]) -> [Double] {
+        var out = [Double]()
+        out.reserveCapacity(values.count)
+        var sum = 0.0
+        for v in values { sum += v; out.append(sum) }
+        return out
     }
 
     // MARK: - Cache
 
-    /// Snapshot the four key totals + the last refresh time. Labels and
-    /// reset captions are recomputed at restore time (current month, current
-    /// reset countdown) so the cached numbers always sit under fresh chrome.
+    /// Full snapshot of both providers encoded as JSON in a single key.
+    /// `unknownModels` arrays default to empty when decoding a snapshot that
+    /// pre-dates the field, so the cache survives the schema change without
+    /// a key bump or a forced rescan.
+    private struct CacheSnapshot: Codable {
+        var claudeToday: Double
+        var claudeMonth: Double
+        var codexToday: Double
+        var codexMonth: Double
+        var claudeTodayTokens: Int
+        var claudeMonthTokens: Int
+        var codexTodayTokens: Int
+        var codexMonthTokens: Int
+        var claudeTodaySeries: [Double]
+        var claudeMonthSeries: [Double]
+        var codexTodaySeries: [Double]
+        var codexMonthSeries: [Double]
+        var claudeTodayUnknown: [String] = []
+        var claudeMonthUnknown: [String] = []
+        var codexTodayUnknown: [String] = []
+        var codexMonthUnknown: [String] = []
+        var lastUpdated: Date?
+    }
+
+    /// Encodes the full snapshot as a single Data value — 1 write vs. the
+    /// previous 12-key dict, halving UserDefaults churn per refresh cycle.
     private func persist() {
-        let snap: [String: Any] = [
-            "claudeToday": claude.today.dollars,
-            "claudeMonth": claude.month.dollars,
-            "codexToday": codex.today.dollars,
-            "codexMonth": codex.month.dollars,
-            "claudeTodayTokens": claude.today.tokens,
-            "claudeMonthTokens": claude.month.tokens,
-            "codexTodayTokens": codex.today.tokens,
-            "codexMonthTokens": codex.month.tokens,
-            "claudeTodaySeries": claude.today.series,
-            "claudeMonthSeries": claude.month.series,
-            "codexTodaySeries": codex.today.series,
-            "codexMonthSeries": codex.month.series,
-            "lastUpdated": lastUpdated?.timeIntervalSinceReferenceDate ?? 0,
-        ]
-        UserDefaults.standard.set(snap, forKey: Self.cacheKey)
+        let snap = CacheSnapshot(
+            claudeToday: claude.today.dollars,
+            claudeMonth: claude.month.dollars,
+            codexToday: codex.today.dollars,
+            codexMonth: codex.month.dollars,
+            claudeTodayTokens: claude.today.tokens,
+            claudeMonthTokens: claude.month.tokens,
+            codexTodayTokens: codex.today.tokens,
+            codexMonthTokens: codex.month.tokens,
+            claudeTodaySeries: claude.today.series,
+            claudeMonthSeries: claude.month.series,
+            codexTodaySeries: codex.today.series,
+            codexMonthSeries: codex.month.series,
+            claudeTodayUnknown: claude.today.unknownModels,
+            claudeMonthUnknown: claude.month.unknownModels,
+            codexTodayUnknown: codex.today.unknownModels,
+            codexMonthUnknown: codex.month.unknownModels,
+            lastUpdated: lastUpdated
+        )
+        if let data = try? JSONEncoder().encode(snap) {
+            UserDefaults.standard.set(data, forKey: Self.cacheKey)
+        }
     }
 
     private func restoreFromCache() {
-        guard let snap = UserDefaults.standard.dictionary(forKey: Self.cacheKey) else { return }
-        let claudeToday = snap["claudeToday"] as? Double ?? 0
-        let claudeMonth = snap["claudeMonth"] as? Double ?? 0
-        let codexToday = snap["codexToday"] as? Double ?? 0
-        let codexMonth = snap["codexMonth"] as? Double ?? 0
-        let claudeTodayTokens = snap["claudeTodayTokens"] as? Int ?? 0
-        let claudeMonthTokens = snap["claudeMonthTokens"] as? Int ?? 0
-        let codexTodayTokens = snap["codexTodayTokens"] as? Int ?? 0
-        let codexMonthTokens = snap["codexMonthTokens"] as? Int ?? 0
-        let claudeTodaySeries = snap["claudeTodaySeries"] as? [Double] ?? []
-        let claudeMonthSeries = snap["claudeMonthSeries"] as? [Double] ?? []
-        let codexTodaySeries = snap["codexTodaySeries"] as? [Double] ?? []
-        let codexMonthSeries = snap["codexMonthSeries"] as? [Double] ?? []
+        guard let data = UserDefaults.standard.data(forKey: Self.cacheKey),
+              let snap = try? JSONDecoder().decode(CacheSnapshot.self, from: data)
+        else { return }
 
         self.claude = ProviderCost(
-            today: CostWindow(dollars: claudeToday, tokens: claudeTodayTokens,
-                              series: claudeTodaySeries, label: "Today", error: nil),
-            month: CostWindow(dollars: claudeMonth, tokens: claudeMonthTokens,
-                              series: claudeMonthSeries,
-                              label: CostBucketing.currentMonthLabel(), error: nil)
+            today: CostWindow(dollars: snap.claudeToday, tokens: snap.claudeTodayTokens,
+                              series: snap.claudeTodaySeries, label: "Today", error: nil,
+                              unknownModels: snap.claudeTodayUnknown),
+            month: CostWindow(dollars: snap.claudeMonth, tokens: snap.claudeMonthTokens,
+                              series: snap.claudeMonthSeries,
+                              label: CostBucketing.currentMonthLabel(), error: nil,
+                              unknownModels: snap.claudeMonthUnknown)
         )
         self.codex = ProviderCost(
-            today: CostWindow(dollars: codexToday, tokens: codexTodayTokens,
-                              series: codexTodaySeries, label: "Today", error: nil),
-            month: CostWindow(dollars: codexMonth, tokens: codexMonthTokens,
-                              series: codexMonthSeries,
-                              label: CostBucketing.currentMonthLabel(), error: nil)
+            today: CostWindow(dollars: snap.codexToday, tokens: snap.codexTodayTokens,
+                              series: snap.codexTodaySeries, label: "Today", error: nil,
+                              unknownModels: snap.codexTodayUnknown),
+            month: CostWindow(dollars: snap.codexMonth, tokens: snap.codexMonthTokens,
+                              series: snap.codexMonthSeries,
+                              label: CostBucketing.currentMonthLabel(), error: nil,
+                              unknownModels: snap.codexMonthUnknown)
         )
-        if let ts = snap["lastUpdated"] as? Double, ts > 0 {
-            self.lastUpdated = Date(timeIntervalSinceReferenceDate: ts)
-        }
+        self.lastUpdated = snap.lastUpdated
     }
 }

--- a/Sources/Cost/CostStore.swift
+++ b/Sources/Cost/CostStore.swift
@@ -102,21 +102,33 @@ final class CostStore: ObservableObject {
 
         let todaySum = todayEvents.reduce(0.0) { $0 + Pricing.cost(for: $1) }
         let monthSum = monthEvents.reduce(0.0) { $0 + Pricing.cost(for: $1) }
+        let todayTokens = todayEvents.reduce(0) { $0 + tokenCount(of: $1) }
+        let monthTokens = monthEvents.reduce(0) { $0 + tokenCount(of: $1) }
 
         return ProviderCost(
             today: CostWindow(
                 dollars: todaySum,
+                tokens: todayTokens,
                 label: "today",
                 resetCaption: CostBucketing.todayResetCaption,
                 error: nil
             ),
             month: CostWindow(
                 dollars: monthSum,
+                tokens: monthTokens,
                 label: CostBucketing.currentMonthLabel(),
                 resetCaption: CostBucketing.monthResetCaption(),
                 error: nil
             )
         )
+    }
+
+    /// Sum of every token bucket in a single event. Cache reads are usually
+    /// the dominant slice of any heavy Claude Code session and the user
+    /// chose to surface raw activity, so they're included.
+    nonisolated private static func tokenCount(of event: TokenEvent) -> Int {
+        event.inputTokens + event.outputTokens
+            + event.cacheCreationTokens + event.cacheReadTokens
     }
 
     // MARK: - Cache
@@ -130,6 +142,10 @@ final class CostStore: ObservableObject {
             "claudeMonth": claude.month.dollars,
             "codexToday": codex.today.dollars,
             "codexMonth": codex.month.dollars,
+            "claudeTodayTokens": claude.today.tokens,
+            "claudeMonthTokens": claude.month.tokens,
+            "codexTodayTokens": codex.today.tokens,
+            "codexMonthTokens": codex.month.tokens,
             "lastUpdated": lastUpdated?.timeIntervalSinceReferenceDate ?? 0,
         ]
         UserDefaults.standard.set(snap, forKey: Self.cacheKey)
@@ -141,17 +157,23 @@ final class CostStore: ObservableObject {
         let claudeMonth = snap["claudeMonth"] as? Double ?? 0
         let codexToday = snap["codexToday"] as? Double ?? 0
         let codexMonth = snap["codexMonth"] as? Double ?? 0
+        let claudeTodayTokens = snap["claudeTodayTokens"] as? Int ?? 0
+        let claudeMonthTokens = snap["claudeMonthTokens"] as? Int ?? 0
+        let codexTodayTokens = snap["codexTodayTokens"] as? Int ?? 0
+        let codexMonthTokens = snap["codexMonthTokens"] as? Int ?? 0
 
         self.claude = ProviderCost(
-            today: CostWindow(dollars: claudeToday, label: "today",
+            today: CostWindow(dollars: claudeToday, tokens: claudeTodayTokens, label: "today",
                               resetCaption: CostBucketing.todayResetCaption, error: nil),
-            month: CostWindow(dollars: claudeMonth, label: CostBucketing.currentMonthLabel(),
+            month: CostWindow(dollars: claudeMonth, tokens: claudeMonthTokens,
+                              label: CostBucketing.currentMonthLabel(),
                               resetCaption: CostBucketing.monthResetCaption(), error: nil)
         )
         self.codex = ProviderCost(
-            today: CostWindow(dollars: codexToday, label: "today",
+            today: CostWindow(dollars: codexToday, tokens: codexTodayTokens, label: "today",
                               resetCaption: CostBucketing.todayResetCaption, error: nil),
-            month: CostWindow(dollars: codexMonth, label: CostBucketing.currentMonthLabel(),
+            month: CostWindow(dollars: codexMonth, tokens: codexMonthTokens,
+                              label: CostBucketing.currentMonthLabel(),
                               resetCaption: CostBucketing.monthResetCaption(), error: nil)
         )
         if let ts = snap["lastUpdated"] as? Double, ts > 0 {

--- a/Sources/Cost/CostStore.swift
+++ b/Sources/Cost/CostStore.swift
@@ -1,0 +1,100 @@
+import Foundation
+import Combine
+
+/// Singleton equivalent of `UsageStore` for the cost screen. Reads local
+/// session logs (Claude Code + Codex CLI), aggregates today + month-to-date
+/// spend per provider, and publishes the result for SwiftUI consumers.
+///
+/// File IO lives on a background queue; only the published assignment hops
+/// back to the main actor. Refresh cadence is the same `RefreshIntervalStore`
+/// that gates the API-side `UsageStore`, since they share the same UI panel.
+@MainActor
+final class CostStore: ObservableObject {
+    static let shared = CostStore()
+    private init() {}
+
+    @Published var claude: ProviderCost = .empty
+    @Published var codex: ProviderCost = .empty
+    @Published var lastUpdated: Date?
+    @Published var loading = false
+
+    private var refreshTask: Task<Void, Never>?
+    private var pollTimer: Timer?
+    private var intervalCancellable: AnyCancellable?
+
+    private var pollInterval: TimeInterval {
+        TimeInterval(RefreshIntervalStore.shared.seconds)
+    }
+
+    func refresh() {
+        if loading { return }
+        loading = true
+        refreshTask?.cancel()
+        refreshTask = Task.detached(priority: .userInitiated) { [weak self] in
+            let claudeEvents = ClaudeLogReader.scan()
+            let codexEvents = CodexLogReader.scan()
+            let claudeCost = Self.summarize(events: claudeEvents)
+            let codexCost = Self.summarize(events: codexEvents)
+            await self?.commit(claude: claudeCost, codex: codexCost)
+        }
+    }
+
+    private func commit(claude claudeCost: ProviderCost, codex codexCost: ProviderCost) {
+        self.claude = claudeCost
+        self.codex = codexCost
+        self.lastUpdated = Date()
+        self.loading = false
+    }
+
+    func startAutoRefresh() {
+        stopAutoRefresh()
+        refresh()
+        armTimer()
+        intervalCancellable = RefreshIntervalStore.shared.$seconds
+            .dropFirst()
+            .sink { [weak self] _ in
+                Task { @MainActor in self?.armTimer() }
+            }
+    }
+
+    func stopAutoRefresh() {
+        pollTimer?.invalidate()
+        pollTimer = nil
+        intervalCancellable?.cancel()
+        intervalCancellable = nil
+    }
+
+    private func armTimer() {
+        pollTimer?.invalidate()
+        pollTimer = Timer.scheduledTimer(withTimeInterval: pollInterval, repeats: true) { [weak self] _ in
+            Task { @MainActor in self?.refresh() }
+        }
+    }
+
+    /// Pure aggregation. Lives as a static so the detached refresh task can
+    /// call it without touching @MainActor-isolated state.
+    nonisolated private static func summarize(events: [TokenEvent]) -> ProviderCost {
+        let todayEvents = CostBucketing.eventsForToday(events)
+        let monthEvents = CostBucketing.eventsForMonthToDate(events)
+
+        let todaySum = todayEvents.reduce(0.0) { $0 + Pricing.cost(for: $1) }
+        let monthSum = monthEvents.reduce(0.0) { $0 + Pricing.cost(for: $1) }
+
+        return ProviderCost(
+            today: CostWindow(
+                dollars: todaySum,
+                cap: CostBucketing.todayCap,
+                label: "today",
+                resetCaption: CostBucketing.todayResetCaption,
+                error: nil
+            ),
+            month: CostWindow(
+                dollars: monthSum,
+                cap: CostBucketing.monthCap,
+                label: CostBucketing.currentMonthLabel(),
+                resetCaption: CostBucketing.monthResetCaption(),
+                error: nil
+            )
+        )
+    }
+}

--- a/Sources/Cost/CostStore.swift
+++ b/Sources/Cost/CostStore.swift
@@ -104,18 +104,22 @@ final class CostStore: ObservableObject {
         let monthSum = monthEvents.reduce(0.0) { $0 + Pricing.cost(for: $1) }
         let todayTokens = todayEvents.reduce(0) { $0 + tokenCount(of: $1) }
         let monthTokens = monthEvents.reduce(0) { $0 + tokenCount(of: $1) }
+        let todaySeries = CostBucketing.cumulativeHourly(todayEvents)
+        let monthSeries = CostBucketing.cumulativeDaily(monthEvents)
 
         return ProviderCost(
             today: CostWindow(
                 dollars: todaySum,
                 tokens: todayTokens,
-                label: "today",
+                series: todaySeries,
+                label: "Today",
                 resetCaption: CostBucketing.todayResetCaption,
                 error: nil
             ),
             month: CostWindow(
                 dollars: monthSum,
                 tokens: monthTokens,
+                series: monthSeries,
                 label: CostBucketing.currentMonthLabel(),
                 resetCaption: CostBucketing.monthResetCaption(),
                 error: nil
@@ -146,6 +150,10 @@ final class CostStore: ObservableObject {
             "claudeMonthTokens": claude.month.tokens,
             "codexTodayTokens": codex.today.tokens,
             "codexMonthTokens": codex.month.tokens,
+            "claudeTodaySeries": claude.today.series,
+            "claudeMonthSeries": claude.month.series,
+            "codexTodaySeries": codex.today.series,
+            "codexMonthSeries": codex.month.series,
             "lastUpdated": lastUpdated?.timeIntervalSinceReferenceDate ?? 0,
         ]
         UserDefaults.standard.set(snap, forKey: Self.cacheKey)
@@ -161,18 +169,26 @@ final class CostStore: ObservableObject {
         let claudeMonthTokens = snap["claudeMonthTokens"] as? Int ?? 0
         let codexTodayTokens = snap["codexTodayTokens"] as? Int ?? 0
         let codexMonthTokens = snap["codexMonthTokens"] as? Int ?? 0
+        let claudeTodaySeries = snap["claudeTodaySeries"] as? [Double] ?? []
+        let claudeMonthSeries = snap["claudeMonthSeries"] as? [Double] ?? []
+        let codexTodaySeries = snap["codexTodaySeries"] as? [Double] ?? []
+        let codexMonthSeries = snap["codexMonthSeries"] as? [Double] ?? []
 
         self.claude = ProviderCost(
-            today: CostWindow(dollars: claudeToday, tokens: claudeTodayTokens, label: "today",
+            today: CostWindow(dollars: claudeToday, tokens: claudeTodayTokens,
+                              series: claudeTodaySeries, label: "Today",
                               resetCaption: CostBucketing.todayResetCaption, error: nil),
             month: CostWindow(dollars: claudeMonth, tokens: claudeMonthTokens,
+                              series: claudeMonthSeries,
                               label: CostBucketing.currentMonthLabel(),
                               resetCaption: CostBucketing.monthResetCaption(), error: nil)
         )
         self.codex = ProviderCost(
-            today: CostWindow(dollars: codexToday, tokens: codexTodayTokens, label: "today",
+            today: CostWindow(dollars: codexToday, tokens: codexTodayTokens,
+                              series: codexTodaySeries, label: "Today",
                               resetCaption: CostBucketing.todayResetCaption, error: nil),
             month: CostWindow(dollars: codexMonth, tokens: codexMonthTokens,
+                              series: codexMonthSeries,
                               label: CostBucketing.currentMonthLabel(),
                               resetCaption: CostBucketing.monthResetCaption(), error: nil)
         )

--- a/Sources/Cost/CostStore.swift
+++ b/Sources/Cost/CostStore.swift
@@ -5,20 +5,24 @@ import Combine
 /// session logs (Claude Code + Codex CLI), aggregates today + month-to-date
 /// spend per provider, and publishes the result for SwiftUI consumers.
 ///
-/// File IO lives on a background queue; only the published assignment hops
-/// back to the main actor. Refresh cadence is the same `RefreshIntervalStore`
-/// that gates the API-side `UsageStore`, since they share the same UI panel.
+/// Per-provider loading flags drive parallel scans that commit independently
+/// — Codex (small) appears within ~50ms while Claude (often 20k+ events)
+/// continues to scan in the background. Last-known totals are cached to
+/// UserDefaults so the first hover after launch shows yesterday's snapshot
+/// instantly rather than zeros.
 @MainActor
 final class CostStore: ObservableObject {
     static let shared = CostStore()
-    private init() {}
 
     @Published var claude: ProviderCost = .empty
     @Published var codex: ProviderCost = .empty
+    @Published var claudeLoading = false
+    @Published var codexLoading = false
     @Published var lastUpdated: Date?
-    @Published var loading = false
 
-    private var refreshTask: Task<Void, Never>?
+    var loading: Bool { claudeLoading || codexLoading }
+
+    private static let cacheKey = "MacIsland.costCache.v1"
     private var pollTimer: Timer?
     private var intervalCancellable: AnyCancellable?
 
@@ -26,24 +30,43 @@ final class CostStore: ObservableObject {
         TimeInterval(RefreshIntervalStore.shared.seconds)
     }
 
+    private init() {
+        restoreFromCache()
+    }
+
     func refresh() {
-        if loading { return }
-        loading = true
-        refreshTask?.cancel()
-        refreshTask = Task.detached(priority: .userInitiated) { [weak self] in
-            let claudeEvents = ClaudeLogReader.scan()
-            let codexEvents = CodexLogReader.scan()
-            let claudeCost = Self.summarize(events: claudeEvents)
-            let codexCost = Self.summarize(events: codexEvents)
-            await self?.commit(claude: claudeCost, codex: codexCost)
+        // Per-provider gate so a slow Claude scan doesn't block a fast
+        // Codex one (and vice versa) on the next tick.
+        if !claudeLoading {
+            claudeLoading = true
+            Task.detached(priority: .userInitiated) { [weak self] in
+                let events = ClaudeLogReader.scan()
+                let cost = Self.summarize(events: events)
+                await self?.commitClaude(cost)
+            }
+        }
+        if !codexLoading {
+            codexLoading = true
+            Task.detached(priority: .userInitiated) { [weak self] in
+                let events = CodexLogReader.scan()
+                let cost = Self.summarize(events: events)
+                await self?.commitCodex(cost)
+            }
         }
     }
 
-    private func commit(claude claudeCost: ProviderCost, codex codexCost: ProviderCost) {
-        self.claude = claudeCost
-        self.codex = codexCost
+    private func commitClaude(_ cost: ProviderCost) {
+        self.claude = cost
+        self.claudeLoading = false
         self.lastUpdated = Date()
-        self.loading = false
+        persist()
+    }
+
+    private func commitCodex(_ cost: ProviderCost) {
+        self.codex = cost
+        self.codexLoading = false
+        self.lastUpdated = Date()
+        persist()
     }
 
     func startAutoRefresh() {
@@ -83,18 +106,56 @@ final class CostStore: ObservableObject {
         return ProviderCost(
             today: CostWindow(
                 dollars: todaySum,
-                cap: CostBucketing.todayCap,
                 label: "today",
                 resetCaption: CostBucketing.todayResetCaption,
                 error: nil
             ),
             month: CostWindow(
                 dollars: monthSum,
-                cap: CostBucketing.monthCap,
                 label: CostBucketing.currentMonthLabel(),
                 resetCaption: CostBucketing.monthResetCaption(),
                 error: nil
             )
         )
+    }
+
+    // MARK: - Cache
+
+    /// Snapshot the four key totals + the last refresh time. Labels and
+    /// reset captions are recomputed at restore time (current month, current
+    /// reset countdown) so the cached numbers always sit under fresh chrome.
+    private func persist() {
+        let snap: [String: Any] = [
+            "claudeToday": claude.today.dollars,
+            "claudeMonth": claude.month.dollars,
+            "codexToday": codex.today.dollars,
+            "codexMonth": codex.month.dollars,
+            "lastUpdated": lastUpdated?.timeIntervalSinceReferenceDate ?? 0,
+        ]
+        UserDefaults.standard.set(snap, forKey: Self.cacheKey)
+    }
+
+    private func restoreFromCache() {
+        guard let snap = UserDefaults.standard.dictionary(forKey: Self.cacheKey) else { return }
+        let claudeToday = snap["claudeToday"] as? Double ?? 0
+        let claudeMonth = snap["claudeMonth"] as? Double ?? 0
+        let codexToday = snap["codexToday"] as? Double ?? 0
+        let codexMonth = snap["codexMonth"] as? Double ?? 0
+
+        self.claude = ProviderCost(
+            today: CostWindow(dollars: claudeToday, label: "today",
+                              resetCaption: CostBucketing.todayResetCaption, error: nil),
+            month: CostWindow(dollars: claudeMonth, label: CostBucketing.currentMonthLabel(),
+                              resetCaption: CostBucketing.monthResetCaption(), error: nil)
+        )
+        self.codex = ProviderCost(
+            today: CostWindow(dollars: codexToday, label: "today",
+                              resetCaption: CostBucketing.todayResetCaption, error: nil),
+            month: CostWindow(dollars: codexMonth, label: CostBucketing.currentMonthLabel(),
+                              resetCaption: CostBucketing.monthResetCaption(), error: nil)
+        )
+        if let ts = snap["lastUpdated"] as? Double, ts > 0 {
+            self.lastUpdated = Date(timeIntervalSinceReferenceDate: ts)
+        }
     }
 }

--- a/Sources/Cost/CostUsage.swift
+++ b/Sources/Cost/CostUsage.swift
@@ -7,12 +7,13 @@ import Foundation
 /// like an achievement rather than a burned-through budget.
 struct CostWindow {
     let dollars: Double
+    let tokens: Int
     let label: String
     let resetCaption: String
     let error: String?
 
     static let unknown = CostWindow(
-        dollars: 0, label: "—",
+        dollars: 0, tokens: 0, label: "—",
         resetCaption: "no data", error: "no data"
     )
 }
@@ -24,11 +25,11 @@ struct ProviderCost {
 
     static let empty = ProviderCost(
         today: CostWindow(
-            dollars: 0, label: "today",
+            dollars: 0, tokens: 0, label: "today",
             resetCaption: CostBucketing.todayResetCaption, error: nil
         ),
         month: CostWindow(
-            dollars: 0,
+            dollars: 0, tokens: 0,
             label: CostBucketing.currentMonthLabel(),
             resetCaption: CostBucketing.monthResetCaption(), error: nil
         )
@@ -39,11 +40,11 @@ struct ProviderCost {
     /// `AppUsage.dummy` pattern used by UsageView).
     static let dummy = ProviderCost(
         today: CostWindow(
-            dollars: 11.25, label: "today",
+            dollars: 11.25, tokens: 1_240_000, label: "today",
             resetCaption: CostBucketing.todayResetCaption, error: nil
         ),
         month: CostWindow(
-            dollars: 142.0,
+            dollars: 142.0, tokens: 18_500_000,
             label: CostBucketing.currentMonthLabel(),
             resetCaption: CostBucketing.monthResetCaption(), error: nil
         )

--- a/Sources/Cost/CostUsage.swift
+++ b/Sources/Cost/CostUsage.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+/// One time-bucket of estimated dollar spend (today's, this month's, etc).
+/// `cap` is the fixed-scale ceiling the bar fills against — when `dollars`
+/// exceeds `cap`, the bar saturates at full and the dollar number is the
+/// load-bearing display.
+struct CostWindow {
+    let dollars: Double
+    let cap: Double
+    let label: String
+    let resetCaption: String
+    let error: String?
+
+    var fillFraction: Double {
+        guard cap > 0 else { return 0 }
+        return min(1.0, dollars / cap)
+    }
+
+    static let unknown = CostWindow(
+        dollars: 0, cap: 25, label: "—",
+        resetCaption: "no data", error: "no data"
+    )
+}
+
+/// Per-provider cost summary: today + month-to-date in calendar-local time.
+struct ProviderCost {
+    var today: CostWindow
+    var month: CostWindow
+
+    static let empty = ProviderCost(
+        today: CostWindow(
+            dollars: 0, cap: CostBucketing.todayCap, label: "today",
+            resetCaption: "resets at midnight", error: nil
+        ),
+        month: CostWindow(
+            dollars: 0, cap: CostBucketing.monthCap,
+            label: CostBucketing.currentMonthLabel(),
+            resetCaption: CostBucketing.monthResetCaption(), error: nil
+        )
+    )
+
+    /// Placeholder values shown when a provider is toggled off in Settings.
+    /// Non-zero so the chart visualization stays meaningful (mirrors the
+    /// `AppUsage.dummy` pattern used by UsageView).
+    static let dummy = ProviderCost(
+        today: CostWindow(
+            dollars: 11.25, cap: CostBucketing.todayCap, label: "today",
+            resetCaption: "resets at midnight", error: nil
+        ),
+        month: CostWindow(
+            dollars: 142.0, cap: CostBucketing.monthCap,
+            label: CostBucketing.currentMonthLabel(),
+            resetCaption: CostBucketing.monthResetCaption(), error: nil
+        )
+    )
+}

--- a/Sources/Cost/CostUsage.swift
+++ b/Sources/Cost/CostUsage.swift
@@ -8,12 +8,16 @@ import Foundation
 struct CostWindow {
     let dollars: Double
     let tokens: Int
+    /// Cumulative dollar spend over the period — one point per hour for
+    /// today, one per day for the month. Drives the sparkline visualization
+    /// in the cost cell. Always monotonically non-decreasing.
+    let series: [Double]
     let label: String
     let resetCaption: String
     let error: String?
 
     static let unknown = CostWindow(
-        dollars: 0, tokens: 0, label: "—",
+        dollars: 0, tokens: 0, series: [], label: "—",
         resetCaption: "no data", error: "no data"
     )
 }
@@ -25,11 +29,11 @@ struct ProviderCost {
 
     static let empty = ProviderCost(
         today: CostWindow(
-            dollars: 0, tokens: 0, label: "today",
+            dollars: 0, tokens: 0, series: [], label: "Today",
             resetCaption: CostBucketing.todayResetCaption, error: nil
         ),
         month: CostWindow(
-            dollars: 0, tokens: 0,
+            dollars: 0, tokens: 0, series: [],
             label: CostBucketing.currentMonthLabel(),
             resetCaption: CostBucketing.monthResetCaption(), error: nil
         )
@@ -40,11 +44,14 @@ struct ProviderCost {
     /// `AppUsage.dummy` pattern used by UsageView).
     static let dummy = ProviderCost(
         today: CostWindow(
-            dollars: 11.25, tokens: 1_240_000, label: "today",
+            dollars: 11.25, tokens: 1_240_000,
+            series: [0.5, 1.2, 2.4, 3.6, 5.1, 7.0, 9.2, 11.25],
+            label: "Today",
             resetCaption: CostBucketing.todayResetCaption, error: nil
         ),
         month: CostWindow(
             dollars: 142.0, tokens: 18_500_000,
+            series: [3, 8, 15, 22, 31, 40, 52, 65, 78, 90, 105, 120, 135, 142],
             label: CostBucketing.currentMonthLabel(),
             resetCaption: CostBucketing.monthResetCaption(), error: nil
         )

--- a/Sources/Cost/CostUsage.swift
+++ b/Sources/Cost/CostUsage.swift
@@ -14,10 +14,15 @@ struct CostWindow {
     let series: [Double]
     let label: String
     let error: String?
+    /// Sorted unique model names that contributed real (non-zero) token
+    /// activity in this window but had no entry in the embedded pricing
+    /// snapshot. Surfaced as a warning glyph so a freshly released model
+    /// doesn't silently read as $0.
+    let unknownModels: [String]
 
     static let unknown = CostWindow(
         dollars: 0, tokens: 0, series: [], label: "—",
-        error: "no data"
+        error: "no data", unknownModels: []
     )
 }
 
@@ -28,11 +33,13 @@ struct ProviderCost {
 
     static let empty = ProviderCost(
         today: CostWindow(
-            dollars: 0, tokens: 0, series: [], label: "Today", error: nil
+            dollars: 0, tokens: 0, series: [], label: "Today", error: nil,
+            unknownModels: []
         ),
         month: CostWindow(
             dollars: 0, tokens: 0, series: [],
-            label: CostBucketing.currentMonthLabel(), error: nil
+            label: CostBucketing.currentMonthLabel(), error: nil,
+            unknownModels: []
         )
     )
 
@@ -43,12 +50,13 @@ struct ProviderCost {
         today: CostWindow(
             dollars: 11.25, tokens: 1_240_000,
             series: [0.5, 1.2, 2.4, 3.6, 5.1, 7.0, 9.2, 11.25],
-            label: "Today", error: nil
+            label: "Today", error: nil, unknownModels: []
         ),
         month: CostWindow(
             dollars: 142.0, tokens: 18_500_000,
             series: [3, 8, 15, 22, 31, 40, 52, 65, 78, 90, 105, 120, 135, 142],
-            label: CostBucketing.currentMonthLabel(), error: nil
+            label: CostBucketing.currentMonthLabel(), error: nil,
+            unknownModels: []
         )
     )
 }

--- a/Sources/Cost/CostUsage.swift
+++ b/Sources/Cost/CostUsage.swift
@@ -1,23 +1,18 @@
 import Foundation
 
 /// One time-bucket of estimated dollar spend (today's, this month's, etc).
-/// `cap` is the fixed-scale ceiling the bar fills against — when `dollars`
-/// exceeds `cap`, the bar saturates at full and the dollar number is the
-/// load-bearing display.
+/// No "cap" or fill metaphor — the dollar number is the load-bearing
+/// display. The cost screen visualizes spend as a glowing brand-colored
+/// number whose aura grows softly with the amount, so heavier usage feels
+/// like an achievement rather than a burned-through budget.
 struct CostWindow {
     let dollars: Double
-    let cap: Double
     let label: String
     let resetCaption: String
     let error: String?
 
-    var fillFraction: Double {
-        guard cap > 0 else { return 0 }
-        return min(1.0, dollars / cap)
-    }
-
     static let unknown = CostWindow(
-        dollars: 0, cap: 25, label: "—",
+        dollars: 0, label: "—",
         resetCaption: "no data", error: "no data"
     )
 }
@@ -29,26 +24,26 @@ struct ProviderCost {
 
     static let empty = ProviderCost(
         today: CostWindow(
-            dollars: 0, cap: CostBucketing.todayCap, label: "today",
-            resetCaption: "resets at midnight", error: nil
+            dollars: 0, label: "today",
+            resetCaption: CostBucketing.todayResetCaption, error: nil
         ),
         month: CostWindow(
-            dollars: 0, cap: CostBucketing.monthCap,
+            dollars: 0,
             label: CostBucketing.currentMonthLabel(),
             resetCaption: CostBucketing.monthResetCaption(), error: nil
         )
     )
 
     /// Placeholder values shown when a provider is toggled off in Settings.
-    /// Non-zero so the chart visualization stays meaningful (mirrors the
+    /// Non-zero so the visualization remains meaningful (mirrors the
     /// `AppUsage.dummy` pattern used by UsageView).
     static let dummy = ProviderCost(
         today: CostWindow(
-            dollars: 11.25, cap: CostBucketing.todayCap, label: "today",
-            resetCaption: "resets at midnight", error: nil
+            dollars: 11.25, label: "today",
+            resetCaption: CostBucketing.todayResetCaption, error: nil
         ),
         month: CostWindow(
-            dollars: 142.0, cap: CostBucketing.monthCap,
+            dollars: 142.0,
             label: CostBucketing.currentMonthLabel(),
             resetCaption: CostBucketing.monthResetCaption(), error: nil
         )

--- a/Sources/Cost/CostUsage.swift
+++ b/Sources/Cost/CostUsage.swift
@@ -13,12 +13,11 @@ struct CostWindow {
     /// in the cost cell. Always monotonically non-decreasing.
     let series: [Double]
     let label: String
-    let resetCaption: String
     let error: String?
 
     static let unknown = CostWindow(
         dollars: 0, tokens: 0, series: [], label: "—",
-        resetCaption: "no data", error: "no data"
+        error: "no data"
     )
 }
 
@@ -29,13 +28,11 @@ struct ProviderCost {
 
     static let empty = ProviderCost(
         today: CostWindow(
-            dollars: 0, tokens: 0, series: [], label: "Today",
-            resetCaption: CostBucketing.todayResetCaption, error: nil
+            dollars: 0, tokens: 0, series: [], label: "Today", error: nil
         ),
         month: CostWindow(
             dollars: 0, tokens: 0, series: [],
-            label: CostBucketing.currentMonthLabel(),
-            resetCaption: CostBucketing.monthResetCaption(), error: nil
+            label: CostBucketing.currentMonthLabel(), error: nil
         )
     )
 
@@ -46,14 +43,12 @@ struct ProviderCost {
         today: CostWindow(
             dollars: 11.25, tokens: 1_240_000,
             series: [0.5, 1.2, 2.4, 3.6, 5.1, 7.0, 9.2, 11.25],
-            label: "Today",
-            resetCaption: CostBucketing.todayResetCaption, error: nil
+            label: "Today", error: nil
         ),
         month: CostWindow(
             dollars: 142.0, tokens: 18_500_000,
             series: [3, 8, 15, 22, 31, 40, 52, 65, 78, 90, 105, 120, 135, 142],
-            label: CostBucketing.currentMonthLabel(),
-            resetCaption: CostBucketing.monthResetCaption(), error: nil
+            label: CostBucketing.currentMonthLabel(), error: nil
         )
     )
 }

--- a/Sources/Cost/Pricing.swift
+++ b/Sources/Cost/Pricing.swift
@@ -1,0 +1,103 @@
+import Foundation
+
+/// Embedded snapshot of per-million-token API prices in USD. Mirrors LiteLLM's
+/// `model_prices_and_context_window.json` for the models we actually expect
+/// in Claude Code and Codex CLI sessions, so totals cross-check against
+/// `npx ccusage` and `npx @ccusage/codex` to within rounding.
+///
+/// To refresh: bump `snapshotDate` and re-fetch the four rates per model
+/// from `https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json`.
+/// Unknown models silently price to $0 — same behavior as ccusage when
+/// LiteLLM has no entry.
+enum Pricing {
+    static let snapshotDate = "2026-04-30"
+
+    struct Rates {
+        let inputPerMillion: Double
+        let outputPerMillion: Double
+        let cacheCreationPerMillion: Double
+        let cacheReadPerMillion: Double
+    }
+
+    private static let table: [String: Rates] = [
+        // Anthropic — LiteLLM lists Opus 4-5/4-6/4-7 at the same rates
+        // (cheaper than the original Opus 4 because Anthropic re-tiered the
+        // Opus line in 2025).
+        "claude-opus-4-7": Rates(
+            inputPerMillion: 5, outputPerMillion: 25,
+            cacheCreationPerMillion: 6.25, cacheReadPerMillion: 0.50
+        ),
+        "claude-opus-4-6": Rates(
+            inputPerMillion: 5, outputPerMillion: 25,
+            cacheCreationPerMillion: 6.25, cacheReadPerMillion: 0.50
+        ),
+        "claude-opus-4-5": Rates(
+            inputPerMillion: 5, outputPerMillion: 25,
+            cacheCreationPerMillion: 6.25, cacheReadPerMillion: 0.50
+        ),
+        "claude-sonnet-4-6": Rates(
+            inputPerMillion: 3, outputPerMillion: 15,
+            cacheCreationPerMillion: 3.75, cacheReadPerMillion: 0.30
+        ),
+        "claude-sonnet-4-5": Rates(
+            inputPerMillion: 3, outputPerMillion: 15,
+            cacheCreationPerMillion: 3.75, cacheReadPerMillion: 0.30
+        ),
+        "claude-haiku-4-5": Rates(
+            inputPerMillion: 1, outputPerMillion: 5,
+            cacheCreationPerMillion: 1.25, cacheReadPerMillion: 0.10
+        ),
+
+        // OpenAI — Codex CLI tags conversations with the chat-completion
+        // model name. cache_creation has no separate rate (OpenAI bills
+        // cache writes at the standard input rate).
+        "gpt-5.5": Rates(
+            inputPerMillion: 5, outputPerMillion: 30,
+            cacheCreationPerMillion: 5, cacheReadPerMillion: 0.50
+        ),
+        "gpt-5.4": Rates(
+            inputPerMillion: 2.5, outputPerMillion: 15,
+            cacheCreationPerMillion: 2.5, cacheReadPerMillion: 0.25
+        ),
+        "gpt-5.4-mini": Rates(
+            inputPerMillion: 0.75, outputPerMillion: 4.5,
+            cacheCreationPerMillion: 0.75, cacheReadPerMillion: 0.075
+        ),
+        "gpt-5-codex": Rates(
+            inputPerMillion: 1.25, outputPerMillion: 10,
+            cacheCreationPerMillion: 1.25, cacheReadPerMillion: 0.125
+        ),
+    ]
+
+    /// Compute the dollar cost of a single TokenEvent. Returns 0 for unknown
+    /// models — ccusage parity. Synthetic placeholder models filtered upstream.
+    ///
+    /// Anthropic's 1M-context tier (2x rate above 200k tokens) is omitted —
+    /// it only affects sonnet-4-5 with the 1M flag and is rarely hit in
+    /// Claude Code workflows. ccusage's per-bucket threshold check would
+    /// disagree with Anthropic's per-position-in-context billing anyway.
+    static func cost(for event: TokenEvent) -> Double {
+        let lookup = canonicalModel(event.model)
+        guard let rates = table[lookup] else { return 0 }
+
+        let input = Double(event.inputTokens) / 1_000_000 * rates.inputPerMillion
+        let output = Double(event.outputTokens) / 1_000_000 * rates.outputPerMillion
+        let cacheCreate = Double(event.cacheCreationTokens) / 1_000_000 * rates.cacheCreationPerMillion
+        let cacheRead = Double(event.cacheReadTokens) / 1_000_000 * rates.cacheReadPerMillion
+
+        return input + output + cacheCreate + cacheRead
+    }
+
+    /// Strip Anthropic-style date suffixes (e.g. "claude-haiku-4-5-20251001"
+    /// → "claude-haiku-4-5") so the snapshot table doesn't need an entry per
+    /// pinned release.
+    private static func canonicalModel(_ raw: String) -> String {
+        guard raw.count > 9 else { return raw }
+        let suffixStart = raw.index(raw.endIndex, offsetBy: -9)
+        let suffix = raw[suffixStart...]
+        guard suffix.first == "-",
+              suffix.dropFirst().allSatisfy({ $0.isNumber })
+        else { return raw }
+        return String(raw[..<suffixStart])
+    }
+}

--- a/Sources/Cost/Pricing.swift
+++ b/Sources/Cost/Pricing.swift
@@ -88,6 +88,28 @@ enum Pricing {
         return input + output + cacheCreate + cacheRead
     }
 
+    /// Whether the embedded snapshot has a price entry for this model.
+    /// Lets callers warn the user about unpriced spend without re-implementing
+    /// the canonical-name stripping logic.
+    static func isKnown(_ rawModel: String) -> Bool {
+        table[canonicalModel(rawModel)] != nil
+    }
+
+    /// Calendar days between `snapshotDate` and now (UTC). Returns 0 if the
+    /// snapshot string fails to parse, so a malformed constant is treated as
+    /// fresh rather than triggering a permanent staleness warning.
+    static var daysSinceSnapshot: Int {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        formatter.timeZone = TimeZone(identifier: "UTC")
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        guard let snapshot = formatter.date(from: snapshotDate) else { return 0 }
+        var calendar = Calendar(identifier: .gregorian)
+        if let utc = TimeZone(identifier: "UTC") { calendar.timeZone = utc }
+        let components = calendar.dateComponents([.day], from: snapshot, to: Date())
+        return max(0, components.day ?? 0)
+    }
+
     /// Strip Anthropic-style date suffixes (e.g. "claude-haiku-4-5-20251001"
     /// → "claude-haiku-4-5") so the snapshot table doesn't need an entry per
     /// pinned release.

--- a/Sources/Cost/TokenEvent.swift
+++ b/Sources/Cost/TokenEvent.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+/// A single billable unit of token consumption parsed from a local session log.
+/// Both `ClaudeLogReader` and `CodexLogReader` emit these so the cost pipeline
+/// downstream is provider-agnostic.
+struct TokenEvent {
+    enum Provider {
+        case claude
+        case codex
+    }
+
+    let provider: Provider
+    let timestamp: Date
+    let model: String
+    let inputTokens: Int
+    let outputTokens: Int
+    /// Tokens written to the prompt cache during this turn. Anthropic-only.
+    let cacheCreationTokens: Int
+    /// Tokens served from the prompt cache during this turn. Both providers
+    /// (Codex calls these "cached_input_tokens" — they are billed at a
+    /// discount but still draw from the input bucket).
+    let cacheReadTokens: Int
+}

--- a/Sources/Model/CostStylePref.swift
+++ b/Sources/Model/CostStylePref.swift
@@ -25,15 +25,20 @@ enum CostStyle: String, CaseIterable {
 final class CostStylePref: ObservableObject {
     static let shared = CostStylePref()
 
-    private static let key = "MacIsland.costStyle"
+    private static let styleKey = "MacIsland.costStyle"
+    private static let cycledKey = "MacIsland.costStyleCycled"
 
     @Published var style: CostStyle {
-        didSet { UserDefaults.standard.set(style.rawValue, forKey: Self.key) }
+        didSet { UserDefaults.standard.set(style.rawValue, forKey: Self.styleKey) }
+    }
+    @Published var hasCycledStyle: Bool {
+        didSet { UserDefaults.standard.set(hasCycledStyle, forKey: Self.cycledKey) }
     }
 
     private init() {
-        let raw = UserDefaults.standard.string(forKey: Self.key) ?? ""
+        let raw = UserDefaults.standard.string(forKey: Self.styleKey) ?? ""
         self.style = CostStyle(rawValue: raw) ?? .dollar
+        self.hasCycledStyle = UserDefaults.standard.bool(forKey: Self.cycledKey)
     }
 
     func cycle() {
@@ -41,5 +46,6 @@ final class CostStylePref: ObservableObject {
         if let i = all.firstIndex(of: style) {
             style = all[(i + 1) % all.count]
         }
+        if !hasCycledStyle { hasCycledStyle = true }
     }
 }

--- a/Sources/Model/CostStylePref.swift
+++ b/Sources/Model/CostStylePref.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+/// Visualization style for the cost screen — cycled via Cmd-click on the
+/// expanded panel, mirroring how `StylePref` cycles chart styles on the
+/// usage screen. Each style is a different way of bragging about the same
+/// number: pure dollars, value extracted vs a $20/mo subscription baseline,
+/// raw token throughput, or a cumulative trend line.
+enum CostStyle: String, CaseIterable {
+    case dollar
+    case multi
+    case tokens
+    case spark
+
+    var label: String {
+        switch self {
+        case .dollar: "USD"
+        case .multi:  "VALUE"
+        case .tokens: "TOKENS"
+        case .spark:  "TREND"
+        }
+    }
+}
+
+@MainActor
+final class CostStylePref: ObservableObject {
+    static let shared = CostStylePref()
+
+    private static let key = "MacIsland.costStyle"
+
+    @Published var style: CostStyle {
+        didSet { UserDefaults.standard.set(style.rawValue, forKey: Self.key) }
+    }
+
+    private init() {
+        let raw = UserDefaults.standard.string(forKey: Self.key) ?? ""
+        self.style = CostStyle(rawValue: raw) ?? .dollar
+    }
+
+    func cycle() {
+        let all = CostStyle.allCases
+        if let i = all.firstIndex(of: style) {
+            style = all[(i + 1) % all.count]
+        }
+    }
+}

--- a/Sources/Model/ScreenPref.swift
+++ b/Sources/Model/ScreenPref.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+/// Which page of the expanded panel is currently active. Persisted across
+/// launches so the app reopens on the last-viewed page.
+@MainActor
+final class ScreenPref: ObservableObject {
+    static let shared = ScreenPref()
+
+    enum Screen: String, CaseIterable {
+        case usage
+        case cost
+    }
+
+    private static let key = "MacIsland.screen"
+
+    @Published var screen: Screen {
+        didSet { UserDefaults.standard.set(screen.rawValue, forKey: Self.key) }
+    }
+
+    private init() {
+        let raw = UserDefaults.standard.string(forKey: Self.key) ?? ""
+        self.screen = Screen(rawValue: raw) ?? .usage
+    }
+
+    /// Two-page carousel — swipe left advances forward, swipe right rewinds.
+    /// Wraps trivially since there are only two pages.
+    func advance() {
+        screen = (screen == .usage) ? .cost : .usage
+    }
+
+    func rewind() {
+        screen = (screen == .cost) ? .usage : .cost
+    }
+}

--- a/Sources/Model/ScreenPref.swift
+++ b/Sources/Model/ScreenPref.swift
@@ -22,13 +22,15 @@ final class ScreenPref: ObservableObject {
         self.screen = Screen(rawValue: raw) ?? .usage
     }
 
-    /// Two-page carousel — swipe left advances forward, swipe right rewinds.
-    /// Wraps trivially since there are only two pages.
+    /// Edge-clamped carousel — swiping past the rightmost page does
+    /// nothing (no wrap to page 1), and likewise for the leftmost page.
+    /// Matches the iOS Home Screen rubber-band feel where the user
+    /// understands they've hit a boundary instead of teleporting around.
     func advance() {
-        screen = (screen == .usage) ? .cost : .usage
+        if screen == .usage { screen = .cost }
     }
 
     func rewind() {
-        screen = (screen == .cost) ? .usage : .cost
+        if screen == .cost { screen = .usage }
     }
 }

--- a/Sources/Model/ScreenPref.swift
+++ b/Sources/Model/ScreenPref.swift
@@ -12,14 +12,25 @@ final class ScreenPref: ObservableObject {
     }
 
     private static let key = "MacIsland.screen"
+    private static let swipedKey = "MacIsland.hasSwipedScreen"
 
     @Published var screen: Screen {
-        didSet { UserDefaults.standard.set(screen.rawValue, forKey: Self.key) }
+        didSet {
+            UserDefaults.standard.set(screen.rawValue, forKey: Self.key)
+            // Once the user has swiped between pages even once, we've made
+            // our point — kill the discoverability peek in `PagedContent`.
+            if oldValue != screen, !hasSwipedScreen { hasSwipedScreen = true }
+        }
+    }
+
+    @Published var hasSwipedScreen: Bool {
+        didSet { UserDefaults.standard.set(hasSwipedScreen, forKey: Self.swipedKey) }
     }
 
     private init() {
         let raw = UserDefaults.standard.string(forKey: Self.key) ?? ""
         self.screen = Screen(rawValue: raw) ?? .usage
+        self.hasSwipedScreen = UserDefaults.standard.bool(forKey: Self.swipedKey)
     }
 
     /// Edge-clamped carousel — swiping past the rightmost page does

--- a/Sources/Theme/Typography.swift
+++ b/Sources/Theme/Typography.swift
@@ -10,7 +10,9 @@ import SwiftUI
 ///   18pt SF Mono semibold  — sub-hero (chart values)
 ///   15pt SF Mono semibold  — picker preview numerics
 ///   15pt SF Pro medium     — unit suffixes adjacent to hero ($, k, M, B)
+///   14pt SF Pro semibold   — Settings brand wordmark
 ///   13pt SF Pro semibold   — provider titles ("Claude", "Codex")
+///   13pt SF Pro medium     — Settings row titles
 ///   12pt SF Pro medium     — tab labels (a hair larger so they feel clickable)
 ///   11pt — body row
 ///       SF Mono semibold for inline numerics (bar dollars, sparkline overlay)
@@ -40,8 +42,10 @@ enum Typography {
 
     // MARK: - Display text (SF Pro)
 
+    static let brand         = Font.system(size: 14, weight: .semibold)
     static let unit          = Font.system(size: 15, weight: .medium)
     static let providerTitle = Font.system(size: 13, weight: .semibold)
+    static let rowTitle      = Font.system(size: 13, weight: .medium)
     static let tabLabel      = Font.system(size: 12, weight: .medium)
     static let label         = Font.system(size: 11, weight: .medium)
     static let button        = Font.system(size: 11, weight: .semibold)

--- a/Sources/Theme/Typography.swift
+++ b/Sources/Theme/Typography.swift
@@ -1,27 +1,55 @@
 import SwiftUI
 
-/// The locked type scale for CodexIsland. SF Pro everywhere, monospacedDigit
-/// on every percentage so digits don't jiggle as values change.
+/// Locked type scale for CodexIsland. Eight tokens across six visual tiers,
+/// no half-points. Hero numerics use SF Mono so the display digits — which
+/// are the product's brand — have a developer-tool character that SF Pro
+/// with `monospacedDigit()` can't deliver.
 ///
-/// Sizes (top-to-bottom in visual prominence):
-///   38pt semibold mono — NumericChart big number
-///   18pt semibold mono — chart values (ring / bar / stepped / spark)
-///   13pt semibold      — provider titles ("Claude", "Codex")
-///   11pt               — chart labels ("5h", "week"), live-status text
-///   10pt mono          — footer captions ("resets in 3h", "synced 5s ago")
-///   9pt bold mono      — chips (MAX / PLUS / style label), tracking 0.8
+/// Tiers (largest to smallest):
+///   38pt SF Mono semibold  — hero numerics (count-up dollar, big tokens)
+///   18pt SF Mono semibold  — sub-hero (chart values)
+///   15pt SF Mono semibold  — picker preview numerics
+///   15pt SF Pro medium     — unit suffixes adjacent to hero ($, k, M, B)
+///   13pt SF Pro semibold   — provider titles ("Claude", "Codex")
+///   12pt SF Pro medium     — tab labels (a hair larger so they feel clickable)
+///   11pt — body row
+///       SF Mono semibold for inline numerics (bar dollars, sparkline overlay)
+///       SF Pro medium for window labels ("Today", "Apr")
+///       SF Pro semibold for buttons ("Refresh", "Check")
+///   10pt — micro row
+///       SF Mono regular for caption (reset glyph "↻ 5h", "synced 2m ago")
+///       SF Pro medium for sub-bar labels and picker tile labels
+///       SF Pro semibold for tracked-uppercase section labels
+///   9pt SF Mono bold tracked — chips (MAX / PRO / PLUS)
 ///
-/// White-text ladder (foregroundStyle.opacity) for emphasis tiers:
-///   1.0   — primary value text
-///   0.78  — chip text
-///   0.55  — labels / "synced" caption
-///   0.42  — secondary hints
-///   0.06  — hairline strokes / divider gradients
+/// White-text opacity ladder (combine freely with any tier):
+///   1.00  primary value
+///   0.78  chip text
+///   0.55  labels
+///   0.40  secondary captions
+///   0.32  tertiary
+///   0.18  hints
+///   0.06  hairlines
 enum Typography {
-    static let bigNumber = Font.system(size: 38, weight: .semibold).monospacedDigit()
-    static let chartValue = Font.system(size: 18, weight: .semibold).monospacedDigit()
+    // MARK: - Numerics (SF Mono)
+
+    static let bigNumber     = Font.system(size: 38, weight: .semibold, design: .monospaced)
+    static let chartValue    = Font.system(size: 18, weight: .semibold, design: .monospaced)
+    static let previewNumber = Font.system(size: 15, weight: .semibold, design: .monospaced)
+    static let bodyNumber    = Font.system(size: 11, weight: .semibold, design: .monospaced)
+
+    // MARK: - Display text (SF Pro)
+
+    static let unit          = Font.system(size: 15, weight: .medium)
     static let providerTitle = Font.system(size: 13, weight: .semibold)
-    static let label = Font.system(size: 11, weight: .medium)
-    static let caption = Font.system(size: 10).monospaced()
-    static let chip = Font.system(size: 9, weight: .bold).monospaced()
+    static let tabLabel      = Font.system(size: 12, weight: .medium)
+    static let label         = Font.system(size: 11, weight: .medium)
+    static let button        = Font.system(size: 11, weight: .semibold)
+    static let micro         = Font.system(size: 10, weight: .medium)
+    static let sectionLabel  = Font.system(size: 10, weight: .semibold)
+
+    // MARK: - Specialty
+
+    static let caption = Font.system(size: 10, design: .monospaced)
+    static let chip    = Font.system(size: 9, weight: .bold).monospaced()
 }

--- a/Sources/Views/Charts/ChartHead.swift
+++ b/Sources/Views/Charts/ChartHead.swift
@@ -9,18 +9,18 @@ struct ChartHead: View {
     var body: some View {
         HStack(alignment: .firstTextBaseline) {
             Text(label)
-                .font(.system(size: 11, weight: .medium))
+                .font(Typography.label)
                 .foregroundStyle(.white.opacity(0.55))
                 .textCase(.lowercase)
             Spacer()
             HStack(alignment: .firstTextBaseline, spacing: 1) {
                 Text("\(Int(value))")
-                    .font(.system(size: 18, weight: .semibold).monospacedDigit())
+                    .font(Typography.chartValue)
                     .foregroundStyle(UrgencyColor.value(value))
                     .numericTransition(value: value)
                     .animation(.strongEaseOut, value: value)
                 Text("%")
-                    .font(.system(size: 11, weight: .medium))
+                    .font(Typography.label)
                     .foregroundStyle(.white.opacity(0.5))
             }
         }
@@ -32,7 +32,7 @@ struct ChartFoot: View {
 
     var body: some View {
         Text(caption)
-            .font(.system(size: 10).monospaced())
+            .font(Typography.caption)
             .foregroundStyle(.white.opacity(0.4))
             .lineLimit(1)
             .truncationMode(.tail)

--- a/Sources/Views/Charts/NumericChart.swift
+++ b/Sources/Views/Charts/NumericChart.swift
@@ -10,24 +10,24 @@ struct NumericChart: View {
         VStack(alignment: .leading, spacing: 6) {
             HStack(alignment: .firstTextBaseline) {
                 Text(label)
-                    .font(.system(size: 11, weight: .medium))
+                    .font(Typography.label)
                     .foregroundStyle(.white.opacity(0.55))
                     .textCase(.lowercase)
                 Spacer()
                 // "resets in 3h" → "↻ 3h" — same info, less prose. The
                 // glyph reads at a glance; the words don't.
                 Text(sub.replacingOccurrences(of: "resets in ", with: "↻ "))
-                    .font(.system(size: 10).monospaced())
+                    .font(Typography.caption)
                     .foregroundStyle(.white.opacity(0.4))
             }
             HStack(alignment: .firstTextBaseline, spacing: 2) {
                 Text("\(Int(value))")
-                    .font(.system(size: 38, weight: .semibold).monospacedDigit())
+                    .font(Typography.bigNumber)
                     .foregroundStyle(UrgencyColor.value(value))
                     .numericTransition(value: value)
                     .animation(.strongEaseOut, value: value)
                 Text("%")
-                    .font(.system(size: 15, weight: .medium))
+                    .font(Typography.unit)
                     .foregroundStyle(.white.opacity(0.4))
             }
             .frame(maxWidth: .infinity, alignment: .leading)

--- a/Sources/Views/Charts/RingChart.swift
+++ b/Sources/Views/Charts/RingChart.swift
@@ -25,24 +25,24 @@ struct RingChart: View {
 
                 VStack(alignment: .leading, spacing: 4) {
                     Text(label)
-                        .font(.system(size: 11, weight: .medium))
+                        .font(Typography.label)
                         .foregroundStyle(.white.opacity(0.55))
                         .textCase(.lowercase)
                     HStack(alignment: .firstTextBaseline, spacing: 1) {
                         Text("\(Int(value))")
-                            .font(.system(size: 18, weight: .semibold).monospacedDigit())
+                            .font(Typography.chartValue)
                             .foregroundStyle(UrgencyColor.value(value))
                             .numericTransition(value: value)
                             .animation(.strongEaseOut, value: value)
                         Text("%")
-                            .font(.system(size: 11, weight: .medium))
+                            .font(Typography.label)
                             .foregroundStyle(.white.opacity(0.5))
                     }
                 }
                 Spacer()
             }
             Text(sub)
-                .font(.system(size: 10).monospaced())
+                .font(Typography.caption)
                 .foregroundStyle(.white.opacity(0.4))
                 .lineLimit(1)
                 .truncationMode(.tail)

--- a/Sources/Views/Charts/SteppedChart.swift
+++ b/Sources/Views/Charts/SteppedChart.swift
@@ -10,17 +10,16 @@ struct SteppedChart: View {
         VStack(alignment: .leading, spacing: 8) {
             ChartHead(value: value, label: label)
             HStack(spacing: 2) {
-                let segments = 20
+                let segments = 30
                 let filled = (value / 100) * Double(segments)
                 ForEach(0..<segments, id: \.self) { i in
-                    RoundedRectangle(cornerRadius: 1)
-                        .fill(Double(i) < floor(filled) ? color : .white.opacity(0.06))
+                    RoundedRectangle(cornerRadius: 1.5)
+                        .fill(Double(i) < floor(filled) ? color : .white.opacity(0.10))
                         .frame(maxWidth: .infinity)
-                        .frame(height: 14)
-                        // 10ms stagger across cells gives a brief "fill"
-                        // sweep when a new value arrives. Total animation
-                        // is still under 300ms (200ms across all 20).
-                        .animation(.strongEaseOut.delay(Double(i) * 0.01), value: value)
+                        .frame(height: 16)
+                        // ~7ms stagger across 30 cells = ~210ms sweep when
+                        // a new value arrives. Stays under the 300ms budget.
+                        .animation(.strongEaseOut.delay(Double(i) * 0.007), value: value)
                 }
             }
             ChartFoot(caption: sub)

--- a/Sources/Views/CostBlock.swift
+++ b/Sources/Views/CostBlock.swift
@@ -50,7 +50,7 @@ struct CostTile: View {
                 Spacer()
                 Text(resetGlyph)
                     .font(Typography.caption)
-                    .foregroundStyle(.white.opacity(0.4))
+                    .foregroundStyle(.white.opacity(window.unknownModels.isEmpty ? 0.4 : 0.5))
             }
 
             Spacer(minLength: 0)
@@ -285,9 +285,15 @@ struct CostTile: View {
     /// the current clock so the panel always shows accurate time-remaining
     /// regardless of how stale the last refresh is. Mirrors `NumericChart`'s
     /// "↻ 3h" treatment so the cost screen doesn't introduce a new caption
-    /// shape.
+    /// shape. When the embedded pricing snapshot is missing models that
+    /// produced real spend in this window, the countdown is replaced with
+    /// an "⚠ N unpriced" warning so the user knows the dollar total is an
+    /// undercount rather than a clean zero.
     private var resetGlyph: String {
         if let err = window.error { return err }
+        if !window.unknownModels.isEmpty {
+            return "⚠ \(window.unknownModels.count) unpriced"
+        }
         return "↻ " + (isMonth ? CostBucketing.monthResetIn() : CostBucketing.todayResetIn())
     }
 }

--- a/Sources/Views/CostBlock.swift
+++ b/Sources/Views/CostBlock.swift
@@ -1,45 +1,40 @@
 import SwiftUI
 
-/// Two cost cells per provider — today + month-to-date — laid out horizontally
-/// to mirror `ChartsBlock`'s 5h+week pair on the usage screen.
+/// Two cost cells per provider — Today + month-to-date — laid out
+/// horizontally to mirror `ChartsBlock`'s 5h+week pair on the usage screen.
 struct CostBlock: View {
     let color: Color
     let cost: ProviderCost
     let loading: Bool
-    /// Monthly cost of the user's subscription in USD, used to compute the
-    /// ROI multiplier on each cell. Nil when the plan is unknown or free —
-    /// the cell then shows just the token brag without the "X.Xx" prefix.
-    let subscriptionMonthlyUSD: Double?
 
     var body: some View {
         HStack(spacing: 18) {
-            CostTile(
-                color: color, window: cost.today, loading: loading,
-                subscriptionMonthlyUSD: subscriptionMonthlyUSD, isMonth: false
-            )
-            CostTile(
-                color: color, window: cost.month, loading: loading,
-                subscriptionMonthlyUSD: subscriptionMonthlyUSD, isMonth: true
-            )
+            CostTile(color: color, window: cost.today, loading: loading, isMonth: false)
+            CostTile(color: color, window: cost.month, loading: loading, isMonth: true)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
         .padding(.horizontal, 12)
     }
 }
 
-/// One cost cell. The dollar number is the hero — 38pt brand-colored
-/// monospace digits with a soft glow whose intensity grows with the
-/// amount, plus a count-up reveal on first appearance and a smooth
-/// interpolation on refresh. Below it: a single small caption with the
-/// ROI multiplier vs the user's subscription and the period's raw token
-/// count, so heavy use reads as "look how much value I extracted" rather
-/// than "look how much I burned."
+/// One cost cell. Branches on `CostStylePref.style` for the hero
+/// visualization — pure dollars, value multiplier vs a $20/mo baseline,
+/// raw token throughput, or a cumulative trend line. Cmd-click on the
+/// expanded panel cycles styles (handled in `IslandRootView`).
 struct CostTile: View {
     let color: Color
     let window: CostWindow
     let loading: Bool
-    let subscriptionMonthlyUSD: Double?
     let isMonth: Bool
+
+    @ObservedObject private var stylePref = CostStylePref.shared
+
+    /// "Pro/Plus" subscription value — the implicit baseline the value
+    /// multiplier compares against. Hardcoded because asking the user to
+    /// configure their plan in Settings adds friction; $20/mo is the
+    /// most common tier across both providers and serves as a relatable
+    /// "subscription dollar" yardstick.
+    private static let baselineMonthlyUSD: Double = 20
 
     /// Locked to match `ChartTile.tileHeight` so swipe transitions don't
     /// reflow the panel.
@@ -51,7 +46,6 @@ struct CostTile: View {
                 Text(window.label)
                     .font(.system(size: 11, weight: .medium))
                     .foregroundStyle(.white.opacity(0.55))
-                    .textCase(.lowercase)
                 Spacer()
                 Text(resetGlyph)
                     .font(.system(size: 10).monospaced())
@@ -60,19 +54,16 @@ struct CostTile: View {
 
             Spacer(minLength: 0)
 
-            HStack(alignment: .firstTextBaseline, spacing: 1) {
-                Text("$")
-                    .font(.system(size: 15, weight: .medium))
-                    .foregroundStyle(.white.opacity(0.4))
-                CountUpDollar(target: window.dollars, color: color, glowOpacity: glowOpacity)
+            Group {
+                switch stylePref.style {
+                case .dollar: dollarHero
+                case .multi:  multiplierHero
+                case .tokens: tokensHero
+                case .spark:  sparkHero
+                }
             }
-            .frame(maxWidth: .infinity, alignment: .leading)
-
-            Text(captionText)
-                .font(.system(size: 10).monospaced())
-                .foregroundStyle(.white.opacity(0.55))
-                .lineLimit(1)
-                .truncationMode(.tail)
+            .id(stylePref.style)
+            .transition(.chartSwap.animation(.chartSwap))
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .frame(height: Self.tileHeight)
@@ -80,10 +71,111 @@ struct CostTile: View {
         .animation(.easeOut(duration: 0.18), value: loading)
     }
 
-    /// Glow intensity scales softly with spend so a $5 day looks calm and a
-    /// $1500 month looks luminous. Logarithmic so the curve doesn't blow
-    /// out at the high end. Caps around 0.85 so even at peak the glow
-    /// stays a halo, not a smear.
+    // MARK: - Heroes
+
+    private var dollarHero: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 1) {
+            Text("$")
+                .font(.system(size: 15, weight: .medium))
+                .foregroundStyle(.white.opacity(0.4))
+            CountUpDollar(target: window.dollars, color: color, glowOpacity: glowOpacity)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var multiplierHero: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 2) {
+            Text(formattedMultiplier)
+                .font(.system(size: 38, weight: .semibold).monospacedDigit())
+                .foregroundStyle(color)
+                .shadow(color: color.opacity(glowOpacity), radius: 6)
+                .shadow(color: color.opacity(glowOpacity * 0.5), radius: 14)
+                .numericTransition(value: multiplier)
+                .animation(.strongEaseOut, value: multiplier)
+            Text("×")
+                .font(.system(size: 18, weight: .medium))
+                .foregroundStyle(color.opacity(0.85))
+                .shadow(color: color.opacity(glowOpacity * 0.6), radius: 4)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var tokensHero: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 3) {
+            Text(tokensValue)
+                .font(.system(size: 38, weight: .semibold).monospacedDigit())
+                .foregroundStyle(color)
+                .shadow(color: color.opacity(glowOpacity), radius: 6)
+                .shadow(color: color.opacity(glowOpacity * 0.5), radius: 14)
+            Text(tokensUnit)
+                .font(.system(size: 15, weight: .medium))
+                .foregroundStyle(.white.opacity(0.4))
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var sparkHero: some View {
+        ZStack(alignment: .bottomTrailing) {
+            CostSparkline(series: window.series, color: color)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            // Small dollar overlay anchored to the bottom-right so the
+            // sparkline gets the full cell but the user still has the
+            // numeric anchor they can read at a glance.
+            HStack(alignment: .firstTextBaseline, spacing: 1) {
+                Text("$")
+                    .font(.system(size: 9, weight: .medium))
+                    .foregroundStyle(.white.opacity(0.5))
+                Text(formattedDollarsCompact)
+                    .font(.system(size: 12, weight: .semibold).monospacedDigit())
+                    .foregroundStyle(color)
+                    .shadow(color: color.opacity(0.7), radius: 3)
+            }
+        }
+    }
+
+    // MARK: - Derived values
+
+    private var multiplier: Double {
+        let denom = isMonth ? Self.baselineMonthlyUSD : (Self.baselineMonthlyUSD / 30.0)
+        guard denom > 0 else { return 0 }
+        return window.dollars / denom
+    }
+
+    private var formattedMultiplier: String {
+        let m = multiplier
+        if m < 0.1 { return "0" }
+        if m < 10 { return String(format: "%.1f", m) }
+        return String(format: "%.0f", m)
+    }
+
+    private var tokensValue: String {
+        let n = window.tokens
+        let v = Double(n)
+        if n < 1_000 { return "\(n)" }
+        if n < 10_000 { return String(format: "%.1f", v / 1_000) }
+        if n < 1_000_000 { return String(format: "%.0f", v / 1_000) }
+        if n < 1_000_000_000 { return String(format: "%.1f", v / 1_000_000) }
+        return String(format: "%.1f", v / 1_000_000_000)
+    }
+
+    private var tokensUnit: String {
+        let n = window.tokens
+        if n < 1_000 { return "tok" }
+        if n < 1_000_000 { return "k" }
+        if n < 1_000_000_000 { return "M" }
+        return "B"
+    }
+
+    private var formattedDollarsCompact: String {
+        let v = window.dollars
+        if v < 100 { return String(format: "%.2f", v) }
+        return String(format: "%.0f", v)
+    }
+
+    /// Glow intensity scales softly with spend so a quiet day stays calm
+    /// and a heavy month looks luminous. Logarithmic so the curve doesn't
+    /// blow out at the high end. Caps around 0.85 so even at peak the
+    /// glow stays a halo, not a smear.
     private var glowOpacity: Double {
         let s = window.dollars
         if s <= 0 { return 0 }
@@ -98,37 +190,5 @@ struct CostTile: View {
         return window.resetCaption
             .replacingOccurrences(of: "resets at ", with: "↻ ")
             .replacingOccurrences(of: "resets in ", with: "↻ ")
-    }
-
-    /// "X.Xx · Y.YM tok" combined caption. The ROI half drops cleanly when
-    /// no subscription is known (Free plan, missing plan tag), leaving
-    /// just the token brag so the cell is never empty.
-    private var captionText: String {
-        let tokens = formatTokens(window.tokens)
-        guard let roi = roiText else { return tokens }
-        return "\(roi) · \(tokens)"
-    }
-
-    /// "16.6x" when the multiplier is meaningful. Today divides by the
-    /// daily portion of the subscription (sub/30) so a heavy day shows as
-    /// 10x+; month divides by the full subscription so power users see
-    /// 5-10x. Both feel like "I extracted way more value than I paid."
-    private var roiText: String? {
-        guard let sub = subscriptionMonthlyUSD, sub > 0 else { return nil }
-        let denom = isMonth ? sub : (sub / 30.0)
-        guard denom > 0 else { return nil }
-        let mult = window.dollars / denom
-        if mult < 0.1 { return "<0.1x" }
-        if mult < 10 { return String(format: "%.1fx", mult) }
-        return String(format: "%.0fx", mult)
-    }
-
-    private func formatTokens(_ n: Int) -> String {
-        let v = Double(n)
-        if n < 1_000 { return "\(n) tok" }
-        if n < 10_000 { return String(format: "%.1fk tok", v / 1_000) }
-        if n < 1_000_000 { return String(format: "%.0fk tok", v / 1_000) }
-        if n < 1_000_000_000 { return String(format: "%.1fM tok", v / 1_000_000) }
-        return String(format: "%.1fB tok", v / 1_000_000_000)
     }
 }

--- a/Sources/Views/CostBlock.swift
+++ b/Sources/Views/CostBlock.swift
@@ -45,11 +45,11 @@ struct CostTile: View {
         VStack(alignment: .leading, spacing: 6) {
             HStack(alignment: .firstTextBaseline) {
                 Text(window.label)
-                    .font(.system(size: 11, weight: .medium))
+                    .font(Typography.label)
                     .foregroundStyle(.white.opacity(0.55))
                 Spacer()
                 Text(resetGlyph)
-                    .font(.system(size: 10).monospaced())
+                    .font(Typography.caption)
                     .foregroundStyle(.white.opacity(0.4))
             }
 
@@ -77,7 +77,7 @@ struct CostTile: View {
     private var dollarHero: some View {
         HStack(alignment: .firstTextBaseline, spacing: 1) {
             Text("$")
-                .font(.system(size: 15, weight: .medium))
+                .font(Typography.unit)
                 .foregroundStyle(.white.opacity(0.4))
             CountUpDollar(target: window.dollars, color: color, glowOpacity: glowOpacity)
         }
@@ -133,7 +133,7 @@ struct CostTile: View {
 
         return VStack(spacing: 3) {
             Text(formatBarDollars(amount))
-                .font(.system(size: 11, weight: .semibold).monospacedDigit())
+                .font(Typography.bodyNumber)
                 .foregroundStyle(isYou ? color : .white.opacity(0.78))
                 .lineLimit(1)
             ZStack(alignment: .bottom) {
@@ -148,7 +148,7 @@ struct CostTile: View {
                     .animation(.strongEaseOut, value: amount)
             }
             Text(label)
-                .font(.system(size: 9, weight: .medium))
+                .font(Typography.micro)
                 .foregroundStyle(.white.opacity(0.5))
                 .lineLimit(1)
         }
@@ -157,12 +157,12 @@ struct CostTile: View {
     private var tokensHero: some View {
         HStack(alignment: .firstTextBaseline, spacing: 3) {
             Text(tokensValue)
-                .font(.system(size: 38, weight: .semibold).monospacedDigit())
+                .font(Typography.bigNumber)
                 .foregroundStyle(color)
                 .shadow(color: color.opacity(glowOpacity), radius: 6)
                 .shadow(color: color.opacity(glowOpacity * 0.5), radius: 14)
             Text(tokensUnit)
-                .font(.system(size: 15, weight: .medium))
+                .font(Typography.unit)
                 .foregroundStyle(.white.opacity(0.4))
         }
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -177,10 +177,10 @@ struct CostTile: View {
             // numeric anchor they can read at a glance.
             HStack(alignment: .firstTextBaseline, spacing: 1) {
                 Text("$")
-                    .font(.system(size: 9, weight: .medium))
+                    .font(Typography.micro)
                     .foregroundStyle(.white.opacity(0.5))
                 Text(formattedDollarsCompact)
-                    .font(.system(size: 12, weight: .semibold).monospacedDigit())
+                    .font(Typography.bodyNumber)
                     .foregroundStyle(color)
                     .shadow(color: color.opacity(0.7), radius: 3)
             }

--- a/Sources/Views/CostBlock.swift
+++ b/Sources/Views/CostBlock.swift
@@ -1,0 +1,80 @@
+import SwiftUI
+
+/// Two cost cells per provider — today + month-to-date — laid out horizontally
+/// to mirror `ChartsBlock`'s 5h+week pair on the usage screen.
+struct CostBlock: View {
+    let color: Color
+    let cost: ProviderCost
+
+    var body: some View {
+        HStack(spacing: 18) {
+            CostTile(color: color, window: cost.today)
+            CostTile(color: color, window: cost.month)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        .padding(.horizontal, 12)
+    }
+}
+
+/// One cost cell. Mirrors `SteppedChart`'s structure (head + 30-segment bar +
+/// foot) with the same type scale, opacity ladder, and stagger timing — only
+/// the head shows a dollar amount instead of a percentage and the bar fills
+/// against `window.cap` instead of 100.
+struct CostTile: View {
+    let color: Color
+    let window: CostWindow
+
+    /// Locked to match `ChartTile.tileHeight` so swipe transitions don't
+    /// reflow the panel.
+    private static let tileHeight: CGFloat = 96
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            CostHead(window: window)
+            HStack(spacing: 2) {
+                let segments = 30
+                let filled = window.fillFraction * Double(segments)
+                ForEach(0..<segments, id: \.self) { i in
+                    RoundedRectangle(cornerRadius: 1.5)
+                        .fill(Double(i) < floor(filled) ? color : .white.opacity(0.10))
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 16)
+                        .animation(.strongEaseOut.delay(Double(i) * 0.007), value: window.dollars)
+                }
+            }
+            ChartFoot(caption: window.error ?? window.resetCaption)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .frame(height: Self.tileHeight)
+    }
+}
+
+/// Cost-screen analog of `ChartHead`. Identical type scale, opacity tiers,
+/// and animations — the only differences are the `$` prefix (instead of `%`
+/// suffix) and the two-decimal dollar formatting. Urgency color drives off
+/// `fillFraction * 100` so the digits warn red/amber when spend approaches
+/// or exceeds the visual cap.
+private struct CostHead: View {
+    let window: CostWindow
+
+    var body: some View {
+        let urgency = window.fillFraction * 100
+        HStack(alignment: .firstTextBaseline) {
+            Text(window.label)
+                .font(.system(size: 11, weight: .medium))
+                .foregroundStyle(.white.opacity(0.55))
+                .textCase(.lowercase)
+            Spacer()
+            HStack(alignment: .firstTextBaseline, spacing: 1) {
+                Text("$")
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(.white.opacity(0.5))
+                Text(String(format: "%.2f", window.dollars))
+                    .font(.system(size: 18, weight: .semibold).monospacedDigit())
+                    .foregroundStyle(UrgencyColor.value(urgency))
+                    .numericTransition(value: window.dollars)
+                    .animation(.strongEaseOut, value: window.dollars)
+            }
+        }
+    }
+}

--- a/Sources/Views/CostBlock.swift
+++ b/Sources/Views/CostBlock.swift
@@ -6,11 +6,17 @@ struct CostBlock: View {
     let color: Color
     let cost: ProviderCost
     let loading: Bool
+    /// Identifies which provider this column is for so the VALUE multiplier
+    /// can pick the right per-plan baseline (Claude Pro $20 vs Max $200,
+    /// Codex Plus $20 vs Pro $200) and the caption can name the plan.
+    let provider: TokenEvent.Provider
 
     var body: some View {
         HStack(spacing: 18) {
-            CostTile(color: color, window: cost.today, loading: loading, isMonth: false)
-            CostTile(color: color, window: cost.month, loading: loading, isMonth: true)
+            CostTile(color: color, window: cost.today, loading: loading,
+                     isMonth: false, provider: provider)
+            CostTile(color: color, window: cost.month, loading: loading,
+                     isMonth: true, provider: provider)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
         .padding(.horizontal, 12)
@@ -26,15 +32,10 @@ struct CostTile: View {
     let window: CostWindow
     let loading: Bool
     let isMonth: Bool
+    let provider: TokenEvent.Provider
 
     @ObservedObject private var stylePref = CostStylePref.shared
-
-    /// Max-tier subscription value — the implicit baseline the value
-    /// multiplier compares against. $200/mo is the high end of either
-    /// provider's plan ladder (Claude Max-20, Codex Pro), so the multiplier
-    /// reads as "this many times the most expensive plan I could be on"
-    /// rather than the inflated 100×+ figures a $20 baseline produced.
-    private static let baselineMonthlyUSD: Double = 200
+    @ObservedObject private var usageStore = UsageStore.shared
 
     /// Locked to match `ChartTile.tileHeight` so swipe transitions don't
     /// reflow the panel.
@@ -83,21 +84,74 @@ struct CostTile: View {
         .frame(maxWidth: .infinity, alignment: .leading)
     }
 
+    /// Side-by-side bar chart: left bar is the plan price (white, subtle),
+    /// right bar is what the user actually spent (brand-colored, glowing).
+    /// Heights are normalized to whichever bar is larger so the contrast
+    /// reads at a glance — heavy use towers over the plan baseline, light
+    /// use sits below it. Labels under each bar name what's being compared
+    /// (the actual plan tier from UsageStore vs "you") so the user always
+    /// knows the reference point.
     private var multiplierHero: some View {
-        HStack(alignment: .firstTextBaseline, spacing: 2) {
-            Text(formattedMultiplier)
-                .font(.system(size: 38, weight: .semibold).monospacedDigit())
-                .foregroundStyle(color)
-                .shadow(color: color.opacity(glowOpacity), radius: 6)
-                .shadow(color: color.opacity(glowOpacity * 0.5), radius: 14)
-                .numericTransition(value: multiplier)
-                .animation(.strongEaseOut, value: multiplier)
-            Text("×")
-                .font(.system(size: 18, weight: .medium))
-                .foregroundStyle(color.opacity(0.85))
-                .shadow(color: color.opacity(glowOpacity * 0.6), radius: 4)
+        let plan = planAmount
+        let spend = window.dollars
+        let maxAmount = max(plan, spend, 0.0001)
+        let maxBarHeight: CGFloat = 40
+
+        return HStack(alignment: .bottom, spacing: 14) {
+            Spacer(minLength: 0)
+            barColumn(
+                amount: plan,
+                label: planLabel ?? "Plan",
+                fill: .white.opacity(0.20),
+                isYou: false,
+                maxAmount: maxAmount,
+                maxBarHeight: maxBarHeight
+            )
+            barColumn(
+                amount: spend,
+                label: "you",
+                fill: color,
+                isYou: true,
+                maxAmount: maxAmount,
+                maxBarHeight: maxBarHeight
+            )
+            Spacer(minLength: 0)
         }
-        .frame(maxWidth: .infinity, alignment: .leading)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private func barColumn(
+        amount: Double,
+        label: String,
+        fill: Color,
+        isYou: Bool,
+        maxAmount: Double,
+        maxBarHeight: CGFloat
+    ) -> some View {
+        let normalized = max(0, amount / maxAmount)
+        let height = max(3, CGFloat(normalized) * maxBarHeight)
+
+        return VStack(spacing: 3) {
+            Text(formatBarDollars(amount))
+                .font(.system(size: 11, weight: .semibold).monospacedDigit())
+                .foregroundStyle(isYou ? color : .white.opacity(0.78))
+                .lineLimit(1)
+            ZStack(alignment: .bottom) {
+                Color.clear.frame(width: 24, height: maxBarHeight)
+                RoundedRectangle(cornerRadius: 3)
+                    .fill(fill)
+                    .frame(width: 24, height: height)
+                    .shadow(
+                        color: isYou ? color.opacity(glowOpacity) : .clear,
+                        radius: 5
+                    )
+                    .animation(.strongEaseOut, value: amount)
+            }
+            Text(label)
+                .font(.system(size: 9, weight: .medium))
+                .foregroundStyle(.white.opacity(0.5))
+                .lineLimit(1)
+        }
     }
 
     private var tokensHero: some View {
@@ -135,17 +189,61 @@ struct CostTile: View {
 
     // MARK: - Derived values
 
-    private var multiplier: Double {
-        let denom = isMonth ? Self.baselineMonthlyUSD : (Self.baselineMonthlyUSD / 30.0)
-        guard denom > 0 else { return 0 }
-        return window.dollars / denom
+    /// Monthly subscription cost in USD for this provider's currently
+    /// detected plan tier. Auto-mapped from Anthropic's "subscriptionType"
+    /// or OpenAI's "plan_type" so each provider's bar reflects its actual
+    /// plan: Claude Pro $20 / Max $200, Codex Plus $20 / Pro $200.
+    private var subscriptionUSD: Double? {
+        let plan: String? = {
+            switch provider {
+            case .claude: return usageStore.claude.plan?.lowercased()
+            case .codex:  return usageStore.codex.plan?.lowercased()
+            }
+        }()
+        guard let plan else { return nil }
+        switch (provider, plan) {
+        case (.claude, "pro"): return 20
+        case (.claude, "max"): return 200
+        case (.codex, "plus"): return 20
+        case (.codex, "pro"):  return 200
+        default: return nil
+        }
     }
 
-    private var formattedMultiplier: String {
-        let m = multiplier
-        if m < 0.1 { return "0" }
-        if m < 10 { return String(format: "%.1f", m) }
-        return String(format: "%.0f", m)
+    /// Display name of the active plan (Pro / Max / Plus). Used as the
+    /// label under the plan bar so the user always knows what the
+    /// comparison is anchored to.
+    private var planLabel: String? {
+        let plan: String? = {
+            switch provider {
+            case .claude: return usageStore.claude.plan?.lowercased()
+            case .codex:  return usageStore.codex.plan?.lowercased()
+            }
+        }()
+        guard let plan else { return nil }
+        switch (provider, plan) {
+        case (.claude, "pro"): return "Pro"
+        case (.claude, "max"): return "Max"
+        case (.codex, "plus"): return "Plus"
+        case (.codex, "pro"):  return "Pro"
+        default: return nil
+        }
+    }
+
+    /// Plan reference for the bar chart — always the FULL monthly plan
+    /// price, regardless of which cell. Subscriptions are monthly, so
+    /// comparing today's spend against a daily portion would muddy the
+    /// reference; comparing today's spend against the full month plan
+    /// shows "you've already spent X% of a month's plan in one day"
+    /// which is the more striking framing.
+    private var planAmount: Double {
+        subscriptionUSD ?? 0
+    }
+
+    private func formatBarDollars(_ v: Double) -> String {
+        if v < 10 { return String(format: "$%.2f", v) }
+        if v < 1000 { return String(format: "$%.0f", v) }
+        return String(format: "$%.0f", v)
     }
 
     private var tokensValue: String {

--- a/Sources/Views/CostBlock.swift
+++ b/Sources/Views/CostBlock.swift
@@ -6,11 +6,21 @@ struct CostBlock: View {
     let color: Color
     let cost: ProviderCost
     let loading: Bool
+    /// Monthly cost of the user's subscription in USD, used to compute the
+    /// ROI multiplier on each cell. Nil when the plan is unknown or free —
+    /// the cell then shows just the token brag without the "X.Xx" prefix.
+    let subscriptionMonthlyUSD: Double?
 
     var body: some View {
         HStack(spacing: 18) {
-            CostTile(color: color, window: cost.today, loading: loading)
-            CostTile(color: color, window: cost.month, loading: loading)
+            CostTile(
+                color: color, window: cost.today, loading: loading,
+                subscriptionMonthlyUSD: subscriptionMonthlyUSD, isMonth: false
+            )
+            CostTile(
+                color: color, window: cost.month, loading: loading,
+                subscriptionMonthlyUSD: subscriptionMonthlyUSD, isMonth: true
+            )
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
         .padding(.horizontal, 12)
@@ -19,14 +29,17 @@ struct CostBlock: View {
 
 /// One cost cell. The dollar number is the hero — 38pt brand-colored
 /// monospace digits with a soft glow whose intensity grows with the
-/// amount, so heavier spend feels rewarding rather than punitive. No bar,
-/// no cap, no fill metaphor. Mirrors `NumericChart`'s layout (label +
-/// reset glyph row on top, big value in the middle) for design-system
-/// continuity with the usage screen.
+/// amount, plus a count-up reveal on first appearance and a smooth
+/// interpolation on refresh. Below it: a single small caption with the
+/// ROI multiplier vs the user's subscription and the period's raw token
+/// count, so heavy use reads as "look how much value I extracted" rather
+/// than "look how much I burned."
 struct CostTile: View {
     let color: Color
     let window: CostWindow
     let loading: Bool
+    let subscriptionMonthlyUSD: Double?
+    let isMonth: Bool
 
     /// Locked to match `ChartTile.tileHeight` so swipe transitions don't
     /// reflow the panel.
@@ -51,15 +64,15 @@ struct CostTile: View {
                 Text("$")
                     .font(.system(size: 15, weight: .medium))
                     .foregroundStyle(.white.opacity(0.4))
-                Text(formatted)
-                    .font(.system(size: 38, weight: .semibold).monospacedDigit())
-                    .foregroundStyle(color)
-                    .shadow(color: color.opacity(glowOpacity), radius: 6)
-                    .shadow(color: color.opacity(glowOpacity * 0.5), radius: 14)
-                    .numericTransition(value: window.dollars)
-                    .animation(.strongEaseOut, value: window.dollars)
+                CountUpDollar(target: window.dollars, color: color, glowOpacity: glowOpacity)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
+
+            Text(captionText)
+                .font(.system(size: 10).monospaced())
+                .foregroundStyle(.white.opacity(0.55))
+                .lineLimit(1)
+                .truncationMode(.tail)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .frame(height: Self.tileHeight)
@@ -87,12 +100,35 @@ struct CostTile: View {
             .replacingOccurrences(of: "resets in ", with: "↻ ")
     }
 
-    /// Drop cents above $100 so 7-digit month totals (e.g. $1432.89) don't
-    /// overflow the 38pt slot. Codex stays sub-$100 typically and keeps
-    /// cents; Claude month rolls over to the no-cents format naturally.
-    private var formatted: String {
-        let v = window.dollars
-        if v < 100 { return String(format: "%.2f", v) }
-        return String(format: "%.0f", v)
+    /// "X.Xx · Y.YM tok" combined caption. The ROI half drops cleanly when
+    /// no subscription is known (Free plan, missing plan tag), leaving
+    /// just the token brag so the cell is never empty.
+    private var captionText: String {
+        let tokens = formatTokens(window.tokens)
+        guard let roi = roiText else { return tokens }
+        return "\(roi) · \(tokens)"
+    }
+
+    /// "16.6x" when the multiplier is meaningful. Today divides by the
+    /// daily portion of the subscription (sub/30) so a heavy day shows as
+    /// 10x+; month divides by the full subscription so power users see
+    /// 5-10x. Both feel like "I extracted way more value than I paid."
+    private var roiText: String? {
+        guard let sub = subscriptionMonthlyUSD, sub > 0 else { return nil }
+        let denom = isMonth ? sub : (sub / 30.0)
+        guard denom > 0 else { return nil }
+        let mult = window.dollars / denom
+        if mult < 0.1 { return "<0.1x" }
+        if mult < 10 { return String(format: "%.1fx", mult) }
+        return String(format: "%.0fx", mult)
+    }
+
+    private func formatTokens(_ n: Int) -> String {
+        let v = Double(n)
+        if n < 1_000 { return "\(n) tok" }
+        if n < 10_000 { return String(format: "%.1fk tok", v / 1_000) }
+        if n < 1_000_000 { return String(format: "%.0fk tok", v / 1_000) }
+        if n < 1_000_000_000 { return String(format: "%.1fM tok", v / 1_000_000) }
+        return String(format: "%.1fB tok", v / 1_000_000_000)
     }
 }

--- a/Sources/Views/CostBlock.swift
+++ b/Sources/Views/CostBlock.swift
@@ -5,76 +5,94 @@ import SwiftUI
 struct CostBlock: View {
     let color: Color
     let cost: ProviderCost
+    let loading: Bool
 
     var body: some View {
         HStack(spacing: 18) {
-            CostTile(color: color, window: cost.today)
-            CostTile(color: color, window: cost.month)
+            CostTile(color: color, window: cost.today, loading: loading)
+            CostTile(color: color, window: cost.month, loading: loading)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
         .padding(.horizontal, 12)
     }
 }
 
-/// One cost cell. Mirrors `SteppedChart`'s structure (head + 30-segment bar +
-/// foot) with the same type scale, opacity ladder, and stagger timing — only
-/// the head shows a dollar amount instead of a percentage and the bar fills
-/// against `window.cap` instead of 100.
+/// One cost cell. The dollar number is the hero — 38pt brand-colored
+/// monospace digits with a soft glow whose intensity grows with the
+/// amount, so heavier spend feels rewarding rather than punitive. No bar,
+/// no cap, no fill metaphor. Mirrors `NumericChart`'s layout (label +
+/// reset glyph row on top, big value in the middle) for design-system
+/// continuity with the usage screen.
 struct CostTile: View {
     let color: Color
     let window: CostWindow
+    let loading: Bool
 
     /// Locked to match `ChartTile.tileHeight` so swipe transitions don't
     /// reflow the panel.
     private static let tileHeight: CGFloat = 96
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            CostHead(window: window)
-            HStack(spacing: 2) {
-                let segments = 30
-                let filled = window.fillFraction * Double(segments)
-                ForEach(0..<segments, id: \.self) { i in
-                    RoundedRectangle(cornerRadius: 1.5)
-                        .fill(Double(i) < floor(filled) ? color : .white.opacity(0.10))
-                        .frame(maxWidth: .infinity)
-                        .frame(height: 16)
-                        .animation(.strongEaseOut.delay(Double(i) * 0.007), value: window.dollars)
-                }
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(alignment: .firstTextBaseline) {
+                Text(window.label)
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(.white.opacity(0.55))
+                    .textCase(.lowercase)
+                Spacer()
+                Text(resetGlyph)
+                    .font(.system(size: 10).monospaced())
+                    .foregroundStyle(.white.opacity(0.4))
             }
-            ChartFoot(caption: window.error ?? window.resetCaption)
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-        .frame(height: Self.tileHeight)
-    }
-}
 
-/// Cost-screen analog of `ChartHead`. Identical type scale, opacity tiers,
-/// and animations — the only differences are the `$` prefix (instead of `%`
-/// suffix) and the two-decimal dollar formatting. Urgency color drives off
-/// `fillFraction * 100` so the digits warn red/amber when spend approaches
-/// or exceeds the visual cap.
-private struct CostHead: View {
-    let window: CostWindow
+            Spacer(minLength: 0)
 
-    var body: some View {
-        let urgency = window.fillFraction * 100
-        HStack(alignment: .firstTextBaseline) {
-            Text(window.label)
-                .font(.system(size: 11, weight: .medium))
-                .foregroundStyle(.white.opacity(0.55))
-                .textCase(.lowercase)
-            Spacer()
             HStack(alignment: .firstTextBaseline, spacing: 1) {
                 Text("$")
-                    .font(.system(size: 11, weight: .medium))
-                    .foregroundStyle(.white.opacity(0.5))
-                Text(String(format: "%.2f", window.dollars))
-                    .font(.system(size: 18, weight: .semibold).monospacedDigit())
-                    .foregroundStyle(UrgencyColor.value(urgency))
+                    .font(.system(size: 15, weight: .medium))
+                    .foregroundStyle(.white.opacity(0.4))
+                Text(formatted)
+                    .font(.system(size: 38, weight: .semibold).monospacedDigit())
+                    .foregroundStyle(color)
+                    .shadow(color: color.opacity(glowOpacity), radius: 6)
+                    .shadow(color: color.opacity(glowOpacity * 0.5), radius: 14)
                     .numericTransition(value: window.dollars)
                     .animation(.strongEaseOut, value: window.dollars)
             }
+            .frame(maxWidth: .infinity, alignment: .leading)
         }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .frame(height: Self.tileHeight)
+        .opacity(loading ? 0.7 : 1.0)
+        .animation(.easeOut(duration: 0.18), value: loading)
+    }
+
+    /// Glow intensity scales softly with spend so a $5 day looks calm and a
+    /// $1500 month looks luminous. Logarithmic so the curve doesn't blow
+    /// out at the high end. Caps around 0.85 so even at peak the glow
+    /// stays a halo, not a smear.
+    private var glowOpacity: Double {
+        let s = window.dollars
+        if s <= 0 { return 0 }
+        let scale = log(s + 1) / log(2000)
+        return min(0.85, 0.20 + scale * 0.65)
+    }
+
+    /// Compact reset hint that mirrors `NumericChart`'s "↻ 3h" treatment so
+    /// the cost screen doesn't introduce a new caption shape.
+    private var resetGlyph: String {
+        if let err = window.error { return err }
+        return window.resetCaption
+            .replacingOccurrences(of: "resets at ", with: "↻ ")
+            .replacingOccurrences(of: "resets in ", with: "↻ ")
+    }
+
+    /// Drop cents above $100 so 7-digit month totals (e.g. $1432.89) don't
+    /// overflow the 38pt slot. Codex stays sub-$100 typically and keeps
+    /// cents; Claude month rolls over to the no-cents format naturally.
+    private var formatted: String {
+        let v = window.dollars
+        if v < 100 { return String(format: "%.2f", v) }
+        return String(format: "%.0f", v)
     }
 }

--- a/Sources/Views/CostBlock.swift
+++ b/Sources/Views/CostBlock.swift
@@ -29,12 +29,12 @@ struct CostTile: View {
 
     @ObservedObject private var stylePref = CostStylePref.shared
 
-    /// "Pro/Plus" subscription value — the implicit baseline the value
-    /// multiplier compares against. Hardcoded because asking the user to
-    /// configure their plan in Settings adds friction; $20/mo is the
-    /// most common tier across both providers and serves as a relatable
-    /// "subscription dollar" yardstick.
-    private static let baselineMonthlyUSD: Double = 20
+    /// Max-tier subscription value — the implicit baseline the value
+    /// multiplier compares against. $200/mo is the high end of either
+    /// provider's plan ladder (Claude Max-20, Codex Pro), so the multiplier
+    /// reads as "this many times the most expensive plan I could be on"
+    /// rather than the inflated 100×+ figures a $20 baseline produced.
+    private static let baselineMonthlyUSD: Double = 200
 
     /// Locked to match `ChartTile.tileHeight` so swipe transitions don't
     /// reflow the panel.

--- a/Sources/Views/CostBlock.swift
+++ b/Sources/Views/CostBlock.swift
@@ -51,6 +51,7 @@ struct CostTile: View {
                 Text(resetGlyph)
                     .font(Typography.caption)
                     .foregroundStyle(.white.opacity(window.unknownModels.isEmpty ? 0.4 : 0.5))
+                    .accessibilityLabel(resetGlyphSpoken)
             }
 
             Spacer(minLength: 0)
@@ -70,6 +71,24 @@ struct CostTile: View {
         .frame(height: Self.tileHeight)
         .opacity(loading ? 0.7 : 1.0)
         .animation(.easeOut(duration: 0.18), value: loading)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(window.label)
+        .accessibilityValue(spokenValue)
+    }
+
+    private var spokenValue: String {
+        switch stylePref.style {
+        case .dollar:
+            return "$\(formattedDollarsCompact)"
+        case .multi:
+            let plan = formatBarDollars(planAmount)
+            let you = formatBarDollars(window.dollars)
+            return "\(planLabel ?? "Plan") \(plan) versus you \(you)"
+        case .tokens:
+            return "\(tokensValue)\(tokensUnit) tokens"
+        case .spark:
+            return "$\(formattedDollarsCompact) cumulative"
+        }
     }
 
     // MARK: - Heroes
@@ -295,5 +314,14 @@ struct CostTile: View {
             return "⚠ \(window.unknownModels.count) unpriced"
         }
         return "↻ " + (isMonth ? CostBucketing.monthResetIn() : CostBucketing.todayResetIn())
+    }
+
+    private var resetGlyphSpoken: String {
+        if let err = window.error { return err }
+        if !window.unknownModels.isEmpty {
+            return "Warning: \(window.unknownModels.count) unpriced models — totals may be incomplete."
+        }
+        let countdown = isMonth ? CostBucketing.monthResetIn() : CostBucketing.todayResetIn()
+        return "Resets in \(countdown)"
     }
 }

--- a/Sources/Views/CostBlock.swift
+++ b/Sources/Views/CostBlock.swift
@@ -109,7 +109,7 @@ struct CostTile: View {
             )
             barColumn(
                 amount: spend,
-                label: "you",
+                label: "You",
                 fill: color,
                 isYou: true,
                 maxAmount: maxAmount,
@@ -281,12 +281,13 @@ struct CostTile: View {
         return min(0.85, 0.20 + scale * 0.65)
     }
 
-    /// Compact reset hint that mirrors `NumericChart`'s "↻ 3h" treatment so
-    /// the cost screen doesn't introduce a new caption shape.
+    /// Compact "↻ 5h" / "↻ 12d" countdown — computed at render time from
+    /// the current clock so the panel always shows accurate time-remaining
+    /// regardless of how stale the last refresh is. Mirrors `NumericChart`'s
+    /// "↻ 3h" treatment so the cost screen doesn't introduce a new caption
+    /// shape.
     private var resetGlyph: String {
         if let err = window.error { return err }
-        return window.resetCaption
-            .replacingOccurrences(of: "resets at ", with: "↻ ")
-            .replacingOccurrences(of: "resets in ", with: "↻ ")
+        return "↻ " + (isMonth ? CostBucketing.monthResetIn() : CostBucketing.todayResetIn())
     }
 }

--- a/Sources/Views/CostSparkline.swift
+++ b/Sources/Views/CostSparkline.swift
@@ -1,0 +1,67 @@
+import SwiftUI
+
+/// Cumulative-spend sparkline. The series is monotonically non-decreasing
+/// so the line always ascends — feels rewarding rather than volatile.
+/// Brand-color stroke with a glow underneath, plus a soft gradient fill
+/// from the line down to the baseline so the area under the curve feels
+/// substantial.
+struct CostSparkline: View {
+    let series: [Double]
+    let color: Color
+
+    var body: some View {
+        GeometryReader { geo in
+            let maxV = series.max() ?? 0
+            // Floor the denominator so a flat / single-point series doesn't
+            // divide by zero and so very small values still draw something.
+            let scale = max(maxV, 0.0001)
+            let n = series.count
+
+            if n < 2 {
+                // One point or fewer — render a tiny dot anchored at the
+                // bottom-left so the cell isn't visually empty.
+                Circle()
+                    .fill(color)
+                    .frame(width: 3, height: 3)
+                    .position(x: 1.5, y: geo.size.height - 1.5)
+                    .shadow(color: color.opacity(0.6), radius: 3)
+            } else {
+                let stepX = geo.size.width / CGFloat(n - 1)
+
+                ZStack {
+                    // Filled area under the curve. Gradient drops to clear
+                    // at the bottom so the fill reads as "weight" without
+                    // competing with the stroke.
+                    Path { p in
+                        p.move(to: CGPoint(x: 0, y: geo.size.height))
+                        for (i, v) in series.enumerated() {
+                            let x = CGFloat(i) * stepX
+                            let y = geo.size.height * (1 - CGFloat(v / scale))
+                            p.addLine(to: CGPoint(x: x, y: y))
+                        }
+                        p.addLine(to: CGPoint(x: geo.size.width, y: geo.size.height))
+                        p.closeSubpath()
+                    }
+                    .fill(LinearGradient(
+                        colors: [color.opacity(0.45), color.opacity(0.0)],
+                        startPoint: .top, endPoint: .bottom
+                    ))
+
+                    // Stroke line on top, with a soft glow so the line
+                    // glows against the dark panel.
+                    Path { p in
+                        let firstY = geo.size.height * (1 - CGFloat(series[0] / scale))
+                        p.move(to: CGPoint(x: 0, y: firstY))
+                        for (i, v) in series.enumerated().dropFirst() {
+                            let x = CGFloat(i) * stepX
+                            let y = geo.size.height * (1 - CGFloat(v / scale))
+                            p.addLine(to: CGPoint(x: x, y: y))
+                        }
+                    }
+                    .stroke(color, style: StrokeStyle(lineWidth: 1.5, lineCap: .round, lineJoin: .round))
+                    .shadow(color: color.opacity(0.7), radius: 3)
+                }
+            }
+        }
+    }
+}

--- a/Sources/Views/CostView.swift
+++ b/Sources/Views/CostView.swift
@@ -13,7 +13,8 @@ struct CostView: View {
             CostBlock(
                 color: visibility.claudeVisible ? IslandColor.claude : .white.opacity(0.32),
                 cost: visibility.claudeVisible ? store.claude : .dummy,
-                loading: store.claudeLoading
+                loading: store.claudeLoading,
+                provider: .claude
             )
             .opacity(visibility.claudeVisible ? 1 : 0.55)
             Rectangle()
@@ -26,7 +27,8 @@ struct CostView: View {
             CostBlock(
                 color: visibility.codexVisible ? IslandColor.codex : .white.opacity(0.32),
                 cost: visibility.codexVisible ? store.codex : .dummy,
-                loading: store.codexLoading
+                loading: store.codexLoading,
+                provider: .codex
             )
             .opacity(visibility.codexVisible ? 1 : 0.55)
         }

--- a/Sources/Views/CostView.swift
+++ b/Sources/Views/CostView.swift
@@ -6,7 +6,6 @@ import SwiftUI
 /// chip + page dots + sync status) lives in `PanelHeader` / `PanelFooter`.
 struct CostView: View {
     @ObservedObject private var store = CostStore.shared
-    @ObservedObject private var usageStore = UsageStore.shared
     @ObservedObject private var visibility = ProviderVisibilityStore.shared
 
     var body: some View {
@@ -14,8 +13,7 @@ struct CostView: View {
             CostBlock(
                 color: visibility.claudeVisible ? IslandColor.claude : .white.opacity(0.32),
                 cost: visibility.claudeVisible ? store.claude : .dummy,
-                loading: store.claudeLoading,
-                subscriptionMonthlyUSD: subscriptionUSD(provider: .claude, plan: usageStore.claude.plan)
+                loading: store.claudeLoading
             )
             .opacity(visibility.claudeVisible ? 1 : 0.55)
             Rectangle()
@@ -28,8 +26,7 @@ struct CostView: View {
             CostBlock(
                 color: visibility.codexVisible ? IslandColor.codex : .white.opacity(0.32),
                 cost: visibility.codexVisible ? store.codex : .dummy,
-                loading: store.codexLoading,
-                subscriptionMonthlyUSD: subscriptionUSD(provider: .codex, plan: usageStore.codex.plan)
+                loading: store.codexLoading
             )
             .opacity(visibility.codexVisible ? 1 : 0.55)
         }
@@ -37,20 +34,5 @@ struct CostView: View {
         .padding(.horizontal, 22)
         .padding(.top, 12)
         .padding(.bottom, 6)
-    }
-
-    /// Map the provider-reported plan tag to its monthly USD price so the
-    /// cost cells can show "X.Xx your sub". Anthropic's `subscriptionType`
-    /// and OpenAI's `plan_type` use different vocabularies and the same
-    /// "pro" tag means $20/mo on Claude but $200/mo on Codex.
-    private func subscriptionUSD(provider: TokenEvent.Provider, plan: String?) -> Double? {
-        guard let plan = plan?.lowercased() else { return nil }
-        switch (provider, plan) {
-        case (.claude, "pro"):  return 20
-        case (.claude, "max"):  return 200
-        case (.codex, "plus"):  return 20
-        case (.codex, "pro"):   return 200
-        default:                return nil   // free tier or unknown — skip ROI
-        }
     }
 }

--- a/Sources/Views/CostView.swift
+++ b/Sources/Views/CostView.swift
@@ -1,27 +1,25 @@
 import SwiftUI
 import AppKit
 
-struct UsageView: View {
+/// Cost screen — second page of the expanded panel. Mirrors `UsageView`'s
+/// chrome (provider titles, hairline divider, footer with style chip + page
+/// dots + sync status) but renders dollar spend instead of subscription %.
+struct CostView: View {
     let notch: NotchInfo
-    @ObservedObject private var store = UsageStore.shared
+    @ObservedObject private var store = CostStore.shared
     @ObservedObject private var pref = StylePref.shared
     @ObservedObject private var visibility = ProviderVisibilityStore.shared
     @ObservedObject private var screenPref = ScreenPref.shared
 
-    private var style: ChartStyle { pref.style }
-
     var body: some View {
         VStack(spacing: 0) {
-            // Top row: provider titles aligned with the system menu bar
-            // (height = 22, the menu-bar item height). The notch-width
-            // spacer in the middle hides inside the physical notch.
             HStack(spacing: 0) {
-                providerTitle(name: "Claude", tag: store.claude.plan?.uppercased(),
+                providerTitle(name: "Claude", tag: planTag(forClaude: true),
                               color: IslandColor.claude, alignment: .leading)
                     .opacity(visibility.claudeVisible ? 1 : 0.30)
                     .saturation(visibility.claudeVisible ? 1 : 0)
                 Color.clear.frame(width: notch.width)
-                providerTitle(name: "Codex", tag: store.codex.plan?.uppercased(),
+                providerTitle(name: "Codex", tag: planTag(forClaude: false),
                               color: IslandColor.codex, alignment: .trailing)
                     .opacity(visibility.codexVisible ? 1 : 0.30)
                     .saturation(visibility.codexVisible ? 1 : 0)
@@ -31,14 +29,10 @@ struct UsageView: View {
             .padding(.top, 4)
             .padding(.bottom, max(0, notch.height - 22 - 4))
 
-            // Charts row: two ChartsBlocks with a 1pt vertical gradient
-            // hairline divider. .clear → 6% white → .clear so the divider
-            // fades at top and bottom.
             HStack(spacing: 0) {
-                ChartsBlock(
+                CostBlock(
                     color: visibility.claudeVisible ? IslandColor.claude : .white.opacity(0.32),
-                    usage: visibility.claudeVisible ? store.claude : .dummy,
-                    style: style, seed: 1
+                    cost: visibility.claudeVisible ? store.claude : .dummy
                 )
                 .opacity(visibility.claudeVisible ? 1 : 0.55)
                 Rectangle()
@@ -48,10 +42,9 @@ struct UsageView: View {
                     ))
                     .frame(width: 1)
                     .padding(.vertical, 8)
-                ChartsBlock(
+                CostBlock(
                     color: visibility.codexVisible ? IslandColor.codex : .white.opacity(0.32),
-                    usage: visibility.codexVisible ? store.codex : .dummy,
-                    style: style, seed: 3
+                    cost: visibility.codexVisible ? store.codex : .dummy
                 )
                 .opacity(visibility.codexVisible ? 1 : 0.55)
             }
@@ -60,9 +53,6 @@ struct UsageView: View {
             .padding(.top, 12)
             .padding(.bottom, 6)
 
-            // Footer: hairline divider + style chip + cmd-click hint
-            // (always visible here; hidden after first cycle in a later
-            // commit) + live-status indicator on the right.
             LinearGradient(
                 colors: [.clear, .white.opacity(0.06), .white.opacity(0.06), .clear],
                 startPoint: .leading, endPoint: .trailing
@@ -71,7 +61,10 @@ struct UsageView: View {
             .padding(.horizontal, 22)
 
             HStack(spacing: 10) {
-                Text(style.label.uppercased())
+                // Mirror the position of UsageView's STEPPED chip with a USD
+                // chip — the cost screen's bars are always stepped, so a
+                // chart-style chip would mislead.
+                Text("USD")
                     .font(.system(size: 9, weight: .bold).monospaced())
                     .tracking(0.8)
                     .foregroundStyle(.white.opacity(0.78))
@@ -85,21 +78,6 @@ struct UsageView: View {
                                     .strokeBorder(.white.opacity(0.10), lineWidth: 0.5)
                             )
                     )
-                    .contentTransition(.opacity)
-                    .animation(.strongEaseOut, value: pref.style)
-
-                if !pref.hasCycledStyle {
-                    HStack(spacing: 5) {
-                        Image(systemName: "command")
-                            .font(.system(size: 10, weight: .semibold))
-                        Text("click to cycle")
-                            .font(.system(size: 11))
-                    }
-                    .foregroundStyle(.white.opacity(0.42))
-                    // Fade + small scale-from-leading on the way out so the
-                    // hint deflates toward the chip rather than just vanishing.
-                    .transition(.opacity.combined(with: .scale(scale: 0.92, anchor: .leading)))
-                }
 
                 Spacer()
 
@@ -128,9 +106,16 @@ struct UsageView: View {
             .padding(.horizontal, 22)
             .padding(.top, 6)
             .padding(.bottom, 10)
-            .animation(.strongEaseOut, value: pref.hasCycledStyle)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    /// Plan tag pulled from the API-side UsageStore — same source as
+    /// UsageView, since the subscription tier is independent of which page
+    /// the user is on.
+    private func planTag(forClaude: Bool) -> String? {
+        let usage = forClaude ? UsageStore.shared.claude : UsageStore.shared.codex
+        return usage.plan?.uppercased()
     }
 
     private func relative(_ d: Date) -> String {
@@ -146,7 +131,6 @@ struct UsageView: View {
         color: Color,
         alignment: HorizontalAlignment
     ) -> some View {
-        // Push past where the overlay logo lands: 9 leading + 20 logo + 8 gap.
         let logoOffset: CGFloat = 9 + 20 + 8
 
         let content = HStack(spacing: 8) {
@@ -184,71 +168,5 @@ struct UsageView: View {
             }
             .frame(maxWidth: .infinity)
         }
-    }
-}
-
-struct ChartsBlock: View {
-    let color: Color
-    let usage: AppUsage
-    let style: ChartStyle
-    let seed: Int
-
-    var body: some View {
-        HStack(spacing: 18) {
-            ChartTile(style: style, color: color, label: "5h",
-                      window: usage.fiveHour, seed: seed)
-            ChartTile(style: style, color: color, label: "week",
-                      window: usage.weekly, seed: seed + 1)
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
-        .padding(.horizontal, 12)
-    }
-}
-
-struct ChartTile: View {
-    let style: ChartStyle
-    let color: Color
-    let label: String
-    let window: WindowUsage
-    let seed: Int
-
-    /// Locked tile height across all 5 styles so the panel size is
-    /// identical regardless of what the user picks.
-    private static let tileHeight: CGFloat = 96
-
-    var body: some View {
-        let value = window.usedPercent * 100   // 0-100
-        let sub = subCaption()
-
-        Group {
-            switch style {
-            case .ring:    RingChart(value: value, color: color, label: label, sub: sub)
-            case .bar:     BarChart(value: value, color: color, label: label, sub: sub)
-            case .stepped: SteppedChart(value: value, color: color, label: label, sub: sub)
-            case .numeric: NumericChart(value: value, color: color, label: label, sub: sub)
-            case .spark:   SparkChart(value: value, color: color, label: label, sub: sub, seed: seed)
-            }
-        }
-        .id(style)
-        // Blur + scale + opacity, all on the same strong ease-out at 220ms.
-        // The blur masks the geometric mismatch between Ring and Bar so the
-        // crossfade reads as one morph instead of two stacked objects.
-        .transition(.chartSwap.animation(.chartSwap))
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-        .frame(height: Self.tileHeight)
-    }
-
-    private func subCaption() -> String {
-        if let err = window.error { return err }
-        guard let r = window.resetAt else { return "" }
-        let delta = max(0, r.timeIntervalSinceNow)
-        return "resets in \(formatDelta(delta))"
-    }
-
-    private func formatDelta(_ s: TimeInterval) -> String {
-        if s < 60 { return "\(Int(s))s" }
-        if s < 3600 { return "\(Int(s/60))m" }
-        if s < 86400 { return "\(Int(s/3600))h" }
-        return "\(Int(s/86400))d"
     }
 }

--- a/Sources/Views/CostView.swift
+++ b/Sources/Views/CostView.swift
@@ -6,6 +6,7 @@ import SwiftUI
 /// chip + page dots + sync status) lives in `PanelHeader` / `PanelFooter`.
 struct CostView: View {
     @ObservedObject private var store = CostStore.shared
+    @ObservedObject private var usageStore = UsageStore.shared
     @ObservedObject private var visibility = ProviderVisibilityStore.shared
 
     var body: some View {
@@ -13,7 +14,8 @@ struct CostView: View {
             CostBlock(
                 color: visibility.claudeVisible ? IslandColor.claude : .white.opacity(0.32),
                 cost: visibility.claudeVisible ? store.claude : .dummy,
-                loading: store.claudeLoading
+                loading: store.claudeLoading,
+                subscriptionMonthlyUSD: subscriptionUSD(provider: .claude, plan: usageStore.claude.plan)
             )
             .opacity(visibility.claudeVisible ? 1 : 0.55)
             Rectangle()
@@ -26,7 +28,8 @@ struct CostView: View {
             CostBlock(
                 color: visibility.codexVisible ? IslandColor.codex : .white.opacity(0.32),
                 cost: visibility.codexVisible ? store.codex : .dummy,
-                loading: store.codexLoading
+                loading: store.codexLoading,
+                subscriptionMonthlyUSD: subscriptionUSD(provider: .codex, plan: usageStore.codex.plan)
             )
             .opacity(visibility.codexVisible ? 1 : 0.55)
         }
@@ -34,5 +37,20 @@ struct CostView: View {
         .padding(.horizontal, 22)
         .padding(.top, 12)
         .padding(.bottom, 6)
+    }
+
+    /// Map the provider-reported plan tag to its monthly USD price so the
+    /// cost cells can show "X.Xx your sub". Anthropic's `subscriptionType`
+    /// and OpenAI's `plan_type` use different vocabularies and the same
+    /// "pro" tag means $20/mo on Claude but $200/mo on Codex.
+    private func subscriptionUSD(provider: TokenEvent.Provider, plan: String?) -> Double? {
+        guard let plan = plan?.lowercased() else { return nil }
+        switch (provider, plan) {
+        case (.claude, "pro"):  return 20
+        case (.claude, "max"):  return 200
+        case (.codex, "plus"):  return 20
+        case (.codex, "pro"):   return 200
+        default:                return nil   // free tier or unknown — skip ROI
+        }
     }
 }

--- a/Sources/Views/CostView.swift
+++ b/Sources/Views/CostView.swift
@@ -1,172 +1,38 @@
 import SwiftUI
-import AppKit
 
-/// Cost screen — second page of the expanded panel. Mirrors `UsageView`'s
-/// chrome (provider titles, hairline divider, footer with style chip + page
-/// dots + sync status) but renders dollar spend instead of subscription %.
+/// Cost data row — two CostBlocks (Claude / Codex) with a hairline vertical
+/// divider. Mirrors `UsageView`'s data-row shape so swipe transitions
+/// between them don't reflow the panel. Chrome (provider titles, footer
+/// chip + page dots + sync status) lives in `PanelHeader` / `PanelFooter`.
 struct CostView: View {
-    let notch: NotchInfo
     @ObservedObject private var store = CostStore.shared
-    @ObservedObject private var pref = StylePref.shared
     @ObservedObject private var visibility = ProviderVisibilityStore.shared
-    @ObservedObject private var screenPref = ScreenPref.shared
 
     var body: some View {
-        VStack(spacing: 0) {
-            HStack(spacing: 0) {
-                providerTitle(name: "Claude", tag: planTag(forClaude: true),
-                              color: IslandColor.claude, alignment: .leading)
-                    .opacity(visibility.claudeVisible ? 1 : 0.30)
-                    .saturation(visibility.claudeVisible ? 1 : 0)
-                Color.clear.frame(width: notch.width)
-                providerTitle(name: "Codex", tag: planTag(forClaude: false),
-                              color: IslandColor.codex, alignment: .trailing)
-                    .opacity(visibility.codexVisible ? 1 : 0.30)
-                    .saturation(visibility.codexVisible ? 1 : 0)
-            }
-            .frame(height: 22)
-            .padding(.horizontal, 16)
-            .padding(.top, 4)
-            .padding(.bottom, max(0, notch.height - 22 - 4))
-
-            HStack(spacing: 0) {
-                CostBlock(
-                    color: visibility.claudeVisible ? IslandColor.claude : .white.opacity(0.32),
-                    cost: visibility.claudeVisible ? store.claude : .dummy
-                )
-                .opacity(visibility.claudeVisible ? 1 : 0.55)
-                Rectangle()
-                    .fill(LinearGradient(
-                        colors: [.clear, .white.opacity(0.06), .clear],
-                        startPoint: .top, endPoint: .bottom
-                    ))
-                    .frame(width: 1)
-                    .padding(.vertical, 8)
-                CostBlock(
-                    color: visibility.codexVisible ? IslandColor.codex : .white.opacity(0.32),
-                    cost: visibility.codexVisible ? store.codex : .dummy
-                )
-                .opacity(visibility.codexVisible ? 1 : 0.55)
-            }
-            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
-            .padding(.horizontal, 22)
-            .padding(.top, 12)
-            .padding(.bottom, 6)
-
-            LinearGradient(
-                colors: [.clear, .white.opacity(0.06), .white.opacity(0.06), .clear],
-                startPoint: .leading, endPoint: .trailing
+        HStack(spacing: 0) {
+            CostBlock(
+                color: visibility.claudeVisible ? IslandColor.claude : .white.opacity(0.32),
+                cost: visibility.claudeVisible ? store.claude : .dummy,
+                loading: store.claudeLoading
             )
-            .frame(height: 1)
-            .padding(.horizontal, 22)
-
-            HStack(spacing: 10) {
-                // Mirror the position of UsageView's STEPPED chip with a USD
-                // chip — the cost screen's bars are always stepped, so a
-                // chart-style chip would mislead.
-                Text("USD")
-                    .font(.system(size: 9, weight: .bold).monospaced())
-                    .tracking(0.8)
-                    .foregroundStyle(.white.opacity(0.78))
-                    .padding(.horizontal, 6)
-                    .padding(.vertical, 2.5)
-                    .background(
-                        RoundedRectangle(cornerRadius: 4)
-                            .fill(.white.opacity(0.08))
-                            .overlay(
-                                RoundedRectangle(cornerRadius: 4)
-                                    .strokeBorder(.white.opacity(0.10), lineWidth: 0.5)
-                            )
-                    )
-
-                Spacer()
-
-                PageIndicator(active: screenPref.screen)
-
-                HStack(spacing: 6) {
-                    LiveDot(active: store.lastUpdated != nil && !store.loading)
-                    if store.loading {
-                        Text("syncing…")
-                            .font(.system(size: 11))
-                            .foregroundStyle(.white.opacity(0.55))
-                    } else if let updated = store.lastUpdated {
-                        Text("synced")
-                            .font(.system(size: 11))
-                            .foregroundStyle(.white.opacity(0.55))
-                        Text(relative(updated))
-                            .font(.system(size: 11).monospacedDigit())
-                            .foregroundStyle(.white.opacity(0.72))
-                    } else {
-                        Text("idle")
-                            .font(.system(size: 11))
-                            .foregroundStyle(.white.opacity(0.4))
-                    }
-                }
-            }
-            .padding(.horizontal, 22)
-            .padding(.top, 6)
-            .padding(.bottom, 10)
+            .opacity(visibility.claudeVisible ? 1 : 0.55)
+            Rectangle()
+                .fill(LinearGradient(
+                    colors: [.clear, .white.opacity(0.06), .clear],
+                    startPoint: .top, endPoint: .bottom
+                ))
+                .frame(width: 1)
+                .padding(.vertical, 8)
+            CostBlock(
+                color: visibility.codexVisible ? IslandColor.codex : .white.opacity(0.32),
+                cost: visibility.codexVisible ? store.codex : .dummy,
+                loading: store.codexLoading
+            )
+            .opacity(visibility.codexVisible ? 1 : 0.55)
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-    }
-
-    /// Plan tag pulled from the API-side UsageStore — same source as
-    /// UsageView, since the subscription tier is independent of which page
-    /// the user is on.
-    private func planTag(forClaude: Bool) -> String? {
-        let usage = forClaude ? UsageStore.shared.claude : UsageStore.shared.codex
-        return usage.plan?.uppercased()
-    }
-
-    private func relative(_ d: Date) -> String {
-        let f = RelativeDateTimeFormatter()
-        f.unitsStyle = .abbreviated
-        return f.localizedString(for: d, relativeTo: Date())
-    }
-
-    @ViewBuilder
-    private func providerTitle(
-        name: String,
-        tag: String?,
-        color: Color,
-        alignment: HorizontalAlignment
-    ) -> some View {
-        let logoOffset: CGFloat = 9 + 20 + 8
-
-        let content = HStack(spacing: 8) {
-            Text(name)
-                .font(.system(size: 13, weight: .semibold))
-                .foregroundStyle(.white)
-            if let tag {
-                Text(tag)
-                    .font(.system(size: 9, weight: .bold).monospaced())
-                    .tracking(0.8)
-                    .foregroundStyle(.white.opacity(0.6))
-                    .padding(.horizontal, 5)
-                    .padding(.vertical, 2)
-                    .background(
-                        RoundedRectangle(cornerRadius: 3)
-                            .fill(.white.opacity(0.06))
-                            .overlay(
-                                RoundedRectangle(cornerRadius: 3)
-                                    .strokeBorder(.white.opacity(0.08), lineWidth: 0.5)
-                            )
-                    )
-            }
-        }
-
-        if alignment == .leading {
-            HStack {
-                content.padding(.leading, logoOffset)
-                Spacer(minLength: 0)
-            }
-            .frame(maxWidth: .infinity)
-        } else {
-            HStack {
-                Spacer(minLength: 0)
-                content.padding(.trailing, logoOffset)
-            }
-            .frame(maxWidth: .infinity)
-        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        .padding(.horizontal, 22)
+        .padding(.top, 12)
+        .padding(.bottom, 6)
     }
 }

--- a/Sources/Views/CountUpDollar.swift
+++ b/Sources/Views/CountUpDollar.swift
@@ -25,7 +25,7 @@ struct CountUpDollar: View {
             let elapsed = context.date.timeIntervalSince(animationStart)
             let displayed = interpolatedValue(elapsed: elapsed)
             Text(formatted(displayed))
-                .font(.system(size: 38, weight: .semibold).monospacedDigit())
+                .font(Typography.bigNumber)
                 .foregroundStyle(color)
                 .shadow(color: color.opacity(glowOpacity), radius: 6)
                 .shadow(color: color.opacity(glowOpacity * 0.5), radius: 14)

--- a/Sources/Views/CountUpDollar.swift
+++ b/Sources/Views/CountUpDollar.swift
@@ -1,0 +1,61 @@
+import SwiftUI
+
+/// Count-up animated dollar number — the slot-machine reveal that gives
+/// the cost screen its dopamine hit. Interpolates from `lastSeenTarget`
+/// (or 0 on first appearance) to `target` over ~0.65s using a cubic
+/// ease-out, driven by a 60Hz TimelineView.
+///
+/// Visually identical to the previous static text — same 38pt brand-color
+/// monospace digits with the dual-shadow glow whose intensity is locked
+/// to the *final* target so the halo settles cleanly when the count
+/// finishes.
+struct CountUpDollar: View {
+    let target: Double
+    let color: Color
+    let glowOpacity: Double
+
+    private static let duration: TimeInterval = 0.65
+
+    @State private var animationStart: Date = Date()
+    @State private var startValue: Double = 0
+    @State private var lastSeenTarget: Double = 0
+
+    var body: some View {
+        TimelineView(.animation(minimumInterval: 1.0 / 60.0)) { context in
+            let elapsed = context.date.timeIntervalSince(animationStart)
+            let displayed = interpolatedValue(elapsed: elapsed)
+            Text(formatted(displayed))
+                .font(.system(size: 38, weight: .semibold).monospacedDigit())
+                .foregroundStyle(color)
+                .shadow(color: color.opacity(glowOpacity), radius: 6)
+                .shadow(color: color.opacity(glowOpacity * 0.5), radius: 14)
+        }
+        .onAppear {
+            // Slot-machine reveal on first hover: rip from $0 up to current.
+            startValue = 0
+            animationStart = Date()
+            lastSeenTarget = target
+        }
+        .onChange(of: target) { _ in
+            // Smooth update during a refresh — count from where the eye
+            // last saw the number, not from zero.
+            startValue = lastSeenTarget
+            animationStart = Date()
+            lastSeenTarget = target
+        }
+    }
+
+    private func interpolatedValue(elapsed: TimeInterval) -> Double {
+        guard elapsed < Self.duration else { return target }
+        let t = max(0, min(1, elapsed / Self.duration))
+        let eased = 1 - pow(1 - t, 3)
+        return startValue + (target - startValue) * eased
+    }
+
+    /// Cents under $100 (where they're meaningful); rounded above so a
+    /// 7-digit month total fits the 38pt slot.
+    private func formatted(_ v: Double) -> String {
+        if v < 100 { return String(format: "%.2f", v) }
+        return String(format: "%.0f", v)
+    }
+}

--- a/Sources/Views/ExpandedView.swift
+++ b/Sources/Views/ExpandedView.swift
@@ -1,9 +1,18 @@
 import SwiftUI
 
+/// Composes the expanded panel: provider titles on top (fixed), the
+/// horizontally-paged data area in the middle (UsageView ↔ CostView),
+/// and the footer (chip + page dots + sync status) at the bottom (fixed).
+/// Only the data area slides between pages — chrome stays put.
 struct ExpandedView: View {
     @ObservedObject var model: IslandModel
 
     var body: some View {
-        PagedContent(model: model)
+        VStack(spacing: 0) {
+            PanelHeader(notch: model.notch)
+            PagedContent()
+            PanelFooter()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 }

--- a/Sources/Views/ExpandedView.swift
+++ b/Sources/Views/ExpandedView.swift
@@ -4,6 +4,6 @@ struct ExpandedView: View {
     @ObservedObject var model: IslandModel
 
     var body: some View {
-        UsageView(notch: model.notch)
+        PagedContent(model: model)
     }
 }

--- a/Sources/Views/IslandRootView.swift
+++ b/Sources/Views/IslandRootView.swift
@@ -125,13 +125,16 @@ struct IslandRootView: View {
                 }
                 .contentShape(IslandShape())
                 .onTapGesture {
-                    // Cmd-click cycles the chart style. The chart crossfade
-                    // (.id(style) on ChartTile) is the confirmation; no
-                    // panel-wide press scale needed — at this size, scaling
-                    // the whole 720pt panel reads as way too much for what's
-                    // really a 1-character UI change.
+                    // Cmd-click cycles the visualization style of whichever
+                    // page is active. Usage rotates Ring/Bar/Stepped/Numeric/
+                    // Spark; cost rotates USD/VALUE/TOKENS/TREND. The cell
+                    // crossfade is the confirmation — no panel-wide press
+                    // scale needed.
                     if NSEvent.modifierFlags.contains(.command) {
-                        StylePref.shared.cycle()
+                        switch ScreenPref.shared.screen {
+                        case .usage: StylePref.shared.cycle()
+                        case .cost:  CostStylePref.shared.cycle()
+                        }
                     }
                 }
                 .onHover { h in

--- a/Sources/Views/IslandRootView.swift
+++ b/Sources/Views/IslandRootView.swift
@@ -112,11 +112,13 @@ struct IslandRootView: View {
                     logo(claudeLogo, color: IslandColor.claude, alignment: .leading)
                         .opacity(visibility.claudeVisible ? 1 : 0.30)
                         .saturation(visibility.claudeVisible ? 1 : 0)
+                        .accessibilityLabel(visibility.claudeVisible ? "Claude" : "Claude (hidden)")
                 }
                 .overlay(alignment: .topTrailing) {
                     logo(openaiLogo, color: IslandColor.codex, alignment: .trailing)
                         .opacity(visibility.codexVisible ? 1 : 0.30)
                         .saturation(visibility.codexVisible ? 1 : 0)
+                        .accessibilityLabel(visibility.codexVisible ? "OpenAI" : "OpenAI (hidden)")
                 }
                 .overlay(alignment: .bottomLeading) {
                     // Utility control, not dashboard status. Keep it in a
@@ -183,6 +185,11 @@ struct IslandRootView: View {
             Spacer(minLength: 0)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("CodexIsland panel")
+        .accessibilityHint(model.state == .compact
+            ? "Hover to expand. Command-click to cycle visualization."
+            : "Command-click to cycle visualization.")
     }
 
     @ViewBuilder

--- a/Sources/Views/IslandRootView.swift
+++ b/Sources/Views/IslandRootView.swift
@@ -4,6 +4,8 @@ import AppKit
 struct IslandRootView: View {
     @ObservedObject var model: IslandModel
     @ObservedObject private var visibility = ProviderVisibilityStore.shared
+    @ObservedObject private var usageStore = UsageStore.shared
+    @ObservedObject private var costStore = CostStore.shared
     @State private var hovering = false
     @State private var contentVisible = false
 
@@ -33,22 +35,24 @@ struct IslandRootView: View {
                     // Loading sweep. 3pt blur + 4pt stroke is half the GPU
                     // cost of the original 5/5 — at 120Hz the blur is hot
                     // because the angular gradient re-rasterizes per frame.
-                    IslandShape()
-                        .stroke(
-                            AngularGradient(
-                                gradient: Gradient(stops: [
-                                    .init(color: .clear, location: 0.00),
-                                    .init(color: IslandColor.cobalt.opacity(0.0), location: 0.55),
-                                    .init(color: IslandColor.cobalt, location: 0.78),
-                                    .init(color: .white.opacity(0.95), location: 0.92),
-                                    .init(color: IslandColor.cobalt.opacity(0.0), location: 1.00),
-                                ]),
-                                center: .center,
-                                angle: .degrees(rotation)
-                            ),
-                            lineWidth: 4
-                        )
-                        .blur(radius: 3)
+                    if usageStore.loading || costStore.loading {
+                        IslandShape()
+                            .stroke(
+                                AngularGradient(
+                                    gradient: Gradient(stops: [
+                                        .init(color: .clear, location: 0.00),
+                                        .init(color: IslandColor.cobalt.opacity(0.0), location: 0.55),
+                                        .init(color: IslandColor.cobalt, location: 0.78),
+                                        .init(color: .white.opacity(0.95), location: 0.92),
+                                        .init(color: IslandColor.cobalt.opacity(0.0), location: 1.00),
+                                    ]),
+                                    center: .center,
+                                    angle: .degrees(rotation)
+                                ),
+                                lineWidth: 4
+                            )
+                            .blur(radius: 3)
+                    }
 
                     IslandShape()
                         .fill(.black)

--- a/Sources/Views/LiveDot.swift
+++ b/Sources/Views/LiveDot.swift
@@ -36,5 +36,6 @@ struct LiveDot: View {
                 withAnimation(.strongEaseOut) { syncBump = 1.0 }
             }
         }
+        .accessibilityHidden(true)
     }
 }

--- a/Sources/Views/PageIndicator.swift
+++ b/Sources/Views/PageIndicator.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+
+/// Two-dot page indicator that mirrors the active screen. Sits in the
+/// expanded panel footer between the style chip and the live-status group.
+struct PageIndicator: View {
+    let active: ScreenPref.Screen
+
+    var body: some View {
+        HStack(spacing: 5) {
+            dot(active: active == .usage)
+            dot(active: active == .cost)
+        }
+        .animation(.strongEaseOut, value: active)
+    }
+
+    private func dot(active: Bool) -> some View {
+        Circle()
+            .fill(.white.opacity(active ? 0.78 : 0.22))
+            .frame(width: 5, height: 5)
+    }
+}

--- a/Sources/Views/PageIndicator.swift
+++ b/Sources/Views/PageIndicator.swift
@@ -11,6 +11,9 @@ struct PageIndicator: View {
             dot(active: active == .cost)
         }
         .animation(.strongEaseOut, value: active)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("Page indicator")
+        .accessibilityValue(active == .usage ? "Usage page, 1 of 2" : "Cost page, 2 of 2")
     }
 
     private func dot(active: Bool) -> some View {

--- a/Sources/Views/PagedContent.swift
+++ b/Sources/Views/PagedContent.swift
@@ -8,8 +8,15 @@ import SwiftUI
 ///
 /// Only the data row swipes — `PanelHeader` and `PanelFooter` are mounted
 /// outside this view so they stay fixed across page changes.
+///
+/// First-encounter peek: on every expand until the user has swiped at
+/// least once (`ScreenPref.hasSwipedScreen`), the data row slides ~28pt
+/// left to reveal the cost screen's edge, then settles back. Subtle and
+/// time-bounded so it stops nagging once they've discovered the gesture.
 struct PagedContent: View {
     @ObservedObject private var screenPref = ScreenPref.shared
+    @State private var peekOffset: CGFloat = 0
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     var body: some View {
         GeometryReader { geo in
@@ -21,9 +28,37 @@ struct PagedContent: View {
                     .frame(width: pageWidth)
             }
             .frame(width: pageWidth, alignment: .leading)
-            .offset(x: screenPref.screen == .usage ? 0 : -pageWidth)
+            .offset(x: (screenPref.screen == .usage ? 0 : -pageWidth) + peekOffset)
             .animation(.openMorph, value: screenPref.screen)
             .clipped()
+            .onAppear {
+                guard !reduceMotion,
+                      !screenPref.hasSwipedScreen,
+                      screenPref.screen == .usage
+                else { return }
+                schedulePeek()
+            }
+            .onChange(of: screenPref.hasSwipedScreen) { swiped in
+                // User swiped mid-peek: collapse the peek smoothly so the
+                // composite offset doesn't jump when the real screen
+                // transition fires alongside it.
+                if swiped, peekOffset != 0 {
+                    withAnimation(.easeOut(duration: 0.25)) { peekOffset = 0 }
+                }
+            }
+        }
+    }
+
+    private func schedulePeek() {
+        // 0.30s wait lets the open-morph spring settle before the peek
+        // starts — peeking during the initial expand would feel chaotic.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.30) {
+            guard !screenPref.hasSwipedScreen else { return }
+            withAnimation(.easeOut(duration: 0.50)) { peekOffset = -28 }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.58) {
+                guard !screenPref.hasSwipedScreen else { return }
+                withAnimation(.easeIn(duration: 0.40)) { peekOffset = 0 }
+            }
         }
     }
 }

--- a/Sources/Views/PagedContent.swift
+++ b/Sources/Views/PagedContent.swift
@@ -1,20 +1,23 @@
 import SwiftUI
 
-/// Two-page horizontal carousel: UsageView (page 0) and CostView (page 1).
-/// Both pages render at the full content width; the HStack is twice that
-/// width and slides via .offset based on `ScreenPref.screen`. Animation uses
-/// the same spring as the expanded-state shape morph for cohesion.
+/// Two-page horizontal carousel: the usage data row (page 0) and the cost
+/// data row (page 1). Both pages render at the full content width; the
+/// HStack is twice that width and slides via `.offset` based on
+/// `ScreenPref.screen`. Animation uses the same spring as the expanded-
+/// state shape morph for cohesion.
+///
+/// Only the data row swipes — `PanelHeader` and `PanelFooter` are mounted
+/// outside this view so they stay fixed across page changes.
 struct PagedContent: View {
-    @ObservedObject var model: IslandModel
     @ObservedObject private var screenPref = ScreenPref.shared
 
     var body: some View {
         GeometryReader { geo in
             let pageWidth = geo.size.width
             HStack(spacing: 0) {
-                UsageView(notch: model.notch)
+                UsageView()
                     .frame(width: pageWidth)
-                CostView(notch: model.notch)
+                CostView()
                     .frame(width: pageWidth)
             }
             .frame(width: pageWidth, alignment: .leading)

--- a/Sources/Views/PagedContent.swift
+++ b/Sources/Views/PagedContent.swift
@@ -16,7 +16,6 @@ import SwiftUI
 struct PagedContent: View {
     @ObservedObject private var screenPref = ScreenPref.shared
     @State private var peekOffset: CGFloat = 0
-    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     var body: some View {
         GeometryReader { geo in
@@ -32,8 +31,12 @@ struct PagedContent: View {
             .animation(.openMorph, value: screenPref.screen)
             .clipped()
             .onAppear {
-                guard !reduceMotion,
-                      !screenPref.hasSwipedScreen,
+                // Discoverability cue, not decorative motion — fires even
+                // when @Environment(\.accessibilityReduceMotion) is on,
+                // because without it reduce-motion users have no path to
+                // learn the second screen exists. The motion is brief
+                // (~1s total) and slow-eased.
+                guard !screenPref.hasSwipedScreen,
                       screenPref.screen == .usage
                 else { return }
                 schedulePeek()
@@ -50,14 +53,22 @@ struct PagedContent: View {
     }
 
     private func schedulePeek() {
-        // 0.30s wait lets the open-morph spring settle before the peek
-        // starts — peeking during the initial expand would feel chaotic.
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.30) {
+        // 0.40s lets the panel's openMorph + content fade-in settle
+        // (~0.42s + ~0.28s) before the peek begins, so the discoverability
+        // beat is its own gesture instead of competing with the entrance.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.40) {
             guard !screenPref.hasSwipedScreen else { return }
-            withAnimation(.easeOut(duration: 0.50)) { peekOffset = -28 }
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.58) {
+            // Reuse the panel-open spring so the peek inherits the same
+            // motion identity that brought the panel into view. Springs
+            // also hand off cleanly to a real swipe if the user grabs
+            // mid-peek (both gestures animate via the same physics).
+            withAnimation(.openMorph) { peekOffset = -46 }
+            // Out spring settles ~0.42s; hold ~0.20s past settle, then
+            // return with closeMorph — snappier, matching the asymmetric
+            // open/close pace already established for the panel itself.
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.62) {
                 guard !screenPref.hasSwipedScreen else { return }
-                withAnimation(.easeIn(duration: 0.40)) { peekOffset = 0 }
+                withAnimation(.closeMorph) { peekOffset = 0 }
             }
         }
     }

--- a/Sources/Views/PagedContent.swift
+++ b/Sources/Views/PagedContent.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+
+/// Two-page horizontal carousel: UsageView (page 0) and CostView (page 1).
+/// Both pages render at the full content width; the HStack is twice that
+/// width and slides via .offset based on `ScreenPref.screen`. Animation uses
+/// the same spring as the expanded-state shape morph for cohesion.
+struct PagedContent: View {
+    @ObservedObject var model: IslandModel
+    @ObservedObject private var screenPref = ScreenPref.shared
+
+    var body: some View {
+        GeometryReader { geo in
+            let pageWidth = geo.size.width
+            HStack(spacing: 0) {
+                UsageView(notch: model.notch)
+                    .frame(width: pageWidth)
+                CostView(notch: model.notch)
+                    .frame(width: pageWidth)
+            }
+            .frame(width: pageWidth, alignment: .leading)
+            .offset(x: screenPref.screen == .usage ? 0 : -pageWidth)
+            .animation(.openMorph, value: screenPref.screen)
+            .clipped()
+        }
+    }
+}

--- a/Sources/Views/PanelFooter.swift
+++ b/Sources/Views/PanelFooter.swift
@@ -39,6 +39,8 @@ struct PanelFooter: View {
                     }
                     .foregroundStyle(.white.opacity(0.42))
                     .transition(.opacity.combined(with: .scale(scale: 0.92, anchor: .leading)))
+                    .accessibilityElement(children: .combine)
+                    .accessibilityLabel("Tip: Command-click to cycle visualization")
                 }
 
                 Spacer()
@@ -126,6 +128,14 @@ struct PanelFooter: View {
                     .foregroundStyle(.white.opacity(0.4))
             }
         }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(liveStatusSpoken)
+    }
+
+    private var liveStatusSpoken: String {
+        if activeLoading { return "Syncing" }
+        if let updated = activeLastUpdated { return "Synced \(relative(updated))" }
+        return "Idle"
     }
 
     private func relative(_ d: Date) -> String {

--- a/Sources/Views/PanelFooter.swift
+++ b/Sources/Views/PanelFooter.swift
@@ -33,9 +33,9 @@ struct PanelFooter: View {
                 if screenPref.screen == .usage && !pref.hasCycledStyle {
                     HStack(spacing: 5) {
                         Image(systemName: "command")
-                            .font(.system(size: 10, weight: .semibold))
+                            .font(Typography.micro)
                         Text("click to cycle")
-                            .font(.system(size: 11))
+                            .font(Typography.label)
                     }
                     .foregroundStyle(.white.opacity(0.42))
                     .transition(.opacity.combined(with: .scale(scale: 0.92, anchor: .leading)))
@@ -64,7 +64,7 @@ struct PanelFooter: View {
             }
         }()
         Text(label)
-            .font(.system(size: 9, weight: .bold).monospaced())
+            .font(Typography.chip)
             .tracking(0.8)
             .foregroundStyle(.white.opacity(0.78))
             .padding(.horizontal, 6)
@@ -103,18 +103,18 @@ struct PanelFooter: View {
             LiveDot(active: activeLastUpdated != nil && !activeLoading)
             if activeLoading {
                 Text("syncing…")
-                    .font(.system(size: 11))
+                    .font(Typography.label)
                     .foregroundStyle(.white.opacity(0.55))
             } else if let updated = activeLastUpdated {
                 Text("synced")
-                    .font(.system(size: 11))
+                    .font(Typography.label)
                     .foregroundStyle(.white.opacity(0.55))
                 Text(relative(updated))
-                    .font(.system(size: 11).monospacedDigit())
+                    .font(Typography.bodyNumber)
                     .foregroundStyle(.white.opacity(0.72))
             } else {
                 Text("idle")
-                    .font(.system(size: 11))
+                    .font(Typography.label)
                     .foregroundStyle(.white.opacity(0.4))
             }
         }

--- a/Sources/Views/PanelFooter.swift
+++ b/Sources/Views/PanelFooter.swift
@@ -1,0 +1,126 @@
+import SwiftUI
+
+/// Hairline divider + chip + cmd-click hint + page indicator + live-status
+/// group. Lives outside `PagedContent` so it stays fixed while the data
+/// area swipes between pages.
+///
+/// Two things change with the active screen:
+///   1. The chip — shows the current chart-style label on the usage page
+///      (since cmd-click cycles styles there) and a static "USD" on the
+///      cost page (cost bars don't cycle).
+///   2. The live-status group — reflects whichever store powers the
+///      currently visible page (UsageStore on usage, CostStore on cost),
+///      so "syncing…" / "synced 5s ago" describes the data the user sees.
+struct PanelFooter: View {
+    @ObservedObject private var pref = StylePref.shared
+    @ObservedObject private var screenPref = ScreenPref.shared
+    @ObservedObject private var usageStore = UsageStore.shared
+    @ObservedObject private var costStore = CostStore.shared
+
+    var body: some View {
+        VStack(spacing: 0) {
+            LinearGradient(
+                colors: [.clear, .white.opacity(0.06), .white.opacity(0.06), .clear],
+                startPoint: .leading, endPoint: .trailing
+            )
+            .frame(height: 1)
+            .padding(.horizontal, 22)
+
+            HStack(spacing: 10) {
+                chip
+
+                if screenPref.screen == .usage && !pref.hasCycledStyle {
+                    HStack(spacing: 5) {
+                        Image(systemName: "command")
+                            .font(.system(size: 10, weight: .semibold))
+                        Text("click to cycle")
+                            .font(.system(size: 11))
+                    }
+                    .foregroundStyle(.white.opacity(0.42))
+                    .transition(.opacity.combined(with: .scale(scale: 0.92, anchor: .leading)))
+                }
+
+                Spacer()
+
+                PageIndicator(active: screenPref.screen)
+
+                liveStatus
+            }
+            .padding(.horizontal, 22)
+            .padding(.top, 6)
+            .padding(.bottom, 10)
+            .animation(.strongEaseOut, value: pref.hasCycledStyle)
+            .animation(.strongEaseOut, value: screenPref.screen)
+        }
+    }
+
+    @ViewBuilder
+    private var chip: some View {
+        let label: String = {
+            switch screenPref.screen {
+            case .usage: return pref.style.label.uppercased()
+            case .cost:  return "USD"
+            }
+        }()
+        Text(label)
+            .font(.system(size: 9, weight: .bold).monospaced())
+            .tracking(0.8)
+            .foregroundStyle(.white.opacity(0.78))
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2.5)
+            .background(
+                RoundedRectangle(cornerRadius: 4)
+                    .fill(.white.opacity(0.08))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 4)
+                            .strokeBorder(.white.opacity(0.10), lineWidth: 0.5)
+                    )
+            )
+            .contentTransition(.opacity)
+            .animation(.strongEaseOut, value: pref.style)
+            .animation(.strongEaseOut, value: screenPref.screen)
+    }
+
+    private var activeLoading: Bool {
+        switch screenPref.screen {
+        case .usage: return usageStore.loading
+        case .cost:  return costStore.loading
+        }
+    }
+
+    private var activeLastUpdated: Date? {
+        switch screenPref.screen {
+        case .usage: return usageStore.lastUpdated
+        case .cost:  return costStore.lastUpdated
+        }
+    }
+
+    @ViewBuilder
+    private var liveStatus: some View {
+        HStack(spacing: 6) {
+            LiveDot(active: activeLastUpdated != nil && !activeLoading)
+            if activeLoading {
+                Text("syncing…")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.white.opacity(0.55))
+            } else if let updated = activeLastUpdated {
+                Text("synced")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.white.opacity(0.55))
+                Text(relative(updated))
+                    .font(.system(size: 11).monospacedDigit())
+                    .foregroundStyle(.white.opacity(0.72))
+            } else {
+                Text("idle")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.white.opacity(0.4))
+            }
+        }
+    }
+
+    private func relative(_ d: Date) -> String {
+        let f = RelativeDateTimeFormatter()
+        f.unitsStyle = .abbreviated
+        return f.localizedString(for: d, relativeTo: Date())
+    }
+}

--- a/Sources/Views/PanelFooter.swift
+++ b/Sources/Views/PanelFooter.swift
@@ -30,7 +30,7 @@ struct PanelFooter: View {
             HStack(spacing: 10) {
                 chip
 
-                if screenPref.screen == .usage && !pref.hasCycledStyle {
+                if !activeStyleCycled {
                     HStack(spacing: 5) {
                         Image(systemName: "command")
                             .font(Typography.micro)
@@ -51,7 +51,15 @@ struct PanelFooter: View {
             .padding(.top, 6)
             .padding(.bottom, 10)
             .animation(.strongEaseOut, value: pref.hasCycledStyle)
+            .animation(.strongEaseOut, value: costPref.hasCycledStyle)
             .animation(.strongEaseOut, value: screenPref.screen)
+        }
+    }
+
+    private var activeStyleCycled: Bool {
+        switch screenPref.screen {
+        case .usage: return pref.hasCycledStyle
+        case .cost:  return costPref.hasCycledStyle
         }
     }
 

--- a/Sources/Views/PanelFooter.swift
+++ b/Sources/Views/PanelFooter.swift
@@ -13,6 +13,7 @@ import SwiftUI
 ///      so "syncing…" / "synced 5s ago" describes the data the user sees.
 struct PanelFooter: View {
     @ObservedObject private var pref = StylePref.shared
+    @ObservedObject private var costPref = CostStylePref.shared
     @ObservedObject private var screenPref = ScreenPref.shared
     @ObservedObject private var usageStore = UsageStore.shared
     @ObservedObject private var costStore = CostStore.shared
@@ -59,7 +60,7 @@ struct PanelFooter: View {
         let label: String = {
             switch screenPref.screen {
             case .usage: return pref.style.label.uppercased()
-            case .cost:  return "USD"
+            case .cost:  return costPref.style.label
             }
         }()
         Text(label)
@@ -78,6 +79,7 @@ struct PanelFooter: View {
             )
             .contentTransition(.opacity)
             .animation(.strongEaseOut, value: pref.style)
+            .animation(.strongEaseOut, value: costPref.style)
             .animation(.strongEaseOut, value: screenPref.screen)
     }
 

--- a/Sources/Views/PanelHeader.swift
+++ b/Sources/Views/PanelHeader.swift
@@ -42,11 +42,11 @@ struct PanelHeader: View {
 
         let content = HStack(spacing: 8) {
             Text(name)
-                .font(.system(size: 13, weight: .semibold))
+                .font(Typography.providerTitle)
                 .foregroundStyle(.white)
             if let tag {
                 Text(tag)
-                    .font(.system(size: 9, weight: .bold).monospaced())
+                    .font(Typography.chip)
                     .tracking(0.8)
                     .foregroundStyle(.white.opacity(0.6))
                     .padding(.horizontal, 5)

--- a/Sources/Views/PanelHeader.swift
+++ b/Sources/Views/PanelHeader.swift
@@ -1,0 +1,79 @@
+import SwiftUI
+
+/// Provider titles row — Claude on the left, Codex on the right, with a
+/// notch-width spacer in the middle that hides the title content behind
+/// the physical notch. Lives outside `PagedContent` so it stays fixed
+/// while the data area swipes between usage/cost screens.
+///
+/// Plan tags ("MAX" / "PLUS") are sourced from `UsageStore` since the
+/// subscription tier is a property of the account, not the current page.
+struct PanelHeader: View {
+    let notch: NotchInfo
+    @ObservedObject private var visibility = ProviderVisibilityStore.shared
+    @ObservedObject private var usageStore = UsageStore.shared
+
+    var body: some View {
+        HStack(spacing: 0) {
+            providerTitle(name: "Claude", tag: usageStore.claude.plan?.uppercased(),
+                          color: IslandColor.claude, alignment: .leading)
+                .opacity(visibility.claudeVisible ? 1 : 0.30)
+                .saturation(visibility.claudeVisible ? 1 : 0)
+            Color.clear.frame(width: notch.width)
+            providerTitle(name: "Codex", tag: usageStore.codex.plan?.uppercased(),
+                          color: IslandColor.codex, alignment: .trailing)
+                .opacity(visibility.codexVisible ? 1 : 0.30)
+                .saturation(visibility.codexVisible ? 1 : 0)
+        }
+        .frame(height: 22)
+        .padding(.horizontal, 16)
+        .padding(.top, 4)
+        .padding(.bottom, max(0, notch.height - 22 - 4))
+    }
+
+    @ViewBuilder
+    private func providerTitle(
+        name: String,
+        tag: String?,
+        color: Color,
+        alignment: HorizontalAlignment
+    ) -> some View {
+        // Push past where the overlay logo lands: 9 leading + 20 logo + 8 gap.
+        let logoOffset: CGFloat = 9 + 20 + 8
+
+        let content = HStack(spacing: 8) {
+            Text(name)
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(.white)
+            if let tag {
+                Text(tag)
+                    .font(.system(size: 9, weight: .bold).monospaced())
+                    .tracking(0.8)
+                    .foregroundStyle(.white.opacity(0.6))
+                    .padding(.horizontal, 5)
+                    .padding(.vertical, 2)
+                    .background(
+                        RoundedRectangle(cornerRadius: 3)
+                            .fill(.white.opacity(0.06))
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 3)
+                                    .strokeBorder(.white.opacity(0.08), lineWidth: 0.5)
+                            )
+                    )
+            }
+        }
+
+        if alignment == .leading {
+            HStack {
+                content.padding(.leading, logoOffset)
+                Spacer(minLength: 0)
+            }
+            .frame(maxWidth: .infinity)
+        } else {
+            HStack {
+                Spacer(minLength: 0)
+                content.padding(.trailing, logoOffset)
+            }
+            .frame(maxWidth: .infinity)
+        }
+    }
+}

--- a/Sources/Views/Settings/BrandHeader.swift
+++ b/Sources/Views/Settings/BrandHeader.swift
@@ -21,23 +21,19 @@ struct BrandHeader: View {
             mark
 
             VStack(alignment: .leading, spacing: 2) {
-                // 14pt semibold — brand wordmark, intentionally one step above providerTitle (13).
                 Text("CodexIsland")
-                    .font(.system(size: 14, weight: .semibold))
+                    .font(Typography.brand)
                     .tracking(-0.15)
                     .foregroundStyle(.white.opacity(0.92))
-                // 11pt regular — tagline reads quieter than label (11 medium).
                 Text("Your AI usage limits, living in your notch.")
-                    .font(.system(size: 11))
+                    .font(Typography.label)
                     .foregroundStyle(.white.opacity(0.55))
             }
 
             Spacer(minLength: 8)
 
-            // 11pt medium mono — no token (bodyNumber is semibold); version pill keeps medium
-            // weight to balance the wordmark without competing.
             Text("v\(version)")
-                .font(.system(size: 11, weight: .medium).monospaced())
+                .font(Typography.bodyNumber)
                 .foregroundStyle(.white.opacity(0.34))
                 .padding(.horizontal, 9)
                 .padding(.vertical, 4)

--- a/Sources/Views/Settings/BrandHeader.swift
+++ b/Sources/Views/Settings/BrandHeader.swift
@@ -21,10 +21,12 @@ struct BrandHeader: View {
             mark
 
             VStack(alignment: .leading, spacing: 2) {
+                // 14pt semibold — brand wordmark, intentionally one step above providerTitle (13).
                 Text("CodexIsland")
                     .font(.system(size: 14, weight: .semibold))
                     .tracking(-0.15)
                     .foregroundStyle(.white.opacity(0.92))
+                // 11pt regular — tagline reads quieter than label (11 medium).
                 Text("Your AI usage limits, living in your notch.")
                     .font(.system(size: 11))
                     .foregroundStyle(.white.opacity(0.55))
@@ -32,6 +34,8 @@ struct BrandHeader: View {
 
             Spacer(minLength: 8)
 
+            // 11pt medium mono — no token (bodyNumber is semibold); version pill keeps medium
+            // weight to balance the wordmark without competing.
             Text("v\(version)")
                 .font(.system(size: 11, weight: .medium).monospaced())
                 .foregroundStyle(.white.opacity(0.34))

--- a/Sources/Views/Settings/ChartStylePicker.swift
+++ b/Sources/Views/Settings/ChartStylePicker.swift
@@ -79,12 +79,11 @@ struct ChartStylePicker: View {
             }
             .frame(width: 28, height: 6)
         case .stepped:
-            HStack(alignment: .bottom, spacing: 2) {
-                ForEach(0..<5) { i in
-                    Rectangle()
-                        .fill(i < 2 ? claude : .white.opacity(0.10))
-                        .frame(width: 4, height: CGFloat(7 + i * 2))
-                        .cornerRadius(0.5)
+            HStack(spacing: 1.5) {
+                ForEach(0..<8) { i in
+                    RoundedRectangle(cornerRadius: 0.75)
+                        .fill(i < 3 ? claude : .white.opacity(0.10))
+                        .frame(width: 2, height: 12)
                 }
             }
             .frame(width: 28, height: 14)

--- a/Sources/Views/Settings/ChartStylePicker.swift
+++ b/Sources/Views/Settings/ChartStylePicker.swift
@@ -29,7 +29,7 @@ struct ChartStylePicker: View {
                 preview(for: style)
                     .frame(height: 34)
                 Text(style.label)
-                    .font(.system(size: 10, weight: .medium))
+                    .font(Typography.micro)
                     .foregroundStyle(isOn
                         ? Color(red: 0.58, green: 0.75, blue: 1.0)
                         : .white.opacity(0.55))
@@ -90,10 +90,10 @@ struct ChartStylePicker: View {
         case .numeric:
             HStack(alignment: .firstTextBaseline, spacing: 1) {
                 Text("35")
-                    .font(.system(size: 16, weight: .bold).monospacedDigit())
+                    .font(Typography.previewNumber)
                     .foregroundStyle(claude)
                 Text("%")
-                    .font(.system(size: 8, weight: .medium))
+                    .font(Typography.micro)
                     .foregroundStyle(.white.opacity(0.5))
             }
         case .spark:

--- a/Sources/Views/Settings/ChartStylePicker.swift
+++ b/Sources/Views/Settings/ChartStylePicker.swift
@@ -28,6 +28,7 @@ struct ChartStylePicker: View {
             VStack(spacing: 7) {
                 preview(for: style)
                     .frame(height: 34)
+                    .accessibilityHidden(true)
                 Text(style.label)
                     .font(Typography.micro)
                     .foregroundStyle(isOn
@@ -55,6 +56,8 @@ struct ChartStylePicker: View {
             }
         }
         .buttonStyle(.plain)
+        .accessibilityLabel(style.label)
+        .accessibilityAddTraits(isOn ? [.isButton, .isSelected] : .isButton)
     }
 
     @ViewBuilder

--- a/Sources/Views/Settings/CostStylePicker.swift
+++ b/Sources/Views/Settings/CostStylePicker.swift
@@ -20,6 +20,9 @@ struct CostStylePicker: View {
         let isOn = (style == selected)
         Button {
             selected = style
+            if !CostStylePref.shared.hasCycledStyle {
+                CostStylePref.shared.hasCycledStyle = true
+            }
         } label: {
             VStack(spacing: 7) {
                 preview(for: style)

--- a/Sources/Views/Settings/CostStylePicker.swift
+++ b/Sources/Views/Settings/CostStylePicker.swift
@@ -25,7 +25,7 @@ struct CostStylePicker: View {
                 preview(for: style)
                     .frame(height: 34)
                 Text(style.label)
-                    .font(.system(size: 10, weight: .medium))
+                    .font(Typography.micro)
                     .foregroundStyle(isOn
                         ? Color(red: 0.58, green: 0.75, blue: 1.0)
                         : .white.opacity(0.55))
@@ -60,10 +60,10 @@ struct CostStylePicker: View {
         case .dollar:
             HStack(alignment: .firstTextBaseline, spacing: 1) {
                 Text("$")
-                    .font(.system(size: 8, weight: .medium))
+                    .font(Typography.micro)
                     .foregroundStyle(.white.opacity(0.5))
                 Text("87")
-                    .font(.system(size: 16, weight: .semibold).monospacedDigit())
+                    .font(Typography.previewNumber)
                     .foregroundStyle(claude)
             }
         case .multi:
@@ -77,10 +77,10 @@ struct CostStylePicker: View {
         case .tokens:
             HStack(alignment: .firstTextBaseline, spacing: 1) {
                 Text("2.4")
-                    .font(.system(size: 16, weight: .semibold).monospacedDigit())
+                    .font(Typography.previewNumber)
                     .foregroundStyle(claude)
                 Text("M")
-                    .font(.system(size: 8, weight: .medium))
+                    .font(Typography.micro)
                     .foregroundStyle(.white.opacity(0.5))
             }
         case .spark:

--- a/Sources/Views/Settings/CostStylePicker.swift
+++ b/Sources/Views/Settings/CostStylePicker.swift
@@ -27,6 +27,7 @@ struct CostStylePicker: View {
             VStack(spacing: 7) {
                 preview(for: style)
                     .frame(height: 34)
+                    .accessibilityHidden(true)
                 Text(style.label)
                     .font(Typography.micro)
                     .foregroundStyle(isOn
@@ -54,6 +55,8 @@ struct CostStylePicker: View {
             }
         }
         .buttonStyle(.plain)
+        .accessibilityLabel(style.label)
+        .accessibilityAddTraits(isOn ? [.isButton, .isSelected] : .isButton)
     }
 
     @ViewBuilder

--- a/Sources/Views/Settings/CostStylePicker.swift
+++ b/Sources/Views/Settings/CostStylePicker.swift
@@ -1,0 +1,114 @@
+import SwiftUI
+
+/// Four-tile picker for the default cost view style. Mirror of
+/// `ChartStylePicker` for the cost screen — same visual language so the
+/// Display tab reads as one cohesive picker section. Selecting a tile
+/// also updates the `CostStylePref.shared` singleton via the binding.
+struct CostStylePicker: View {
+    @Binding var selected: CostStyle
+
+    var body: some View {
+        HStack(spacing: 6) {
+            ForEach(CostStyle.allCases, id: \.self) { style in
+                tile(for: style)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func tile(for style: CostStyle) -> some View {
+        let isOn = (style == selected)
+        Button {
+            selected = style
+        } label: {
+            VStack(spacing: 7) {
+                preview(for: style)
+                    .frame(height: 34)
+                Text(style.label)
+                    .font(.system(size: 10, weight: .medium))
+                    .foregroundStyle(isOn
+                        ? Color(red: 0.58, green: 0.75, blue: 1.0)
+                        : .white.opacity(0.55))
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.top, 14)
+            .padding(.horizontal, 6)
+            .padding(.bottom, 10)
+            .background {
+                RoundedRectangle(cornerRadius: 9)
+                    .fill(isOn
+                          ? IslandColor.cobalt.opacity(0.14)
+                          : .white.opacity(0.025))
+                    .overlay {
+                        RoundedRectangle(cornerRadius: 9)
+                            .strokeBorder(isOn
+                                ? IslandColor.cobalt.opacity(0.6)
+                                : .clear, lineWidth: 1)
+                    }
+                    .shadow(color: isOn
+                            ? IslandColor.cobalt.opacity(0.18)
+                            : .clear, radius: 9)
+            }
+        }
+        .buttonStyle(.plain)
+    }
+
+    @ViewBuilder
+    private func preview(for style: CostStyle) -> some View {
+        let claude = IslandColor.claude
+        switch style {
+        case .dollar:
+            HStack(alignment: .firstTextBaseline, spacing: 1) {
+                Text("$")
+                    .font(.system(size: 8, weight: .medium))
+                    .foregroundStyle(.white.opacity(0.5))
+                Text("87")
+                    .font(.system(size: 16, weight: .semibold).monospacedDigit())
+                    .foregroundStyle(claude)
+            }
+        case .multi:
+            HStack(alignment: .bottom, spacing: 4) {
+                Capsule().fill(.white.opacity(0.20))
+                    .frame(width: 8, height: 6)
+                Capsule().fill(claude)
+                    .frame(width: 8, height: 18)
+                    .shadow(color: claude.opacity(0.6), radius: 3)
+            }
+        case .tokens:
+            HStack(alignment: .firstTextBaseline, spacing: 1) {
+                Text("2.4")
+                    .font(.system(size: 16, weight: .semibold).monospacedDigit())
+                    .foregroundStyle(claude)
+                Text("M")
+                    .font(.system(size: 8, weight: .medium))
+                    .foregroundStyle(.white.opacity(0.5))
+            }
+        case .spark:
+            CostSparkPath()
+                .stroke(claude, style: StrokeStyle(lineWidth: 1.5, lineCap: .round, lineJoin: .round))
+                .shadow(color: claude.opacity(0.6), radius: 2)
+                .frame(width: 32, height: 16)
+        }
+    }
+}
+
+/// Static ascending sparkline for the TREND tile preview. Always trends
+/// upward (slight wiggle) to match the always-cumulative nature of the
+/// real cost sparkline.
+private struct CostSparkPath: Shape {
+    func path(in rect: CGRect) -> Path {
+        var p = Path()
+        let pts: [(CGFloat, CGFloat)] = [
+            (0.00, 0.92), (0.16, 0.78),
+            (0.34, 0.65), (0.50, 0.50),
+            (0.69, 0.38), (0.84, 0.22),
+            (1.00, 0.10),
+        ]
+        for (i, pt) in pts.enumerated() {
+            let cgp = CGPoint(x: rect.minX + rect.width * pt.0,
+                              y: rect.minY + rect.height * pt.1)
+            if i == 0 { p.move(to: cgp) } else { p.addLine(to: cgp) }
+        }
+        return p
+    }
+}

--- a/Sources/Views/Settings/SettingsFooter.swift
+++ b/Sources/Views/Settings/SettingsFooter.swift
@@ -13,10 +13,8 @@ struct SettingsFooter: View {
 
     var body: some View {
         HStack(alignment: .center, spacing: 14) {
-            // 11pt mono regular — no token (caption is 10pt, bodyNumber is 11pt semibold);
-            // version text needs the lighter weight to recede next to the dotted-link row.
             Text(version)
-                .font(.system(size: 11).monospaced())
+                .font(Typography.bodyNumber)
                 .foregroundStyle(.white.opacity(0.34))
 
             link("GitHub", url: Self.githubURL)
@@ -27,9 +25,8 @@ struct SettingsFooter: View {
             Button {
                 NSApp.terminate(nil)
             } label: {
-                // 11.5pt: matches Settings row subtitle scale.
                 Text("Quit")
-                    .font(.system(size: 11.5, weight: .medium))
+                    .font(Typography.label)
                     .foregroundStyle(.white.opacity(quitHovered ? 0.92 : 0.55))
                     .padding(.horizontal, 11)
                     .padding(.vertical, 5)
@@ -68,12 +65,11 @@ private struct DottedLink: View {
     var body: some View {
         Button(action: action) {
             HStack(spacing: 4) {
-                // 11.5pt regular + 9pt arrow glyph — paired off-grid sizes for the dotted link.
                 Text(title)
-                    .font(.system(size: 11.5))
+                    .font(Typography.label)
                     .foregroundStyle(.white.opacity(hovered ? 0.92 : 0.55))
                 Text("↗")
-                    .font(.system(size: 9))
+                    .font(Typography.micro)
                     .foregroundStyle(.white.opacity(hovered ? 0.6 : 0.3))
             }
             .overlay(alignment: .bottom) {

--- a/Sources/Views/Settings/SettingsFooter.swift
+++ b/Sources/Views/Settings/SettingsFooter.swift
@@ -13,6 +13,8 @@ struct SettingsFooter: View {
 
     var body: some View {
         HStack(alignment: .center, spacing: 14) {
+            // 11pt mono regular — no token (caption is 10pt, bodyNumber is 11pt semibold);
+            // version text needs the lighter weight to recede next to the dotted-link row.
             Text(version)
                 .font(.system(size: 11).monospaced())
                 .foregroundStyle(.white.opacity(0.34))
@@ -25,6 +27,7 @@ struct SettingsFooter: View {
             Button {
                 NSApp.terminate(nil)
             } label: {
+                // 11.5pt: matches Settings row subtitle scale.
                 Text("Quit")
                     .font(.system(size: 11.5, weight: .medium))
                     .foregroundStyle(.white.opacity(quitHovered ? 0.92 : 0.55))
@@ -65,6 +68,7 @@ private struct DottedLink: View {
     var body: some View {
         Button(action: action) {
             HStack(spacing: 4) {
+                // 11.5pt regular + 9pt arrow glyph — paired off-grid sizes for the dotted link.
                 Text(title)
                     .font(.system(size: 11.5))
                     .foregroundStyle(.white.opacity(hovered ? 0.92 : 0.55))

--- a/Sources/Views/Settings/SettingsRow.swift
+++ b/Sources/Views/Settings/SettingsRow.swift
@@ -40,9 +40,7 @@ struct SettingsRow<Trailing: View>: View {
                             .accessibilityHidden(true)
                     }
                     Text(title)
-                        // 13.5pt sits between providerTitle (13) and unit (15) — Settings rows
-                        // need a touch more presence than provider titles without the unit's weight.
-                        .font(.system(size: 13.5, weight: .medium))
+                        .font(Typography.rowTitle)
                         .tracking(-0.07)
                         .foregroundStyle(.white.opacity(0.92))
                     if let chip {
@@ -60,9 +58,8 @@ struct SettingsRow<Trailing: View>: View {
                     }
                 }
                 if let subtitle {
-                    // 11.5pt: half-step above label (11) for Settings subtitle hierarchy.
                     Text(subtitle)
-                        .font(.system(size: 11.5))
+                        .font(Typography.label)
                         .foregroundStyle(.white.opacity(0.55))
                 }
             }

--- a/Sources/Views/Settings/SettingsRow.swift
+++ b/Sources/Views/Settings/SettingsRow.swift
@@ -37,6 +37,7 @@ struct SettingsRow<Trailing: View>: View {
                             .frame(width: 7, height: 7)
                             .shadow(color: dot.opacity(0.7), radius: 4)
                             .alignmentGuide(.firstTextBaseline) { $0[VerticalAlignment.center] + 4 }
+                            .accessibilityHidden(true)
                     }
                     Text(title)
                         // 13.5pt sits between providerTitle (13) and unit (15) — Settings rows
@@ -55,6 +56,7 @@ struct SettingsRow<Trailing: View>: View {
                                 RoundedRectangle(cornerRadius: 3)
                                     .fill(.white.opacity(0.06))
                             )
+                            .accessibilityLabel("Plan: \(chip)")
                     }
                 }
                 if let subtitle {
@@ -64,6 +66,7 @@ struct SettingsRow<Trailing: View>: View {
                         .foregroundStyle(.white.opacity(0.55))
                 }
             }
+            .accessibilityElement(children: .combine)
 
             Spacer(minLength: 8)
 

--- a/Sources/Views/Settings/SettingsRow.swift
+++ b/Sources/Views/Settings/SettingsRow.swift
@@ -39,12 +39,14 @@ struct SettingsRow<Trailing: View>: View {
                             .alignmentGuide(.firstTextBaseline) { $0[VerticalAlignment.center] + 4 }
                     }
                     Text(title)
+                        // 13.5pt sits between providerTitle (13) and unit (15) — Settings rows
+                        // need a touch more presence than provider titles without the unit's weight.
                         .font(.system(size: 13.5, weight: .medium))
                         .tracking(-0.07)
                         .foregroundStyle(.white.opacity(0.92))
                     if let chip {
                         Text(chip)
-                            .font(.system(size: 9, weight: .bold).monospaced())
+                            .font(Typography.chip)
                             .tracking(0.8)
                             .foregroundStyle(.white.opacity(0.6))
                             .padding(.horizontal, 5)
@@ -56,6 +58,7 @@ struct SettingsRow<Trailing: View>: View {
                     }
                 }
                 if let subtitle {
+                    // 11.5pt: half-step above label (11) for Settings subtitle hierarchy.
                     Text(subtitle)
                         .font(.system(size: 11.5))
                         .foregroundStyle(.white.opacity(0.55))

--- a/Sources/Views/SettingsButton.swift
+++ b/Sources/Views/SettingsButton.swift
@@ -27,5 +27,6 @@ struct SettingsButton: View {
         .onHover { hovered = $0 }
         .help("Settings")
         .animation(.strongEaseOut, value: hovered)
+        .accessibilityLabel("Settings")
     }
 }

--- a/Sources/Views/SettingsButton.swift
+++ b/Sources/Views/SettingsButton.swift
@@ -13,7 +13,7 @@ struct SettingsButton: View {
             SettingsWindowController.shared.show()
         } label: {
             Image(systemName: "gearshape")
-                .font(.system(size: 11, weight: .semibold))
+                .font(Typography.button)
                 .symbolRenderingMode(.hierarchical)
                 .foregroundStyle(.white.opacity(hovered ? 0.64 : 0.34))
                 .frame(width: 26, height: 26)

--- a/Sources/Views/SettingsView.swift
+++ b/Sources/Views/SettingsView.swift
@@ -90,7 +90,7 @@ struct SettingsView: View {
             activeTab = tab
         } label: {
             Text(tab.label)
-                .font(.system(size: 12, weight: .medium))
+                .font(Typography.tabLabel)
                 .foregroundStyle(isOn
                     ? .white.opacity(0.95)
                     : .white.opacity(0.50))
@@ -146,14 +146,14 @@ struct SettingsView: View {
     private func sectionLabel(_ text: String, hint: String? = nil) -> some View {
         HStack(alignment: .firstTextBaseline) {
             Text(text)
-                .font(.system(size: 10.5, weight: .semibold))
+                .font(Typography.sectionLabel)
                 .tracking(1.05)
                 .textCase(.uppercase)
                 .foregroundStyle(.white.opacity(0.34))
             Spacer(minLength: 8)
             if let hint {
                 Text(hint)
-                    .font(.system(size: 9.5, weight: .medium))
+                    .font(Typography.micro)
                     .foregroundStyle(.white.opacity(0.18))
             }
         }
@@ -174,7 +174,7 @@ struct SettingsView: View {
             }
             SettingsRow(
                 title: "Refresh interval",
-                subtitle: "How often to re-check usage."
+                subtitle: "How often to refresh."
             ) {
                 refreshSegmented
             }
@@ -189,7 +189,7 @@ struct SettingsView: View {
             sectionLabel("Updates")
             SettingsRow(
                 title: "Check for updates automatically",
-                subtitle: "Sparkle checks the appcast in the background and prompts you when a new version ships."
+                subtitle: "Check for new versions in the background and notify you when one's available."
             ) {
                 SettingsToggle(isOn: updater.automaticallyChecks) {
                     updater.automaticallyChecks.toggle()
@@ -197,13 +197,13 @@ struct SettingsView: View {
             }
             SettingsRow(
                 title: "Check now",
-                subtitle: "Look for a new version right now."
+                subtitle: "Look for a new version immediately."
             ) {
                 Button {
                     updater.checkForUpdates()
                 } label: {
                     Text("Check")
-                        .font(.system(size: 11, weight: .semibold))
+                        .font(Typography.button)
                         .foregroundStyle(.white.opacity(0.9))
                         .padding(.horizontal, 12)
                         .padding(.vertical, 5)
@@ -259,13 +259,13 @@ struct SettingsView: View {
     private var costSection: some View {
         HStack(alignment: .center, spacing: 10) {
             Text("Cost")
-                .font(.system(size: 10.5, weight: .semibold))
+                .font(Typography.sectionLabel)
                 .tracking(1.05)
                 .textCase(.uppercase)
                 .foregroundStyle(.white.opacity(0.34))
 
             Text(costSubtitle())
-                .font(.system(size: 11))
+                .font(Typography.label)
                 .foregroundStyle(.white.opacity(0.42))
                 .lineLimit(1)
                 .truncationMode(.tail)
@@ -276,7 +276,7 @@ struct SettingsView: View {
                 cost.refresh()
             } label: {
                 Text(cost.loading ? "Refreshing…" : "Refresh")
-                    .font(.system(size: 11, weight: .semibold))
+                    .font(Typography.button)
                     .foregroundStyle(.white.opacity(0.9))
                     .padding(.horizontal, 12)
                     .padding(.vertical, 5)
@@ -303,12 +303,12 @@ struct SettingsView: View {
         guard let updated = cost.lastUpdated else { return "swipe panel to view" }
         let f = RelativeDateTimeFormatter()
         f.unitsStyle = .abbreviated
-        return "Last scan \(f.localizedString(for: updated, relativeTo: Date()))"
+        return "last scan \(f.localizedString(for: updated, relativeTo: Date()))"
     }
 
     private var chartSection: some View {
         VStack(alignment: .leading, spacing: 0) {
-            sectionLabel("Default chart", hint: "⌘-click in panel to cycle")
+            sectionLabel("Chart style", hint: "⌘-click to cycle")
             ChartStylePicker(selected: $stylePref.style)
                 .padding(.top, 4)
                 .padding(.horizontal, 10)
@@ -320,7 +320,7 @@ struct SettingsView: View {
 
     private var costStyleSection: some View {
         VStack(alignment: .leading, spacing: 0) {
-            sectionLabel("Default cost view", hint: "⌘-click in panel to cycle")
+            sectionLabel("Cost view", hint: "⌘-click to cycle")
             CostStylePicker(selected: $costStylePref.style)
                 .padding(.top, 4)
                 .padding(.horizontal, 10)
@@ -340,7 +340,7 @@ struct SettingsView: View {
                     refreshStore.seconds = value
                 } label: {
                     Text(label(for: value))
-                        .font(.system(size: 11, weight: .semibold).monospaced())
+                        .font(Typography.bodyNumber)
                         .foregroundStyle(isOn
                             ? Color.white.opacity(0.95)
                             : .white.opacity(0.55))

--- a/Sources/Views/SettingsView.swift
+++ b/Sources/Views/SettingsView.swift
@@ -34,20 +34,26 @@ struct SettingsView: View {
 
             hairline
 
-            Group {
-                switch activeTab {
-                case .general:   generalTab
-                case .display:   displayTab
-                case .providers: providersTab
+            // ScrollView guarantees the footer stays at the bottom of the
+            // window regardless of how much content the active tab has —
+            // overflow scrolls instead of pushing chrome off-screen.
+            ScrollView(.vertical, showsIndicators: false) {
+                Group {
+                    switch activeTab {
+                    case .general:   generalTab
+                    case .display:   displayTab
+                    case .providers: providersTab
+                    }
                 }
+                .frame(maxWidth: .infinity, alignment: .top)
             }
-            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
 
             hairline
 
             SettingsFooter(version: version)
         }
-        .frame(minWidth: 440, minHeight: 460)
+        .frame(minWidth: 440, minHeight: 420)
         .background(Color(red: 0.020, green: 0.020, blue: 0.027))
         .preferredColorScheme(.dark)
     }

--- a/Sources/Views/SettingsView.swift
+++ b/Sources/Views/SettingsView.swift
@@ -112,6 +112,8 @@ struct SettingsView: View {
         }
         .buttonStyle(.plain)
         .animation(.easeOut(duration: 0.12), value: isOn)
+        .accessibilityLabel("\(tab.label) tab")
+        .accessibilityAddTraits(isOn ? [.isButton, .isSelected] : .isButton)
     }
 
     // MARK: - Tab content
@@ -377,6 +379,8 @@ struct SettingsView: View {
                         }
                 }
                 .buttonStyle(.plain)
+                .accessibilityLabel("Refresh interval, \(label(for: value))")
+                .accessibilityAddTraits(isOn ? [.isButton, .isSelected] : .isButton)
             }
         }
         .padding(2)

--- a/Sources/Views/SettingsView.swift
+++ b/Sources/Views/SettingsView.swift
@@ -172,48 +172,59 @@ struct SettingsView: View {
         .padding(.bottom, 6)
     }
 
+    /// Single-row Cost section. Re-uses the section-label typography on the
+    /// left so it visually rhymes with the other section headers, but
+    /// inlines the freshness caption + refresh button on the right instead
+    /// of stacking a SettingsRow underneath. Saves ~70pt vs the expanded
+    /// section pattern, which keeps SettingsFooter on screen at 720pt.
     private var costSection: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            sectionLabel("Cost", hint: "swipe panel to view")
-            SettingsRow(
-                title: "Refresh now",
-                subtitle: costSubtitle()
-            ) {
-                Button {
-                    cost.refresh()
-                } label: {
-                    Text("Refresh")
-                        .font(.system(size: 11, weight: .semibold))
-                        .foregroundStyle(.white.opacity(0.9))
-                        .padding(.horizontal, 12)
-                        .padding(.vertical, 5)
-                        .background {
-                            RoundedRectangle(cornerRadius: 6)
-                                .fill(.white.opacity(0.10))
-                                .overlay {
-                                    RoundedRectangle(cornerRadius: 6)
-                                        .strokeBorder(.white.opacity(0.08), lineWidth: 0.5)
-                                }
-                        }
-                }
-                .buttonStyle(.plain)
-                .disabled(cost.loading)
-                .opacity(cost.loading ? 0.55 : 1)
+        HStack(alignment: .center, spacing: 10) {
+            Text("Cost")
+                .font(.system(size: 10.5, weight: .semibold))
+                .tracking(1.05)
+                .textCase(.uppercase)
+                .foregroundStyle(.white.opacity(0.34))
+
+            Text(costSubtitle())
+                .font(.system(size: 11))
+                .foregroundStyle(.white.opacity(0.42))
+                .lineLimit(1)
+                .truncationMode(.tail)
+
+            Spacer(minLength: 8)
+
+            Button {
+                cost.refresh()
+            } label: {
+                Text(cost.loading ? "Refreshing…" : "Refresh")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(.white.opacity(0.9))
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 5)
+                    .background {
+                        RoundedRectangle(cornerRadius: 6)
+                            .fill(.white.opacity(0.10))
+                            .overlay {
+                                RoundedRectangle(cornerRadius: 6)
+                                    .strokeBorder(.white.opacity(0.08), lineWidth: 0.5)
+                            }
+                    }
             }
+            .buttonStyle(.plain)
+            .disabled(cost.loading)
+            .opacity(cost.loading ? 0.55 : 1)
         }
-        .padding(.horizontal, 14)
+        .padding(.horizontal, 24)
         .padding(.top, 14)
         .padding(.bottom, 6)
     }
 
     private func costSubtitle() -> String {
-        if cost.loading { return "syncing local logs…" }
-        guard let updated = cost.lastUpdated else {
-            return "Re-scan ~/.claude/projects and ~/.codex/sessions."
-        }
+        if cost.loading { return "scanning local logs…" }
+        guard let updated = cost.lastUpdated else { return "swipe panel to view" }
         let f = RelativeDateTimeFormatter()
         f.unitsStyle = .abbreviated
-        return "Last scan \(f.localizedString(for: updated, relativeTo: Date()))."
+        return "Last scan \(f.localizedString(for: updated, relativeTo: Date()))"
     }
 
     private var chartSection: some View {

--- a/Sources/Views/SettingsView.swift
+++ b/Sources/Views/SettingsView.swift
@@ -17,6 +17,7 @@ struct SettingsView: View {
     @ObservedObject private var visibility = ProviderVisibilityStore.shared
     @ObservedObject private var refreshStore = RefreshIntervalStore.shared
     @ObservedObject private var usage = UsageStore.shared
+    @ObservedObject private var cost = CostStore.shared
     @ObservedObject private var updater = UpdaterController.shared
 
     private var version: String {
@@ -36,6 +37,7 @@ struct SettingsView: View {
             generalSection
             updatesSection
             providersSection
+            costSection
             chartSection
 
             Spacer(minLength: 0)
@@ -168,6 +170,50 @@ struct SettingsView: View {
         .padding(.horizontal, 14)
         .padding(.top, 14)
         .padding(.bottom, 6)
+    }
+
+    private var costSection: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            sectionLabel("Cost", hint: "swipe panel to view")
+            SettingsRow(
+                title: "Refresh now",
+                subtitle: costSubtitle()
+            ) {
+                Button {
+                    cost.refresh()
+                } label: {
+                    Text("Refresh")
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundStyle(.white.opacity(0.9))
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 5)
+                        .background {
+                            RoundedRectangle(cornerRadius: 6)
+                                .fill(.white.opacity(0.10))
+                                .overlay {
+                                    RoundedRectangle(cornerRadius: 6)
+                                        .strokeBorder(.white.opacity(0.08), lineWidth: 0.5)
+                                }
+                        }
+                }
+                .buttonStyle(.plain)
+                .disabled(cost.loading)
+                .opacity(cost.loading ? 0.55 : 1)
+            }
+        }
+        .padding(.horizontal, 14)
+        .padding(.top, 14)
+        .padding(.bottom, 6)
+    }
+
+    private func costSubtitle() -> String {
+        if cost.loading { return "syncing local logs…" }
+        guard let updated = cost.lastUpdated else {
+            return "Re-scan ~/.claude/projects and ~/.codex/sessions."
+        }
+        let f = RelativeDateTimeFormatter()
+        f.unitsStyle = .abbreviated
+        return "Last scan \(f.localizedString(for: updated, relativeTo: Date()))."
     }
 
     private var chartSection: some View {

--- a/Sources/Views/SettingsView.swift
+++ b/Sources/Views/SettingsView.swift
@@ -303,12 +303,28 @@ struct SettingsView: View {
         .padding(.bottom, 14)
     }
 
+    /// Days past the embedded pricing snapshot before the Cost section
+    /// admits the data may be stale. Anthropic re-tiered Opus once already,
+    /// so two months without a refresh is the point where dollar totals
+    /// could meaningfully drift from reality.
+    private static let pricingFreshnessThreshold = 60
+
     private func costSubtitle() -> String {
-        if cost.loading { return "scanning local logs…" }
-        guard let updated = cost.lastUpdated else { return "swipe panel to view" }
-        let f = RelativeDateTimeFormatter()
-        f.unitsStyle = .abbreviated
-        return "last scan \(f.localizedString(for: updated, relativeTo: Date()))"
+        let base: String
+        if cost.loading {
+            base = "scanning local logs…"
+        } else if let updated = cost.lastUpdated {
+            let f = RelativeDateTimeFormatter()
+            f.unitsStyle = .abbreviated
+            base = "last scan \(f.localizedString(for: updated, relativeTo: Date()))"
+        } else {
+            base = "swipe panel to view"
+        }
+        let days = Pricing.daysSinceSnapshot
+        if days > Self.pricingFreshnessThreshold {
+            return base + " · pricing data \(days)d old"
+        }
+        return base
     }
 
     private var chartSection: some View {

--- a/Sources/Views/SettingsView.swift
+++ b/Sources/Views/SettingsView.swift
@@ -16,7 +16,12 @@ struct SettingsView: View {
     @ObservedObject private var cost = CostStore.shared
     @ObservedObject private var updater = UpdaterController.shared
 
-    @State private var activeTab: SettingsTab = .general
+    @AppStorage("Settings.activeTab") private var activeTabRaw: String = SettingsTab.general.rawValue
+
+    private var activeTab: SettingsTab {
+        get { SettingsTab(rawValue: activeTabRaw) ?? .general }
+        nonmutating set { activeTabRaw = newValue.rawValue }
+    }
 
     private var version: String {
         Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? ""

--- a/Sources/Views/SettingsView.swift
+++ b/Sources/Views/SettingsView.swift
@@ -1,24 +1,22 @@
 import SwiftUI
 import AppKit
 
-/// Settings window content. Composed of six zones:
-///   1. Brand header — notch silhouette + name + tagline + version pill
-///   2. General — Launch at Login, Refresh interval
-///   3. Providers — Claude / Codex per-provider visibility
-///   4. Default chart — 5-tile picker (replaces the buried ⌘-click cycle)
-///   5. Footer — version + GitHub + License + Quit
-///
-/// All sections sit on the same near-black surface (#050507) and are
-/// separated by hairline gradient dividers. No bordered cards — rows lift
-/// to a faint white wash on hover instead.
+/// Settings window — three tabs (General / Display / Providers) sandwiched
+/// between a fixed brand header on top and the version/links/Quit footer
+/// on the bottom. Tabs let each topical group stay short enough to fit a
+/// modest window without scrolling, and the window itself is now resizable
+/// rather than locked at 480×720, so the user controls the visible space.
 struct SettingsView: View {
     @ObservedObject private var launchStore = LaunchAtLoginStore.shared
     @ObservedObject private var stylePref = StylePref.shared
+    @ObservedObject private var costStylePref = CostStylePref.shared
     @ObservedObject private var visibility = ProviderVisibilityStore.shared
     @ObservedObject private var refreshStore = RefreshIntervalStore.shared
     @ObservedObject private var usage = UsageStore.shared
     @ObservedObject private var cost = CostStore.shared
     @ObservedObject private var updater = UpdaterController.shared
+
+    @State private var activeTab: SettingsTab = .general
 
     private var version: String {
         Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? ""
@@ -32,23 +30,100 @@ struct SettingsView: View {
 
             BrandHeader(version: version)
 
+            tabBar
+
             hairline
 
-            generalSection
-            updatesSection
-            providersSection
-            costSection
-            chartSection
-
-            Spacer(minLength: 0)
+            Group {
+                switch activeTab {
+                case .general:   generalTab
+                case .display:   displayTab
+                case .providers: providersTab
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
 
             hairline
 
             SettingsFooter(version: version)
         }
-        .frame(width: 480, height: 720)
+        .frame(minWidth: 440, minHeight: 460)
         .background(Color(red: 0.020, green: 0.020, blue: 0.027))
         .preferredColorScheme(.dark)
+    }
+
+    // MARK: - Tabs
+
+    enum SettingsTab: String, CaseIterable {
+        case general, display, providers
+
+        var label: String {
+            switch self {
+            case .general:   "General"
+            case .display:   "Display"
+            case .providers: "Providers"
+            }
+        }
+    }
+
+    private var tabBar: some View {
+        HStack(spacing: 4) {
+            ForEach(SettingsTab.allCases, id: \.self) { tab in
+                tabButton(tab)
+            }
+        }
+        .padding(.horizontal, 18)
+        .padding(.top, 4)
+        .padding(.bottom, 10)
+    }
+
+    @ViewBuilder
+    private func tabButton(_ tab: SettingsTab) -> some View {
+        let isOn = (activeTab == tab)
+        Button {
+            activeTab = tab
+        } label: {
+            Text(tab.label)
+                .font(.system(size: 12, weight: .medium))
+                .foregroundStyle(isOn
+                    ? .white.opacity(0.95)
+                    : .white.opacity(0.50))
+                .padding(.horizontal, 12)
+                .padding(.vertical, 6)
+                .background {
+                    RoundedRectangle(cornerRadius: 6)
+                        .fill(isOn ? .white.opacity(0.08) : .clear)
+                        .overlay {
+                            RoundedRectangle(cornerRadius: 6)
+                                .strokeBorder(.white.opacity(isOn ? 0.08 : 0), lineWidth: 0.5)
+                        }
+                }
+        }
+        .buttonStyle(.plain)
+        .animation(.easeOut(duration: 0.12), value: isOn)
+    }
+
+    // MARK: - Tab content
+
+    private var generalTab: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            generalSection
+            updatesSection
+        }
+    }
+
+    private var displayTab: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            chartSection
+            costStyleSection
+        }
+    }
+
+    private var providersTab: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            providersSection
+            costSection
+        }
     }
 
     // MARK: - Pieces
@@ -168,15 +243,13 @@ struct SettingsView: View {
             }
         }
         .padding(.horizontal, 14)
-        .padding(.top, 14)
+        .padding(.top, 18)
         .padding(.bottom, 6)
     }
 
     /// Single-row Cost section. Re-uses the section-label typography on the
-    /// left so it visually rhymes with the other section headers, but
-    /// inlines the freshness caption + refresh button on the right instead
-    /// of stacking a SettingsRow underneath. Saves ~70pt vs the expanded
-    /// section pattern, which keeps SettingsFooter on screen at 720pt.
+    /// left and inlines the freshness caption + refresh button on the right
+    /// — compact so it sits cleanly under the Providers list.
     private var costSection: some View {
         HStack(alignment: .center, spacing: 10) {
             Text("Cost")
@@ -216,7 +289,7 @@ struct SettingsView: View {
         }
         .padding(.horizontal, 24)
         .padding(.top, 14)
-        .padding(.bottom, 6)
+        .padding(.bottom, 14)
     }
 
     private func costSubtitle() -> String {
@@ -231,6 +304,18 @@ struct SettingsView: View {
         VStack(alignment: .leading, spacing: 0) {
             sectionLabel("Default chart", hint: "⌘-click in panel to cycle")
             ChartStylePicker(selected: $stylePref.style)
+                .padding(.top, 4)
+                .padding(.horizontal, 10)
+        }
+        .padding(.horizontal, 14)
+        .padding(.top, 18)
+        .padding(.bottom, 14)
+    }
+
+    private var costStyleSection: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            sectionLabel("Default cost view", hint: "⌘-click in panel to cycle")
+            CostStylePicker(selected: $costStylePref.style)
                 .padding(.top, 4)
                 .padding(.horizontal, 10)
         }

--- a/Sources/Views/SettingsWindowController.swift
+++ b/Sources/Views/SettingsWindowController.swift
@@ -13,7 +13,7 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
     private init() {
         let hosting = NSHostingController(rootView: SettingsView())
         let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 480, height: 540),
+            contentRect: NSRect(x: 0, y: 0, width: 480, height: 620),
             styleMask: [.titled, .closable, .resizable, .fullSizeContentView],
             backing: .buffered,
             defer: false
@@ -26,7 +26,7 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
         window.backgroundColor = NSColor(
             calibratedRed: 0.075, green: 0.077, blue: 0.090, alpha: 1
         )
-        window.minSize = NSSize(width: 440, height: 460)
+        window.minSize = NSSize(width: 440, height: 420)
         // Hide the dock-stow button (we have no dock icon) but keep zoom
         // alongside resize handles so the user controls size.
         window.standardWindowButton(.miniaturizeButton)?.isHidden = true

--- a/Sources/Views/SettingsWindowController.swift
+++ b/Sources/Views/SettingsWindowController.swift
@@ -13,8 +13,8 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
     private init() {
         let hosting = NSHostingController(rootView: SettingsView())
         let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 400, height: 340),
-            styleMask: [.titled, .closable, .fullSizeContentView],
+            contentRect: NSRect(x: 0, y: 0, width: 480, height: 540),
+            styleMask: [.titled, .closable, .resizable, .fullSizeContentView],
             backing: .buffered,
             defer: false
         )
@@ -26,10 +26,10 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
         window.backgroundColor = NSColor(
             calibratedRed: 0.075, green: 0.077, blue: 0.090, alpha: 1
         )
-        // Hide miniaturize/zoom buttons — settings has no business being
-        // resized or stowed in the dock (we have no dock icon).
+        window.minSize = NSSize(width: 440, height: 460)
+        // Hide the dock-stow button (we have no dock icon) but keep zoom
+        // alongside resize handles so the user controls size.
         window.standardWindowButton(.miniaturizeButton)?.isHidden = true
-        window.standardWindowButton(.zoomButton)?.isHidden = true
         window.center()
         super.init(window: window)
         window.delegate = self

--- a/Sources/Views/UsageView.swift
+++ b/Sources/Views/UsageView.swift
@@ -1,189 +1,43 @@
 import SwiftUI
 import AppKit
 
+/// Usage data row — two ChartsBlocks (Claude / Codex) with a hairline
+/// vertical divider. The chrome (provider titles, footer chip + page dots
+/// + sync status) lives in `PanelHeader` / `PanelFooter` so it stays fixed
+/// while this row swipes between usage and cost screens.
 struct UsageView: View {
-    let notch: NotchInfo
     @ObservedObject private var store = UsageStore.shared
     @ObservedObject private var pref = StylePref.shared
     @ObservedObject private var visibility = ProviderVisibilityStore.shared
-    @ObservedObject private var screenPref = ScreenPref.shared
 
     private var style: ChartStyle { pref.style }
 
     var body: some View {
-        VStack(spacing: 0) {
-            // Top row: provider titles aligned with the system menu bar
-            // (height = 22, the menu-bar item height). The notch-width
-            // spacer in the middle hides inside the physical notch.
-            HStack(spacing: 0) {
-                providerTitle(name: "Claude", tag: store.claude.plan?.uppercased(),
-                              color: IslandColor.claude, alignment: .leading)
-                    .opacity(visibility.claudeVisible ? 1 : 0.30)
-                    .saturation(visibility.claudeVisible ? 1 : 0)
-                Color.clear.frame(width: notch.width)
-                providerTitle(name: "Codex", tag: store.codex.plan?.uppercased(),
-                              color: IslandColor.codex, alignment: .trailing)
-                    .opacity(visibility.codexVisible ? 1 : 0.30)
-                    .saturation(visibility.codexVisible ? 1 : 0)
-            }
-            .frame(height: 22)
-            .padding(.horizontal, 16)
-            .padding(.top, 4)
-            .padding(.bottom, max(0, notch.height - 22 - 4))
-
-            // Charts row: two ChartsBlocks with a 1pt vertical gradient
-            // hairline divider. .clear → 6% white → .clear so the divider
-            // fades at top and bottom.
-            HStack(spacing: 0) {
-                ChartsBlock(
-                    color: visibility.claudeVisible ? IslandColor.claude : .white.opacity(0.32),
-                    usage: visibility.claudeVisible ? store.claude : .dummy,
-                    style: style, seed: 1
-                )
-                .opacity(visibility.claudeVisible ? 1 : 0.55)
-                Rectangle()
-                    .fill(LinearGradient(
-                        colors: [.clear, .white.opacity(0.06), .clear],
-                        startPoint: .top, endPoint: .bottom
-                    ))
-                    .frame(width: 1)
-                    .padding(.vertical, 8)
-                ChartsBlock(
-                    color: visibility.codexVisible ? IslandColor.codex : .white.opacity(0.32),
-                    usage: visibility.codexVisible ? store.codex : .dummy,
-                    style: style, seed: 3
-                )
-                .opacity(visibility.codexVisible ? 1 : 0.55)
-            }
-            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
-            .padding(.horizontal, 22)
-            .padding(.top, 12)
-            .padding(.bottom, 6)
-
-            // Footer: hairline divider + style chip + cmd-click hint
-            // (always visible here; hidden after first cycle in a later
-            // commit) + live-status indicator on the right.
-            LinearGradient(
-                colors: [.clear, .white.opacity(0.06), .white.opacity(0.06), .clear],
-                startPoint: .leading, endPoint: .trailing
+        HStack(spacing: 0) {
+            ChartsBlock(
+                color: visibility.claudeVisible ? IslandColor.claude : .white.opacity(0.32),
+                usage: visibility.claudeVisible ? store.claude : .dummy,
+                style: style, seed: 1
             )
-            .frame(height: 1)
-            .padding(.horizontal, 22)
-
-            HStack(spacing: 10) {
-                Text(style.label.uppercased())
-                    .font(.system(size: 9, weight: .bold).monospaced())
-                    .tracking(0.8)
-                    .foregroundStyle(.white.opacity(0.78))
-                    .padding(.horizontal, 6)
-                    .padding(.vertical, 2.5)
-                    .background(
-                        RoundedRectangle(cornerRadius: 4)
-                            .fill(.white.opacity(0.08))
-                            .overlay(
-                                RoundedRectangle(cornerRadius: 4)
-                                    .strokeBorder(.white.opacity(0.10), lineWidth: 0.5)
-                            )
-                    )
-                    .contentTransition(.opacity)
-                    .animation(.strongEaseOut, value: pref.style)
-
-                if !pref.hasCycledStyle {
-                    HStack(spacing: 5) {
-                        Image(systemName: "command")
-                            .font(.system(size: 10, weight: .semibold))
-                        Text("click to cycle")
-                            .font(.system(size: 11))
-                    }
-                    .foregroundStyle(.white.opacity(0.42))
-                    // Fade + small scale-from-leading on the way out so the
-                    // hint deflates toward the chip rather than just vanishing.
-                    .transition(.opacity.combined(with: .scale(scale: 0.92, anchor: .leading)))
-                }
-
-                Spacer()
-
-                PageIndicator(active: screenPref.screen)
-
-                HStack(spacing: 6) {
-                    LiveDot(active: store.lastUpdated != nil && !store.loading)
-                    if store.loading {
-                        Text("syncing…")
-                            .font(.system(size: 11))
-                            .foregroundStyle(.white.opacity(0.55))
-                    } else if let updated = store.lastUpdated {
-                        Text("synced")
-                            .font(.system(size: 11))
-                            .foregroundStyle(.white.opacity(0.55))
-                        Text(relative(updated))
-                            .font(.system(size: 11).monospacedDigit())
-                            .foregroundStyle(.white.opacity(0.72))
-                    } else {
-                        Text("idle")
-                            .font(.system(size: 11))
-                            .foregroundStyle(.white.opacity(0.4))
-                    }
-                }
-            }
-            .padding(.horizontal, 22)
-            .padding(.top, 6)
-            .padding(.bottom, 10)
-            .animation(.strongEaseOut, value: pref.hasCycledStyle)
+            .opacity(visibility.claudeVisible ? 1 : 0.55)
+            Rectangle()
+                .fill(LinearGradient(
+                    colors: [.clear, .white.opacity(0.06), .clear],
+                    startPoint: .top, endPoint: .bottom
+                ))
+                .frame(width: 1)
+                .padding(.vertical, 8)
+            ChartsBlock(
+                color: visibility.codexVisible ? IslandColor.codex : .white.opacity(0.32),
+                usage: visibility.codexVisible ? store.codex : .dummy,
+                style: style, seed: 3
+            )
+            .opacity(visibility.codexVisible ? 1 : 0.55)
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-    }
-
-    private func relative(_ d: Date) -> String {
-        let f = RelativeDateTimeFormatter()
-        f.unitsStyle = .abbreviated
-        return f.localizedString(for: d, relativeTo: Date())
-    }
-
-    @ViewBuilder
-    private func providerTitle(
-        name: String,
-        tag: String?,
-        color: Color,
-        alignment: HorizontalAlignment
-    ) -> some View {
-        // Push past where the overlay logo lands: 9 leading + 20 logo + 8 gap.
-        let logoOffset: CGFloat = 9 + 20 + 8
-
-        let content = HStack(spacing: 8) {
-            Text(name)
-                .font(.system(size: 13, weight: .semibold))
-                .foregroundStyle(.white)
-            if let tag {
-                Text(tag)
-                    .font(.system(size: 9, weight: .bold).monospaced())
-                    .tracking(0.8)
-                    .foregroundStyle(.white.opacity(0.6))
-                    .padding(.horizontal, 5)
-                    .padding(.vertical, 2)
-                    .background(
-                        RoundedRectangle(cornerRadius: 3)
-                            .fill(.white.opacity(0.06))
-                            .overlay(
-                                RoundedRectangle(cornerRadius: 3)
-                                    .strokeBorder(.white.opacity(0.08), lineWidth: 0.5)
-                            )
-                    )
-            }
-        }
-
-        if alignment == .leading {
-            HStack {
-                content.padding(.leading, logoOffset)
-                Spacer(minLength: 0)
-            }
-            .frame(maxWidth: .infinity)
-        } else {
-            HStack {
-                Spacer(minLength: 0)
-                content.padding(.trailing, logoOffset)
-            }
-            .frame(maxWidth: .infinity)
-        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        .padding(.horizontal, 22)
+        .padding(.top, 12)
+        .padding(.bottom, 6)
     }
 }
 

--- a/Sources/Views/UsageView.swift
+++ b/Sources/Views/UsageView.swift
@@ -90,6 +90,9 @@ struct ChartTile: View {
         .transition(.chartSwap.animation(.chartSwap))
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .frame(height: Self.tileHeight)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(label), \(Int(value))%")
+        .accessibilityValue(subCaption())
     }
 
     private func subCaption() -> String {

--- a/Sources/Window/IslandHostingView.swift
+++ b/Sources/Window/IslandHostingView.swift
@@ -12,6 +12,11 @@ import SwiftUI
 final class IslandHostingView: NSHostingView<IslandRootView> {
     let islandModel: IslandModel
 
+    /// Accumulated horizontal scroll delta for the in-flight two-finger swipe.
+    /// Reset on `.began`, evaluated on `.ended`.
+    private var swipeAccumX: CGFloat = 0
+    private var swipeAccumY: CGFloat = 0
+
     init(rootView: IslandRootView, model: IslandModel) {
         self.islandModel = model
         super.init(rootView: rootView)
@@ -35,5 +40,43 @@ final class IslandHostingView: NSHostingView<IslandRootView> {
             height: size.height
         )
         return rect.contains(point) ? super.hitTest(point) : nil
+    }
+
+    /// Two-finger trackpad swipe → page change. Only fires when the panel is
+    /// expanded and the gesture is horizontal-dominant. Uses
+    /// `hasPreciseScrollingDeltas` to filter out mouse-wheel ticks (which
+    /// shouldn't be page-changers — only gestures should).
+    override func scrollWheel(with event: NSEvent) {
+        guard event.hasPreciseScrollingDeltas,
+              islandModel.state == .expanded else {
+            super.scrollWheel(with: event)
+            return
+        }
+
+        if event.phase == .began {
+            swipeAccumX = 0
+            swipeAccumY = 0
+        }
+        swipeAccumX += event.scrollingDeltaX
+        swipeAccumY += event.scrollingDeltaY
+
+        guard event.phase == .ended else { return }
+
+        // Threshold tuned to feel like a single deliberate swipe (~1/4 inch
+        // of finger travel) without firing on a small horizontal nudge that
+        // crept into a vertical scroll.
+        let threshold: CGFloat = 60
+        defer { swipeAccumX = 0; swipeAccumY = 0 }
+        guard abs(swipeAccumX) > abs(swipeAccumY),
+              abs(swipeAccumX) > threshold else { return }
+
+        // Natural-scrolling convention: physical swipe-left → negative
+        // deltaX → advance to next page (cost screen sits "to the right" of
+        // the usage screen, like an iOS Home Screen page 2).
+        if swipeAccumX < 0 {
+            ScreenPref.shared.advance()
+        } else {
+            ScreenPref.shared.rewind()
+        }
     }
 }


### PR DESCRIPTION
## Summary

Adds a second screen to the panel — accessible via two-finger trackpad swipe — that scans local Claude/Codex logs and surfaces them as priced totals. Restructures Settings into tabs to make room for the new picker, and lays down a real type system on the way out.

**Cost screen (new)**
- Scans `~/.claude/projects/**/conversation.jsonl` and Codex `rollout-*.jsonl` files into per-day/per-month dollar totals, persisted to UserDefaults for instant first paint.
- Cmd-click cycles 4 hero visualizations: **USD** (count-up dollar), **VALUE** (per-plan bar chart vs. Pro/Max/Plus baseline), **TOKENS** (big k/M/B figure), **TREND** (cumulative spend sparkline).
- Auto-derives the plan baseline per-provider per-plan from `UsageStore`'s plan tag — Claude Pro $20 / Max $200, Codex Plus $20 / Pro $200. Free / unknown plans skip the multiplier.
- Two-finger trackpad swipe + page dots in the footer; edge-clamped so the rightmost screen doesn't wrap.

**Settings redesign**
- Three tabs: **General** (Launch at Login, Refresh interval, Updates), **Display** (chart style + cost view pickers), **Providers** (Claude/Codex visibility, Cost refresh).
- Window is now `.resizable` with a ScrollView wrapper so the footer stays pinned regardless of tab content height. Default 480×620, min 440×420.

**Typography pass**
- The `Typography` enum existed but nothing referenced it. Rebuilt as 8 tokens across 6 visual tiers (no half-points). Hero numerics adopt SF Mono so the display digits — which are the brand here — have actual character vs. the generic system look.

**Microcopy**
- Drops Sparkle/appcast jargon from the auto-update settings.
- "Default chart" → "Chart style"; "Default cost view" → "Cost view" (the picker IS the source of truth, not just a default).
- Lowercase \`last scan 2m ago\` matches the other subtitles in the same view.

## Test plan

No automated test suite (SwiftUI macOS app). Smoke checks:
- [x] \`./build.sh\` succeeds — universal binary, ad-hoc signed
- [ ] Click the notch → panel expands; swipe right reveals cost screen
- [ ] Cmd-click on cost panel cycles USD → VALUE → TOKENS → TREND; chip in footer updates
- [ ] Settings: all three tabs render without footer clipping at 480×620 default
- [ ] Settings: window resizes down to 440×420 min, content scrolls instead of clipping
- [ ] Settings → Display: both pickers render previews; selection persists across launch
- [ ] Heavy-day overflow check: \`\$1234.56\` Today total in SF Mono — confirm no clipping in the cell
- [ ] Refresh interval segmented control still gates polling at 5m/15m/30m

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added local cost tracking for Claude and Codex with automatic background refresh at launch
  * New Cost screen with tiles, multiple display styles (dollar, comparison, tokens, sparkline), sparklines, and animated count-up dollars
  * Two-page swipe navigation between Usage and Cost

* **Style**
  * Overhauled typography tokens for consistency
  * Refined chart segments and visuals

* **Accessibility**
  * Improved labels and accessibility behavior across controls

* **Chores**
  * Settings reorganized into tabs and made resizable
<!-- end of auto-generated comment: release notes by coderabbit.ai -->