### PR TITLE
refactor(app): centralize CODEXISLAND_DEMO/DEBUG behind AppEnvironment

### DIFF
--- a/Sources/Cost/CostStore.swift
+++ b/Sources/Cost/CostStore.swift
@@ -33,7 +33,7 @@ final class CostStore: ObservableObject {
     }
 
     private init() {
-        if ProcessInfo.processInfo.environment["CODEXISLAND_DEMO"] == "1" {
+        if AppEnvironment.isDemo {
             loadDemoData()
             return
         }
@@ -44,7 +44,7 @@ final class CostStore: ObservableObject {
         // Demo mode: skip log scanning, inject hand-tuned numbers that
         // tell a "user extracts more value than the $200 subscription"
         // story. Never persists, so real cache is preserved.
-        if ProcessInfo.processInfo.environment["CODEXISLAND_DEMO"] == "1" {
+        if AppEnvironment.isDemo {
             loadDemoData()
             return
         }

--- a/Sources/Model/AlertEngine.swift
+++ b/Sources/Model/AlertEngine.swift
@@ -186,7 +186,7 @@ final class AlertEngine: ObservableObject {
     }
 
     private func isPulseSuppressed() -> Bool {
-        if ProcessInfo.processInfo.environment["CODEXISLAND_DEMO"] == "1" {
+        if AppEnvironment.isDemo {
             return true
         }
         // Panel-expanded suppression: we don't have a direct handle to the

--- a/Sources/Model/AppEnvironment.swift
+++ b/Sources/Model/AppEnvironment.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+enum AppMode {
+    case normal
+    case demo
+    case debug
+}
+
+enum AppEnvironment {
+    static let current: AppMode = {
+        let env = ProcessInfo.processInfo.environment
+        if env["CODEXISLAND_DEMO"] == "1" { return .demo }
+        if env["CODEXISLAND_DEBUG"] == "1" { return .debug }
+        return .normal
+    }()
+
+    static var isDemo: Bool { current == .demo }
+    static var isDebug: Bool { current == .debug }
+}

--- a/Sources/Model/ScreenPref.swift
+++ b/Sources/Model/ScreenPref.swift
@@ -34,8 +34,7 @@ final class ScreenPref: ObservableObject {
         // launch so screen recordings always capture it. didSet does not
         // run for init assignments, so this never persists back to
         // UserDefaults — the real app's onboarding state is preserved.
-        let demo = ProcessInfo.processInfo.environment["CODEXISLAND_DEMO"] == "1"
-        self.hasSwipedScreen = demo ? false : UserDefaults.standard.bool(forKey: Self.swipedKey)
+        self.hasSwipedScreen = AppEnvironment.isDemo ? false : UserDefaults.standard.bool(forKey: Self.swipedKey)
     }
 
     /// Edge-clamped carousel — swiping past the rightmost page does

--- a/Sources/Model/StylePreferenceStore.swift
+++ b/Sources/Model/StylePreferenceStore.swift
@@ -27,8 +27,7 @@ where S.RawValue == String {
         let raw = UserDefaults.standard.string(forKey: styleKey) ?? ""
         self.style = S(rawValue: raw) ?? defaultStyle
         // Demo mode keeps the ⌘-click hint visible regardless of prior session.
-        let demo = ProcessInfo.processInfo.environment["CODEXISLAND_DEMO"] == "1"
-        self.hasCycledStyle = demo ? false : UserDefaults.standard.bool(forKey: cycledKey)
+        self.hasCycledStyle = AppEnvironment.isDemo ? false : UserDefaults.standard.bool(forKey: cycledKey)
     }
 
     func cycle() {

--- a/Sources/Usage/UsageStore.swift
+++ b/Sources/Usage/UsageStore.swift
@@ -32,7 +32,7 @@ final class UsageStore: ObservableObject {
         // data". Reset times are recomputed each refresh so the countdowns
         // tick down naturally on camera. Off by default — only fires when
         // CODEXISLAND_DEMO=1 is set in the launching env.
-        if ProcessInfo.processInfo.environment["CODEXISLAND_DEMO"] == "1" {
+        if AppEnvironment.isDemo {
             let now = Date()
             self.claude = AppUsage(
                 fiveHour: WindowUsage(

--- a/Sources/Views/Charts/SparkChart.swift
+++ b/Sources/Views/Charts/SparkChart.swift
@@ -32,7 +32,7 @@ private struct SparkSVG: View {
     /// recordings actually look like a heavy user instead of a quiet one.
     private func generatePoints(width: CGFloat, height: CGFloat) -> [CGPoint] {
         let n = 36
-        let demo = ProcessInfo.processInfo.environment["CODEXISLAND_DEMO"] == "1"
+        let demo = AppEnvironment.isDemo
         let startFactor: Double = demo ? 0.85 : 0.4
         let targetFactor: Double = demo ? 1.0 : 0.7
         let noiseAmpA: Double = demo ? 14 : 7

--- a/Sources/Views/SettingsView.swift
+++ b/Sources/Views/SettingsView.swift
@@ -296,7 +296,7 @@ struct SettingsView: View {
     }
 
     private var isDevMode: Bool {
-        ProcessInfo.processInfo.environment["CODEXISLAND_DEBUG"] == "1"
+        AppEnvironment.isDebug
     }
 
     /// Resets the engine's crossing memory before injecting so each click


### PR DESCRIPTION
## Summary

Addresses audit finding **A2**: every demo/debug-mode check was a raw `ProcessInfo.processInfo.environment["CODEXISLAND_..."] == "1"` lookup duplicated across the codebase. A typo silently misses the mode, and adding a third mode would mean hunting every call site.

This PR introduces `Sources/Model/AppEnvironment.swift` — a tiny `AppMode` enum (`.normal`, `.demo`, `.debug`) plus `AppEnvironment.isDemo` / `AppEnvironment.isDebug` accessors. The mode is resolved once from the process env at first access (a `static let`), which matches how the env vars are intended to be used (set at launch, never mutated).

## Changes

- New: `Sources/Model/AppEnvironment.swift`
- Replaced 8 raw env-lookup sites with `AppEnvironment.isDemo` / `AppEnvironment.isDebug`:
  - `Sources/Usage/UsageStore.swift`
  - `Sources/Cost/CostStore.swift` (×2)
  - `Sources/Model/AlertEngine.swift`
  - `Sources/Model/StylePreferenceStore.swift`
  - `Sources/Model/ScreenPref.swift`
  - `Sources/Views/Charts/SparkChart.swift`
  - `Sources/Views/SettingsView.swift`

The audit listed 6 sites; while doing the sweep I found two more (`ScreenPref.swift`, `SparkChart.swift`) using the same `["CODEXISLAND_DEMO"] == "1"` pattern, and migrated those too so the centralization is complete.

## Behavior preservation

Every original site was a literal `== "1"` check, semantically equivalent to the new helpers. No call site checked for any other value.

## Verification

- `./build.sh` succeeds (universal binary, ad-hoc signed).
- `grep -rn 'CODEXISLAND_DEMO\|CODEXISLAND_DEBUG' Sources/` — only matches left are inside `AppEnvironment.swift`, one doc comment in `UsageStore.swift`, and one UI subtitle string in `SettingsView.swift`. All legitimate.
- `CODEXISLAND_DEMO=1 ./build/CodexIsland.app/Contents/MacOS/CodexIsland` launches cleanly.