### PR TITLE
fix(settings): surface provider auth/fetch errors instead of rendering 0%

### DIFF
--- a/Sources/Views/SettingsView.swift
+++ b/Sources/Views/SettingsView.swift
@@ -695,7 +695,12 @@ struct SettingsView: View {
             guard let updated = usage.lastUpdated else { return "idle" }
             return "synced \(Self.relativeFormatter.localizedString(for: updated, relativeTo: Date()))"
         }()
-        let nums = "\(u.fiveHour.percentInt)% / \(u.weekly.percentInt)%"
+        let nums = "\(Self.windowCaption(u.fiveHour)) / \(Self.windowCaption(u.weekly))"
         return "\(synced) · \(nums)"
+    }
+
+    private static func windowCaption(_ w: WindowUsage) -> String {
+        if let err = w.error, w.percentInt == 0 { return "⚠ \(err)" }
+        return "\(w.percentInt)%"
     }
 }


### PR DESCRIPTION
## Audit finding U1

`providerSubtitle(_:)` in `Sources/Views/SettingsView.swift` reads only `usage.lastUpdated` and `percentInt`, so when auth is missing or a fetch fails — both percentages collapse to `0` — the user sees `synced 2m ago · 0% / 0%`. Settings, the most authoritative diagnostic surface, ends up silently masking the real reason ("auth required — run claude", "no codex auth", "auth expired", "rate limited", etc).

The error strings are documented in the README as the support flow, so masking them here directly undercuts that.

## Fix

Per-window: when `error != nil && percentInt == 0`, render `⚠ <error>` in place of that window's percentage. Mirrors the existing `⚠ N unpriced` fallback in `Sources/Views/CostBlock.swift`.

- Happy path unchanged: `synced 2m ago · 32% / 18%`
- One window erroring, the other live: `synced 2m ago · ⚠ auth required — run claude / 18%`
- Cold-start (`lastUpdated == nil`) still falls back to `idle` — the synced closure is untouched.

Scoped strictly to the rendering path. Doesn't restructure error propagation — that's audit finding A4.

## Test plan

- [x] `SU_FEED_URL= ./build.sh` succeeds
- [ ] Manually verify happy path Settings row reads as before
- [ ] Manually verify Settings row surfaces the error string when `WindowUsage.error` is set