### PR TITLE
fix(build): fail loud on Sparkle XPC codesign errors

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -97,10 +97,19 @@ EOF
 # Ad-hoc sign Sparkle's embedded XPC services first (they're inside the
 # framework bundle), then the framework itself. The outer .app gets re-signed
 # in release.sh after everything's in place.
-codesign --force --sign - --timestamp=none --preserve-metadata=identifier,entitlements,flags \
-  "$FRAMEWORKS_DIR/Sparkle.framework/Versions/Current/XPCServices/Installer.xpc" \
-  "$FRAMEWORKS_DIR/Sparkle.framework/Versions/Current/XPCServices/Downloader.xpc" \
-  2>/dev/null || true
+#
+# Sparkle ships both Installer.xpc and Downloader.xpc, but their presence has
+# varied across Sparkle versions. Gate on path existence (so missing helpers
+# don't fail the build) and propagate any real codesign error — silencing
+# them lets "Updater failed to start" reach end users at Check Now time.
+XPC_DIR="$FRAMEWORKS_DIR/Sparkle.framework/Versions/Current/XPCServices"
+for xpc in Installer.xpc Downloader.xpc; do
+  XPC_PATH="$XPC_DIR/$xpc"
+  if [[ -d "$XPC_PATH" ]]; then
+    codesign --force --sign - --timestamp=none \
+      --preserve-metadata=identifier,entitlements,flags "$XPC_PATH"
+  fi
+done
 codesign --force --sign - --timestamp=none "$FRAMEWORKS_DIR/Sparkle.framework"
 
 echo "✓ built $APP_DIR ($VERSION)"


### PR DESCRIPTION
## Summary

Audit finding **B3**: `build.sh` silenced `codesign` errors when signing Sparkle's embedded XPC helpers (`Installer.xpc`, `Downloader.xpc`):

```sh
codesign --force --sign - ... \
  ".../XPCServices/Installer.xpc" \
  ".../XPCServices/Downloader.xpc" \
  2>/dev/null || true
```

`2>/dev/null` hides the diagnostic and `|| true` forces a 0 exit, so a real signing failure ships an unsigned (or partially signed) Sparkle helper. The user-visible symptom is **"The updater failed to start"** the first time someone hits Check Now — long after the build that introduced it.

This is the same failure shape recorded in `CLAUDE.md`'s history table under **"xattr -d non-recursive"**: silent at build, explosive at runtime, hard to attribute after the fact. The original `|| true` was almost certainly there to tolerate the XPC paths not existing on early builds; the right fix is to gate on path existence instead of silencing all errors.

## What changed

Replaced the silenced two-arg call with a per-path existence guard:

```sh
XPC_DIR="$FRAMEWORKS_DIR/Sparkle.framework/Versions/Current/XPCServices"
for xpc in Installer.xpc Downloader.xpc; do
  XPC_PATH="$XPC_DIR/$xpc"
  if [[ -d "$XPC_PATH" ]]; then
    codesign --force --sign - --timestamp=none \
      --preserve-metadata=identifier,entitlements,flags "$XPC_PATH"
  fi
done
```

- Missing helpers (Sparkle versions that ship only one, or none) skip cleanly.
- Any real `codesign` error now propagates under the `set -euo pipefail` already at the top of `build.sh` and fails the build where it should be caught.
- `--preserve-metadata=identifier,entitlements,flags` retained from the original.

## Test plan

- [x] `bash -n build.sh` — syntax OK
- [x] `SU_FEED_URL= ./build.sh` — full universal build succeeds; both XPCs found and signed; framework signed afterward; no extra output noise
- [ ] Next CI run on `main` (after merge) — confirm the XPC sign step prints visibly in the build log instead of being swallowed