### PR TITLE
fix(build): require VERSION to be strict semver

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -6,6 +6,10 @@ cd "$(dirname "$0")"
 APP_NAME="CodexIsland"
 BUNDLE_ID="dev.codexisland.CodexIsland"
 VERSION="$(cat VERSION)"
+if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "error: VERSION must be X.Y.Z (got '$VERSION')" >&2
+  exit 1
+fi
 BUILD_DIR="./build"
 APP_DIR="$BUILD_DIR/$APP_NAME.app"
 CONTENTS="$APP_DIR/Contents"

--- a/release.sh
+++ b/release.sh
@@ -13,6 +13,10 @@ set -euo pipefail
 cd "$(dirname "$0")"
 
 VERSION="$(cat VERSION)"
+if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "error: VERSION must be X.Y.Z (got '$VERSION')" >&2
+  exit 1
+fi
 APP_NAME="CodexIsland"
 DIST="dist"
 APP="$DIST/$APP_NAME.app"


### PR DESCRIPTION
## Summary

Implements audit finding **B8**: `build.sh` reads `VERSION` and embeds it as both `CFBundleVersion` and `CFBundleShortVersionString` with no validation. Anything (`1`, `latest`, `v0.1.4`, `1.0.0-beta`) currently slips through and ships in a real DMG.

This adds a strict-semver regex check immediately after `VERSION=\"\$(cat VERSION)\"`. If it doesn't match `^[0-9]+\\.[0-9]+\\.[0-9]+$`, the build fails fast with a clear error.

## Why this matters

Per `CLAUDE.md`'s release-process hard rules and history table, a `CFBundleVersion` of `\"1\"` permanently breaks Sparkle auto-update for that install. Apple's component-wise version comparator parses `\"1\"` as `[1]` and treats it as **larger than** `\"0.0.99\"` (`[0,0,99]`) — the first component decides the comparison. Affected installs silently reject every future signed update.

This bug has shipped before. The new guard prevents it from shipping again.

## What's rejected

| Input | Result |
|---|---|
| `0.1.3` | pass |
| `0.0.99` | pass |
| `1` | fail |
| `1.0` | fail |
| `1.0.0-beta` | fail |
| `v1.0.0` | fail |

The project has never shipped a pre-release and the documented Sparkle compatibility expectation is strict numeric semver, so no escape hatch (e.g. for `-beta` suffixes) is provided. If that changes, this regex can be loosened later.

## Test plan

- [x] `bash -n build.sh` passes
- [x] Mental walkthrough of regex against `0.1.3`, `1`, `1.0`, `1.0.0-beta`, `v1.0.0`, `0.0.99` matches expected accept/reject
- [x] Current `VERSION` (`0.1.3`) is accepted — happy path is intact
- [ ] CI green on this PR