### PR TITLE
fix(ci): use explicit DMG path so empty SHA can't poison cask sync

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,14 @@ jobs:
 
       - name: Compute checksum
         id: sha
-        run: echo "sha=$(shasum -a 256 dist/CodexIsland-*.dmg | awk '{print $1}')" >> "$GITHUB_OUTPUT"
+        run: |
+          set -euo pipefail
+          DMG="dist/CodexIsland-${GITHUB_REF_NAME#v}.dmg"
+          if [[ ! -f "$DMG" ]]; then
+            echo "::error::expected DMG not found at $DMG"
+            exit 1
+          fi
+          echo "sha=$(shasum -a 256 "$DMG" | awk '{print $1}')" >> "$GITHUB_OUTPUT"
 
       # Build release notes from Conventional Commits between the previous
       # tag and HEAD. Groups by feat / fix / perf / refactor / docs / chore
@@ -123,6 +130,10 @@ jobs:
           if [[ -z "${HOMEBREW_TAP_TOKEN:-}" ]]; then
             echo "::warning::HOMEBREW_TAP_TOKEN not set — skipping tap sync. Cask in ericjypark/homebrew-tap will be stale until updated manually."
             exit 0
+          fi
+          if [[ -z "${SHA:-}" ]]; then
+            echo "::error::empty SHA from prior step — refusing to rewrite cask"
+            exit 1
           fi
           # Strip leading "v" from the tag to get the cask version
           CASK_VERSION="${VERSION#v}"


### PR DESCRIPTION
## Summary

Implements audit finding **B2**: hardens the release workflow so a missing
DMG can't silently produce an empty SHA-256 and brick `brew install` for
every user on the new release.

## The failure mode

`.github/workflows/release.yml` computed the DMG checksum with a glob:

```yaml
echo "sha=$(shasum -a 256 dist/CodexIsland-*.dmg | awk '{print $1}')"
```

If the glob matches nothing — e.g. `release.sh` silently skipped the DMG
`mv` step — `shasum` gets no arguments, `awk` outputs nothing, and the
step output `sha` is the empty string. That empty string then flows into
the cask-sync sed:

```yaml
sed -i '' "s|sha256 \"[a-f0-9]\{64\}\"|sha256 \"$SHA\"|" Casks/codexisland.rb
```

…which leaves the **old** SHA in the cask. `brew install` on the new
release then mismatches the checksum and fails for every user.

## The fix

1. Replace the glob with the explicit filename `release.sh` produces,
   derived from `GITHUB_REF_NAME` (tag form `vX.Y.Z` → `dist/CodexIsland-X.Y.Z.dmg`).
   Add a `[[ ! -f "$DMG" ]]` existence check that hard-fails the job if
   the expected DMG isn't there.
2. Add a defensive `[[ -z "${SHA:-}" ]]` guard at the top of the cask-sync
   step. If anything ever sneaks an empty SHA past step 1 (e.g. someone
   restructures the compute step), refuse to rewrite the cask rather than
   silently writing a 0-char SHA.

Both failures are now loud — the release fails before publishing a broken
cask.

## Test plan

- [x] `python -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"` passes.
- [ ] Next real release tag (the only way to exercise the workflow end-to-end)
      builds + publishes as before; existence check is a no-op when the DMG
      is present.
- [ ] Manually verifiable: temporarily rename the DMG before the checksum
      step locally → step now fails with `expected DMG not found at …`
      instead of producing an empty SHA.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release workflow reliability with improved checksum validation and error handling to prevent incomplete releases.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ericjypark/codex-island/pull/7)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->