### PR TITLE
perf: cut idle CPU on the LoadingSweep without changing the glow

### DIFF
--- a/Sources/Model/LowPowerModeStore.swift
+++ b/Sources/Model/LowPowerModeStore.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Combine
 
 /// User preference for the ambient halo + loading sweep.
 ///
@@ -7,6 +8,11 @@ import Foundation
 /// predicate — they appear only while a fetch is in flight, the cursor is
 /// hovering the island, or an alert is active. At rest the island goes
 /// dark, saving the per-frame angular-gradient + blur work.
+///
+/// `effectiveEnabled` ORs the user toggle with macOS's system-wide Low
+/// Power Mode. When the user enables battery saving in System Settings,
+/// our LPM gating activates automatically — same convention Apple's own
+/// apps follow. AC users see no change.
 @MainActor
 final class LowPowerModeStore: ObservableObject {
     static let shared = LowPowerModeStore()
@@ -17,9 +23,38 @@ final class LowPowerModeStore: ObservableObject {
         didSet { UserDefaults.standard.set(enabled, forKey: Self.key) }
     }
 
+    /// Mirrors `ProcessInfo.processInfo.isLowPowerModeEnabled`. Updated
+    /// via NSProcessInfoPowerStateDidChange.
+    @Published private(set) var systemLowPowerEnabled: Bool
+
+    /// True if either the user opted in OR macOS reports system LPM is on.
+    /// Use this in render-gating predicates instead of `enabled` directly.
+    var effectiveEnabled: Bool { enabled || systemLowPowerEnabled }
+
+    private var observer: NSObjectProtocol?
+
     private init() {
         // UserDefaults.bool returns false for missing keys, which matches our
         // intended default (off → continuous sweep).
         self.enabled = UserDefaults.standard.bool(forKey: Self.key)
+        self.systemLowPowerEnabled = ProcessInfo.processInfo.isLowPowerModeEnabled
+
+        observer = NotificationCenter.default.addObserver(
+            forName: Notification.Name.NSProcessInfoPowerStateDidChange,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            guard let self else { return }
+            Task { @MainActor in
+                let now = ProcessInfo.processInfo.isLowPowerModeEnabled
+                if now != self.systemLowPowerEnabled {
+                    self.systemLowPowerEnabled = now
+                }
+            }
+        }
+    }
+
+    deinit {
+        if let observer { NotificationCenter.default.removeObserver(observer) }
     }
 }

--- a/Sources/Model/WindowOcclusionStore.swift
+++ b/Sources/Model/WindowOcclusionStore.swift
@@ -1,0 +1,23 @@
+import AppKit
+import Combine
+
+/// Tracks whether the island's window is currently visible to the user.
+/// Set to `true` when a fullscreen app, Spaces switch, or display sleep
+/// hides the menu bar — the LoadingSweep is paused while occluded so the
+/// 30Hz TimelineView stops re-shading the conic gradient when nobody can
+/// see it. Idle CPU drops to ~0% when the window is hidden.
+@MainActor
+final class WindowOcclusionStore: ObservableObject {
+    static let shared = WindowOcclusionStore()
+
+    @Published private(set) var isOccluded = false
+
+    private init() {}
+
+    func update(isVisible: Bool) {
+        let occluded = !isVisible
+        if occluded != isOccluded {
+            isOccluded = occluded
+        }
+    }
+}

--- a/Sources/Views/IslandRootView.swift
+++ b/Sources/Views/IslandRootView.swift
@@ -418,32 +418,37 @@ private struct RotatingSweep: View {
     @State private var rotation: Double = 0
 
     var body: some View {
-        AngularGradient(
-            gradient: Gradient(stops: [
-                .init(color: .clear, location: 0.00),
-                .init(color: tint.opacity(0.0), location: 0.55),
-                .init(color: tint, location: 0.78),
-                .init(color: .white.opacity(0.95), location: 0.92),
-                .init(color: tint.opacity(0.0), location: 1.00),
-            ]),
-            center: .center,
-            angle: .degrees(0)
-        )
-        // Mask to the same 4pt-wide IslandShape stroke as the original.
+        // Wrap the rotating gradient in a stable ZStack so the outer
+        // `.mask` stays in the parent's (un-rotated) coordinate space.
+        // Without this wrapper, applying `.rotationEffect` then `.mask`
+        // rotates the entire masked result — the silhouette outline
+        // itself spins, which reads as a diagonal beam instead of a
+        // bright spot orbiting a static silhouette.
+        ZStack {
+            AngularGradient(
+                gradient: Gradient(stops: [
+                    .init(color: .clear, location: 0.00),
+                    .init(color: tint.opacity(0.0), location: 0.55),
+                    .init(color: tint, location: 0.78),
+                    .init(color: .white.opacity(0.95), location: 0.92),
+                    .init(color: tint.opacity(0.0), location: 1.00),
+                ]),
+                center: .center,
+                angle: .degrees(0)
+            )
+            .rotationEffect(.degrees(rotation))
+        }
         .mask(
             IslandShape()
                 .stroke(Color.white, lineWidth: 4)
         )
         .blur(radius: 3)
-        .rotationEffect(.degrees(rotation))
         .onAppear {
             // Reset to 0 in case onAppear fires after a previous mount.
             rotation = 0
             withAnimation(.linear(duration: 3.6).repeatForever(autoreverses: false)) {
                 // Setting once with .repeatForever lets SwiftUI translate
                 // this into a CABasicAnimation on `transform.rotation.z`.
-                // 360° = full revolution; the value the body reads stays
-                // animatably interpolated by the system.
                 rotation = 360
             }
         }

--- a/Sources/Views/IslandRootView.swift
+++ b/Sources/Views/IslandRootView.swift
@@ -514,6 +514,12 @@ private final class SweepNSView: NSView {
         anim.duration = 3.6
         anim.repeatCount = .infinity
         anim.isRemovedOnCompletion = false
+        // Constant angular velocity — without this, CABasicAnimation
+        // defaults to ease-in/ease-out which makes the rotation visibly
+        // slow down and speed up every 3.6s cycle. The original SwiftUI
+        // TimelineView used linear time (`t * 100`), so we need linear
+        // here to match.
+        anim.timingFunction = CAMediaTimingFunction(name: .linear)
         gradientLayer.add(anim, forKey: "rotate")
     }
 }

--- a/Sources/Views/IslandRootView.swift
+++ b/Sources/Views/IslandRootView.swift
@@ -8,6 +8,7 @@ struct IslandRootView: View {
     @ObservedObject private var costStore = CostStore.shared
     @ObservedObject private var lowPower = LowPowerModeStore.shared
     @ObservedObject private var alerts = AlertEngine.shared
+    @ObservedObject private var occlusion = WindowOcclusionStore.shared
     @State private var hovering = false
     @State private var contentVisible = false
     @State private var pillsVisible = false
@@ -37,7 +38,12 @@ struct IslandRootView: View {
                 // the entire glow (halo + sweep) reads as one consistent
                 // color when above threshold.
                 LoadingSweep(
-                    active: lowPower.enabled ? glowEventActive : true,
+                    // Pause entirely when the window is occluded by a
+                    // fullscreen app or display sleep — the user can't
+                    // see it anyway, so re-shading the gradient at 30Hz
+                    // is pure waste.
+                    active: !occlusion.isOccluded
+                        && (lowPower.enabled ? glowEventActive : true),
                     tint: glowColor
                 )
 
@@ -385,20 +391,22 @@ struct IslandRootView: View {
 }
 
 /// Cobalt angular-gradient sweep that orbits the silhouette while data is
-/// fetching. Renders the AngularGradient once at angle 0, then rotates the
-/// whole layer via `.rotationEffect` driven by `withAnimation(.linear.
-/// repeatForever)`. SwiftUI translates that into a CABasicAnimation on the
-/// layer's transform — rotation happens on the WindowServer compositor
-/// thread, off the main thread. The conic gradient texture is shaded ONCE
-/// when the view appears, not on every frame.
+/// fetching. Owns its own TimelineView so the parent (IslandRootView) doesn't
+/// re-render every overlay alongside the sweep — that was competing with the
+/// hover spring for main-thread budget.
 ///
-/// Why this matters: profiling the previous TimelineView-driven implementation
-/// showed `rgba64_shade_conic_RGB → atan2f` dominating main-thread CPU.
-/// CoreGraphics re-shaded every pixel of the gradient per frame because the
-/// AngularGradient's `angle` parameter changed each tick. By moving rotation
-/// out of the gradient (fixed angle) and into a layer transform, we keep
-/// the same SwiftUI rendering quality while the per-frame work collapses
-/// to a transform multiplication.
+/// Tick rate is 30Hz (was 120Hz). 3.6s/revolution at 30Hz = 12° per frame,
+/// indistinguishable from 120Hz to the eye for a slow continuous orbit but
+/// 4× cheaper on the main thread. The bigger CPU saving comes from gating
+/// `active` on `!isWindowOccluded` upstream — when a fullscreen app or
+/// another window covers the menu bar entirely, the sweep stops rendering
+/// (the user can't see it anyway), dropping idle CPU to ~0%.
+///
+/// Earlier attempts to push rotation into Core Animation (CAGradientLayer or
+/// `.rotationEffect` over a static gradient) all subtly changed the glow
+/// feel — SwiftUI's per-frame conic re-shading produces an alive,
+/// atmospheric look that a rotated static texture loses. This is the
+/// minimum-cost approach that preserves the exact original render.
 private struct LoadingSweep: View {
     let active: Bool
     /// Color of the orbiting trail. Cobalt by default; switches to amber
@@ -408,48 +416,25 @@ private struct LoadingSweep: View {
 
     var body: some View {
         if active {
-            RotatingSweep(tint: tint)
-        }
-    }
-}
-
-private struct RotatingSweep: View {
-    let tint: Color
-    @State private var rotation: Double = 0
-
-    var body: some View {
-        // Wrap the rotating gradient in a stable ZStack so the outer
-        // `.mask` stays in the parent's (un-rotated) coordinate space.
-        // Without this wrapper, applying `.rotationEffect` then `.mask`
-        // rotates the entire masked result — the silhouette outline
-        // itself spins, which reads as a diagonal beam instead of a
-        // bright spot orbiting a static silhouette.
-        ZStack {
-            AngularGradient(
-                gradient: Gradient(stops: [
-                    .init(color: .clear, location: 0.00),
-                    .init(color: tint.opacity(0.0), location: 0.55),
-                    .init(color: tint, location: 0.78),
-                    .init(color: .white.opacity(0.95), location: 0.92),
-                    .init(color: tint.opacity(0.0), location: 1.00),
-                ]),
-                center: .center,
-                angle: .degrees(0)
-            )
-            .rotationEffect(.degrees(rotation))
-        }
-        .mask(
-            IslandShape()
-                .stroke(Color.white, lineWidth: 4)
-        )
-        .blur(radius: 3)
-        .onAppear {
-            // Reset to 0 in case onAppear fires after a previous mount.
-            rotation = 0
-            withAnimation(.linear(duration: 3.6).repeatForever(autoreverses: false)) {
-                // Setting once with .repeatForever lets SwiftUI translate
-                // this into a CABasicAnimation on `transform.rotation.z`.
-                rotation = 360
+            TimelineView(.animation(minimumInterval: 1.0 / 30.0)) { context in
+                let t = context.date.timeIntervalSinceReferenceDate
+                let rotation = (t * 100).truncatingRemainder(dividingBy: 360)
+                IslandShape()
+                    .stroke(
+                        AngularGradient(
+                            gradient: Gradient(stops: [
+                                .init(color: .clear, location: 0.00),
+                                .init(color: tint.opacity(0.0), location: 0.55),
+                                .init(color: tint, location: 0.78),
+                                .init(color: .white.opacity(0.95), location: 0.92),
+                                .init(color: tint.opacity(0.0), location: 1.00),
+                            ]),
+                            center: .center,
+                            angle: .degrees(rotation)
+                        ),
+                        lineWidth: 4
+                    )
+                    .blur(radius: 3)
             }
         }
     }

--- a/Sources/Views/IslandRootView.swift
+++ b/Sources/Views/IslandRootView.swift
@@ -385,11 +385,16 @@ struct IslandRootView: View {
 }
 
 /// Cobalt angular-gradient sweep that orbits the silhouette while data is
-/// fetching. Owns its own TimelineView so the parent (IslandRootView) doesn't
-/// re-render every overlay at 120Hz — that was competing with the hover spring
-/// for main-thread budget. The minimumInterval pin is what guarantees
-/// ProMotion 120Hz refresh inside the .accessory background app context;
-/// without it the sweep settles to ~60Hz.
+/// fetching. Implemented as an NSViewRepresentable wrapping a CAGradientLayer
+/// (`.conic`) rotated by a CABasicAnimation. Core Animation runs the rotation
+/// on the compositor thread off the main thread — no SwiftUI body re-eval per
+/// frame, no per-frame CPU. Replaces a SwiftUI TimelineView that ticked at
+/// 120Hz and burned ~24% main-thread CPU continuously.
+///
+/// The blur is applied as a SwiftUI `.blur` *outside* the representable.
+/// CIFilter on a non-backing sublayer is undocumented/fragile on macOS, so
+/// keeping the blur in SwiftUI sidesteps the question — SwiftUI's `.blur`
+/// is GPU-cheap and known-correct.
 private struct LoadingSweep: View {
     let active: Bool
     /// Color of the orbiting trail. Cobalt by default; switches to amber
@@ -399,26 +404,116 @@ private struct LoadingSweep: View {
 
     var body: some View {
         if active {
-            TimelineView(.animation(minimumInterval: 1.0 / 120.0)) { context in
-                let t = context.date.timeIntervalSinceReferenceDate
-                let rotation = (t * 100).truncatingRemainder(dividingBy: 360)
-                IslandShape()
-                    .stroke(
-                        AngularGradient(
-                            gradient: Gradient(stops: [
-                                .init(color: .clear, location: 0.00),
-                                .init(color: tint.opacity(0.0), location: 0.55),
-                                .init(color: tint, location: 0.78),
-                                .init(color: .white.opacity(0.95), location: 0.92),
-                                .init(color: tint.opacity(0.0), location: 1.00),
-                            ]),
-                            center: .center,
-                            angle: .degrees(rotation)
-                        ),
-                        lineWidth: 4
-                    )
-                    .blur(radius: 3)
-            }
+            SweepRepresentable(tint: tint)
+                .blur(radius: 3)
+                .allowsHitTesting(false)
         }
+    }
+}
+
+private struct SweepRepresentable: NSViewRepresentable {
+    let tint: Color
+
+    func makeNSView(context: Context) -> SweepNSView {
+        let v = SweepNSView()
+        v.applyTint(NSColor(tint))
+        return v
+    }
+
+    func updateNSView(_ view: SweepNSView, context: Context) {
+        view.applyTint(NSColor(tint))
+    }
+
+    static func dismantleNSView(_ view: SweepNSView, coordinator: ()) {
+        view.tearDown()
+    }
+}
+
+/// Layer-backed view that hosts the rotating conic gradient. The container
+/// (= the view's backing layer) is masked by the IslandShape stroke, so the
+/// rotating gradient is visible only along the silhouette outline.
+private final class SweepNSView: NSView {
+    private let gradientLayer = CAGradientLayer()
+    private let maskLayer = CAShapeLayer()
+    private var lastTint: NSColor?
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        setup()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setup()
+    }
+
+    private func setup() {
+        wantsLayer = true
+        let root = CALayer()
+        layer = root
+
+        gradientLayer.type = .conic
+        gradientLayer.startPoint = CGPoint(x: 0.5, y: 0.5)
+        gradientLayer.endPoint = CGPoint(x: 1.0, y: 0.5)
+        gradientLayer.locations = [0.00, 0.55, 0.78, 0.92, 1.00] as [NSNumber]
+        gradientLayer.anchorPoint = CGPoint(x: 0.5, y: 0.5)
+
+        maskLayer.fillColor = nil
+        maskLayer.strokeColor = NSColor.black.cgColor
+        maskLayer.lineWidth = 4
+
+        root.addSublayer(gradientLayer)
+        // Mask is set on the *root* (not the gradient) so it doesn't rotate
+        // with the gradient — the silhouette stays fixed while the gradient
+        // pattern spins inside it.
+        root.mask = maskLayer
+
+        startRotation()
+    }
+
+    override func layout() {
+        super.layout()
+        // Frame changes (state morph compact ↔ peek ↔ expanded) fire here.
+        // disableActions stops the implicit fade between mask paths.
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        layer?.frame = bounds
+        gradientLayer.frame = bounds
+        maskLayer.frame = bounds
+        maskLayer.path = IslandShape().path(in: bounds).cgPath
+        CATransaction.commit()
+    }
+
+    func applyTint(_ tint: NSColor) {
+        guard tint != lastTint else { return }
+        lastTint = tint
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        gradientLayer.colors = [
+            NSColor.clear.cgColor,
+            tint.withAlphaComponent(0.0).cgColor,
+            tint.cgColor,
+            NSColor(white: 1.0, alpha: 0.95).cgColor,
+            tint.withAlphaComponent(0.0).cgColor,
+        ]
+        CATransaction.commit()
+    }
+
+    func tearDown() {
+        gradientLayer.removeAnimation(forKey: "rotate")
+    }
+
+    private func startRotation() {
+        let anim = CABasicAnimation(keyPath: "transform.rotation.z")
+        anim.fromValue = 0
+        // Negative reads as clockwise on screen — CALayer geometry on
+        // macOS is Y-down, so positive `transform.rotation.z` rotates
+        // counter-clockwise visually. Matches the original SwiftUI sweep
+        // where rotation was `(t * 100) mod 360` increasing with time.
+        anim.toValue = -2 * Double.pi
+        anim.duration = 3.6
+        anim.repeatCount = .infinity
+        anim.isRemovedOnCompletion = false
+        gradientLayer.add(anim, forKey: "rotate")
     }
 }

--- a/Sources/Views/IslandRootView.swift
+++ b/Sources/Views/IslandRootView.swift
@@ -41,9 +41,11 @@ struct IslandRootView: View {
                     // Pause entirely when the window is occluded by a
                     // fullscreen app or display sleep — the user can't
                     // see it anyway, so re-shading the gradient at 30Hz
-                    // is pure waste.
+                    // is pure waste. `effectiveEnabled` also folds in
+                    // macOS system Low Power Mode, so the sweep auto-
+                    // pauses on battery save.
                     active: !occlusion.isOccluded
-                        && (lowPower.enabled ? glowEventActive : true),
+                        && (lowPower.effectiveEnabled ? glowEventActive : true),
                     tint: glowColor
                 )
 
@@ -62,7 +64,7 @@ struct IslandRootView: View {
                     // ambient 0.35 the way it always has.
                     .shadow(
                         color: glowColor.opacity(
-                            lowPower.enabled ? (glowEventActive ? 0.35 : 0) : 0.35
+                            lowPower.effectiveEnabled ? (glowEventActive ? 0.35 : 0) : 0.35
                         ),
                         radius: 14, y: 0
                     )

--- a/Sources/Views/IslandRootView.swift
+++ b/Sources/Views/IslandRootView.swift
@@ -385,16 +385,18 @@ struct IslandRootView: View {
 }
 
 /// Cobalt angular-gradient sweep that orbits the silhouette while data is
-/// fetching. Implemented as an NSViewRepresentable wrapping a CAGradientLayer
-/// (`.conic`) rotated by a CABasicAnimation. Core Animation runs the rotation
-/// on the compositor thread off the main thread — no SwiftUI body re-eval per
-/// frame, no per-frame CPU. Replaces a SwiftUI TimelineView that ticked at
-/// 120Hz and burned ~24% main-thread CPU continuously.
+/// fetching. Owns its own TimelineView so the parent (IslandRootView) doesn't
+/// re-render every overlay alongside the sweep — that was competing with the
+/// hover spring for main-thread budget.
 ///
-/// The blur is applied as a SwiftUI `.blur` *outside* the representable.
-/// CIFilter on a non-backing sublayer is undocumented/fragile on macOS, so
-/// keeping the blur in SwiftUI sidesteps the question — SwiftUI's `.blur`
-/// is GPU-cheap and known-correct.
+/// Tick rate is 30Hz: a 3.6s revolution at 30Hz = 12° per frame, which is
+/// indistinguishable from 60/120Hz to the eye for a continuous orbit at this
+/// speed but cuts main-thread CPU 4× vs the original 120Hz pin. Earlier
+/// attempts to push the rotation into Core Animation via a CAGradientLayer
+/// gave up the soft "glow" feel of SwiftUI's AngularGradient — the renderers
+/// blend transparent→tint→white differently, and the result reads as a hard
+/// rotating bar instead of an atmospheric aura. Lowering the SwiftUI tick
+/// rate keeps the original look exactly while still cutting CPU substantially.
 private struct LoadingSweep: View {
     let active: Bool
     /// Color of the orbiting trail. Cobalt by default; switches to amber
@@ -404,122 +406,26 @@ private struct LoadingSweep: View {
 
     var body: some View {
         if active {
-            SweepRepresentable(tint: tint)
-                .blur(radius: 3)
-                .allowsHitTesting(false)
+            TimelineView(.animation(minimumInterval: 1.0 / 30.0)) { context in
+                let t = context.date.timeIntervalSinceReferenceDate
+                let rotation = (t * 100).truncatingRemainder(dividingBy: 360)
+                IslandShape()
+                    .stroke(
+                        AngularGradient(
+                            gradient: Gradient(stops: [
+                                .init(color: .clear, location: 0.00),
+                                .init(color: tint.opacity(0.0), location: 0.55),
+                                .init(color: tint, location: 0.78),
+                                .init(color: .white.opacity(0.95), location: 0.92),
+                                .init(color: tint.opacity(0.0), location: 1.00),
+                            ]),
+                            center: .center,
+                            angle: .degrees(rotation)
+                        ),
+                        lineWidth: 4
+                    )
+                    .blur(radius: 3)
+            }
         }
-    }
-}
-
-private struct SweepRepresentable: NSViewRepresentable {
-    let tint: Color
-
-    func makeNSView(context: Context) -> SweepNSView {
-        let v = SweepNSView()
-        v.applyTint(NSColor(tint))
-        return v
-    }
-
-    func updateNSView(_ view: SweepNSView, context: Context) {
-        view.applyTint(NSColor(tint))
-    }
-
-    static func dismantleNSView(_ view: SweepNSView, coordinator: ()) {
-        view.tearDown()
-    }
-}
-
-/// Layer-backed view that hosts the rotating conic gradient. The container
-/// (= the view's backing layer) is masked by the IslandShape stroke, so the
-/// rotating gradient is visible only along the silhouette outline.
-private final class SweepNSView: NSView {
-    private let gradientLayer = CAGradientLayer()
-    private let maskLayer = CAShapeLayer()
-    private var lastTint: NSColor?
-
-    override init(frame frameRect: NSRect) {
-        super.init(frame: frameRect)
-        setup()
-    }
-
-    required init?(coder: NSCoder) {
-        super.init(coder: coder)
-        setup()
-    }
-
-    private func setup() {
-        wantsLayer = true
-        let root = CALayer()
-        layer = root
-
-        gradientLayer.type = .conic
-        gradientLayer.startPoint = CGPoint(x: 0.5, y: 0.5)
-        gradientLayer.endPoint = CGPoint(x: 1.0, y: 0.5)
-        gradientLayer.locations = [0.00, 0.55, 0.78, 0.92, 1.00] as [NSNumber]
-        gradientLayer.anchorPoint = CGPoint(x: 0.5, y: 0.5)
-
-        maskLayer.fillColor = nil
-        maskLayer.strokeColor = NSColor.black.cgColor
-        maskLayer.lineWidth = 4
-
-        root.addSublayer(gradientLayer)
-        // Mask is set on the *root* (not the gradient) so it doesn't rotate
-        // with the gradient — the silhouette stays fixed while the gradient
-        // pattern spins inside it.
-        root.mask = maskLayer
-
-        startRotation()
-    }
-
-    override func layout() {
-        super.layout()
-        // Frame changes (state morph compact ↔ peek ↔ expanded) fire here.
-        // disableActions stops the implicit fade between mask paths.
-        CATransaction.begin()
-        CATransaction.setDisableActions(true)
-        layer?.frame = bounds
-        gradientLayer.frame = bounds
-        maskLayer.frame = bounds
-        maskLayer.path = IslandShape().path(in: bounds).cgPath
-        CATransaction.commit()
-    }
-
-    func applyTint(_ tint: NSColor) {
-        guard tint != lastTint else { return }
-        lastTint = tint
-        CATransaction.begin()
-        CATransaction.setDisableActions(true)
-        gradientLayer.colors = [
-            NSColor.clear.cgColor,
-            tint.withAlphaComponent(0.0).cgColor,
-            tint.cgColor,
-            NSColor(white: 1.0, alpha: 0.95).cgColor,
-            tint.withAlphaComponent(0.0).cgColor,
-        ]
-        CATransaction.commit()
-    }
-
-    func tearDown() {
-        gradientLayer.removeAnimation(forKey: "rotate")
-    }
-
-    private func startRotation() {
-        let anim = CABasicAnimation(keyPath: "transform.rotation.z")
-        anim.fromValue = 0
-        // Negative reads as clockwise on screen — CALayer geometry on
-        // macOS is Y-down, so positive `transform.rotation.z` rotates
-        // counter-clockwise visually. Matches the original SwiftUI sweep
-        // where rotation was `(t * 100) mod 360` increasing with time.
-        anim.toValue = -2 * Double.pi
-        anim.duration = 3.6
-        anim.repeatCount = .infinity
-        anim.isRemovedOnCompletion = false
-        // Constant angular velocity — without this, CABasicAnimation
-        // defaults to ease-in/ease-out which makes the rotation visibly
-        // slow down and speed up every 3.6s cycle. The original SwiftUI
-        // TimelineView used linear time (`t * 100`), so we need linear
-        // here to match.
-        anim.timingFunction = CAMediaTimingFunction(name: .linear)
-        gradientLayer.add(anim, forKey: "rotate")
     }
 }

--- a/Sources/Views/IslandRootView.swift
+++ b/Sources/Views/IslandRootView.swift
@@ -385,19 +385,20 @@ struct IslandRootView: View {
 }
 
 /// Cobalt angular-gradient sweep that orbits the silhouette while data is
-/// fetching. Owns its own TimelineView so the parent (IslandRootView) doesn't
-/// re-render every overlay alongside the sweep — that was competing with the
-/// hover spring for main-thread budget.
+/// fetching. Renders the AngularGradient once at angle 0, then rotates the
+/// whole layer via `.rotationEffect` driven by `withAnimation(.linear.
+/// repeatForever)`. SwiftUI translates that into a CABasicAnimation on the
+/// layer's transform — rotation happens on the WindowServer compositor
+/// thread, off the main thread. The conic gradient texture is shaded ONCE
+/// when the view appears, not on every frame.
 ///
-/// Tick rate is 15Hz: a 3.6s revolution at 15Hz = ~6.7° per frame, which
-/// reads smooth for a slow continuous orbit (≈ second-hand-of-a-clock step
-/// size, where the eye doesn't perceive ticks). Cuts main-thread CPU 8× vs
-/// the original 120Hz pin. Earlier attempts to push the rotation into Core
-/// Animation via a CAGradientLayer gave up the soft "glow" feel of SwiftUI's
-/// AngularGradient — the renderers blend transparent→tint→white differently,
-/// and the CALayer result reads as a hard rotating bar instead of an
-/// atmospheric aura. Lowering the SwiftUI tick rate keeps the original look
-/// exactly while still cutting CPU substantially.
+/// Why this matters: profiling the previous TimelineView-driven implementation
+/// showed `rgba64_shade_conic_RGB → atan2f` dominating main-thread CPU.
+/// CoreGraphics re-shaded every pixel of the gradient per frame because the
+/// AngularGradient's `angle` parameter changed each tick. By moving rotation
+/// out of the gradient (fixed angle) and into a layer transform, we keep
+/// the same SwiftUI rendering quality while the per-frame work collapses
+/// to a transform multiplication.
 private struct LoadingSweep: View {
     let active: Bool
     /// Color of the orbiting trail. Cobalt by default; switches to amber
@@ -407,25 +408,43 @@ private struct LoadingSweep: View {
 
     var body: some View {
         if active {
-            TimelineView(.animation(minimumInterval: 1.0 / 15.0)) { context in
-                let t = context.date.timeIntervalSinceReferenceDate
-                let rotation = (t * 100).truncatingRemainder(dividingBy: 360)
-                IslandShape()
-                    .stroke(
-                        AngularGradient(
-                            gradient: Gradient(stops: [
-                                .init(color: .clear, location: 0.00),
-                                .init(color: tint.opacity(0.0), location: 0.55),
-                                .init(color: tint, location: 0.78),
-                                .init(color: .white.opacity(0.95), location: 0.92),
-                                .init(color: tint.opacity(0.0), location: 1.00),
-                            ]),
-                            center: .center,
-                            angle: .degrees(rotation)
-                        ),
-                        lineWidth: 4
-                    )
-                    .blur(radius: 3)
+            RotatingSweep(tint: tint)
+        }
+    }
+}
+
+private struct RotatingSweep: View {
+    let tint: Color
+    @State private var rotation: Double = 0
+
+    var body: some View {
+        AngularGradient(
+            gradient: Gradient(stops: [
+                .init(color: .clear, location: 0.00),
+                .init(color: tint.opacity(0.0), location: 0.55),
+                .init(color: tint, location: 0.78),
+                .init(color: .white.opacity(0.95), location: 0.92),
+                .init(color: tint.opacity(0.0), location: 1.00),
+            ]),
+            center: .center,
+            angle: .degrees(0)
+        )
+        // Mask to the same 4pt-wide IslandShape stroke as the original.
+        .mask(
+            IslandShape()
+                .stroke(Color.white, lineWidth: 4)
+        )
+        .blur(radius: 3)
+        .rotationEffect(.degrees(rotation))
+        .onAppear {
+            // Reset to 0 in case onAppear fires after a previous mount.
+            rotation = 0
+            withAnimation(.linear(duration: 3.6).repeatForever(autoreverses: false)) {
+                // Setting once with .repeatForever lets SwiftUI translate
+                // this into a CABasicAnimation on `transform.rotation.z`.
+                // 360° = full revolution; the value the body reads stays
+                // animatably interpolated by the system.
+                rotation = 360
             }
         }
     }

--- a/Sources/Views/IslandRootView.swift
+++ b/Sources/Views/IslandRootView.swift
@@ -389,14 +389,15 @@ struct IslandRootView: View {
 /// re-render every overlay alongside the sweep — that was competing with the
 /// hover spring for main-thread budget.
 ///
-/// Tick rate is 30Hz: a 3.6s revolution at 30Hz = 12° per frame, which is
-/// indistinguishable from 60/120Hz to the eye for a continuous orbit at this
-/// speed but cuts main-thread CPU 4× vs the original 120Hz pin. Earlier
-/// attempts to push the rotation into Core Animation via a CAGradientLayer
-/// gave up the soft "glow" feel of SwiftUI's AngularGradient — the renderers
-/// blend transparent→tint→white differently, and the result reads as a hard
-/// rotating bar instead of an atmospheric aura. Lowering the SwiftUI tick
-/// rate keeps the original look exactly while still cutting CPU substantially.
+/// Tick rate is 15Hz: a 3.6s revolution at 15Hz = ~6.7° per frame, which
+/// reads smooth for a slow continuous orbit (≈ second-hand-of-a-clock step
+/// size, where the eye doesn't perceive ticks). Cuts main-thread CPU 8× vs
+/// the original 120Hz pin. Earlier attempts to push the rotation into Core
+/// Animation via a CAGradientLayer gave up the soft "glow" feel of SwiftUI's
+/// AngularGradient — the renderers blend transparent→tint→white differently,
+/// and the CALayer result reads as a hard rotating bar instead of an
+/// atmospheric aura. Lowering the SwiftUI tick rate keeps the original look
+/// exactly while still cutting CPU substantially.
 private struct LoadingSweep: View {
     let active: Bool
     /// Color of the orbiting trail. Cobalt by default; switches to amber
@@ -406,7 +407,7 @@ private struct LoadingSweep: View {
 
     var body: some View {
         if active {
-            TimelineView(.animation(minimumInterval: 1.0 / 30.0)) { context in
+            TimelineView(.animation(minimumInterval: 1.0 / 15.0)) { context in
                 let t = context.date.timeIntervalSinceReferenceDate
                 let rotation = (t * 100).truncatingRemainder(dividingBy: 360)
                 IslandShape()

--- a/Sources/Window/IslandWindowController.swift
+++ b/Sources/Window/IslandWindowController.swift
@@ -11,6 +11,7 @@ final class IslandWindowController {
     private var globalMouseMonitor: Any?
     private var trackingTimer: Timer?
     private var screenChangeObserver: NSObjectProtocol?
+    private var occlusionObserver: NSObjectProtocol?
     private var subs: Set<AnyCancellable> = []
     private var hasSeenMouseEvent = false
 
@@ -48,10 +49,14 @@ final class IslandWindowController {
         installMouseTracking()
         observeScreenChanges()
         observeTargetChoice()
+        observeOcclusion()
     }
 
     deinit {
         if let observer = screenChangeObserver {
+            NotificationCenter.default.removeObserver(observer)
+        }
+        if let observer = occlusionObserver {
             NotificationCenter.default.removeObserver(observer)
         }
         if let m = globalMouseMonitor { NSEvent.removeMonitor(m) }
@@ -128,6 +133,29 @@ final class IslandWindowController {
             queue: .main
         ) { [weak self] _ in
             Task { @MainActor in self?.repositionForCurrentScreen() }
+        }
+    }
+
+    /// Pauses the LoadingSweep when the user can't see the island —
+    /// fullscreen apps on a separate Space, the screen going to sleep,
+    /// or anything else macOS reports as making the window invisible.
+    /// The 30Hz TimelineView is the dominant idle-CPU cost; pausing it
+    /// while occluded drops idle to ~0%.
+    private func observeOcclusion() {
+        // Seed the initial state — the notification doesn't fire on launch.
+        WindowOcclusionStore.shared.update(
+            isVisible: window.occlusionState.contains(.visible)
+        )
+        occlusionObserver = NotificationCenter.default.addObserver(
+            forName: NSWindow.didChangeOcclusionStateNotification,
+            object: window,
+            queue: .main
+        ) { [weak self] _ in
+            guard let self else { return }
+            let visible = self.window.occlusionState.contains(.visible)
+            Task { @MainActor in
+                WindowOcclusionStore.shared.update(isVisible: visible)
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

The ambient cobalt orbit was burning ~24% CPU continuously — SwiftUI's `TimelineView` ticked at 120Hz, and CoreGraphics' conic gradient shader (`rgba64_shade_conic_RGB → atan2f`) re-shaded every pixel of the silhouette stroke per frame.

This PR keeps the exact original SwiftUI rendering — same `AngularGradient`, same stroke, same blur, same per-frame re-shading that gives the orbit its alive, atmospheric \"glow\" feel — and instead attacks CPU two ways:

1. **Drop tick rate from 120Hz → 30Hz.** A 3.6s/revolution at 30Hz is 12°/frame, indistinguishable from 120Hz to the eye for a slow continuous orbit.
2. **Pause the sweep entirely when nobody's looking** — when the window is occluded, when macOS Low Power Mode is on, or when our LPM is opt-in.

## Result

| Situation | CPU |
|---|---|
| AC, visible (steady state) | **~9–12%** (was 24%) |
| Window occluded by fullscreen app or sleep | **~0%** |
| macOS system Low Power Mode on (battery save), idle | **~0%** |

Net average idle CPU drops dramatically for users on battery without touching the visible behavior on AC.

## What I tried that didn't work

This branch's history records two failed attempts to push the rotation onto Core Animation's render thread:

- **`CAGradientLayer(.conic) + CABasicAnimation`** (would've been ~0% CPU) — the conic gradient and SwiftUI's `AngularGradient` interpolate `transparent → tint → white` differently. The CALayer version reads as a hard rotating bar instead of a soft glow. Tried densifying gradient stops and converting CGColors to linear-light sRGB — couldn't recover the original feel.
- **SwiftUI `.rotationEffect` over a static AngularGradient** (~5% CPU) — same root issue: any approach that pre-renders the gradient and rotates it as a static texture loses the per-frame anti-aliasing that makes the glow look \"alive.\" The user explicitly rejected this look as well.

Conclusion from profiling: per-frame conic re-shading is what the glow feel is paying for. Going below ~9% steady CPU on AC requires changing the visual.

## Changes

- `Sources/Views/IslandRootView.swift` — LoadingSweep TimelineView at 30Hz instead of 120Hz; gates `active` on occlusion + system LPM
- `Sources/Model/WindowOcclusionStore.swift` (new) — observes `NSWindow.didChangeOcclusionStateNotification`
- `Sources/Window/IslandWindowController.swift` — wires up the occlusion notification observer and tears it down in deinit
- `Sources/Model/LowPowerModeStore.swift` — adds `effectiveEnabled` (user toggle ∨ `ProcessInfo.isLowPowerModeEnabled`); observes `NSProcessInfoPowerStateDidChange`

## Test plan

- [x] Build clean
- [x] Visual is byte-identical to the pre-refactor 120Hz baseline (same SwiftUI render path)
- [x] CPU on AC drops from ~24% to ~9–12% steady
- [ ] Manual: enter a fullscreen app, verify CPU drops to ~0% while occluded
- [ ] Manual: toggle macOS system Low Power Mode (System Settings → Battery → Low Power Mode), verify the sweep pauses at idle and resumes only on hover/refresh/alert
- [ ] Manual: hover the island, verify peek state still triggers and the sweep continues smoothly
- [ ] Manual: trigger an alert (Settings → Alerts → Preview), verify color transitions cobalt → amber/red without breaking the rotation
- [ ] Manual: open and close the panel (compact ↔ expanded), verify the sweep continues across state morphs