### PR TITLE
refactor(cost): extract generic LogParseCache shared by readers

### DIFF
--- a/Sources/Cost/ClaudeLogReader.swift
+++ b/Sources/Cost/ClaudeLogReader.swift
@@ -17,54 +17,32 @@ enum ClaudeLogReader {
     /// network. Safe to call from a background thread.
     static func scan(lookbackDays: Int = 30) -> [TokenEvent] {
         let cutoff = Date().addingTimeInterval(-Double(lookbackDays) * 86400)
-        var cache = loadCache()
         var seen = Set<String>()
         var out: [TokenEvent] = []
-        var visited = Set<String>()
-        var cacheChanged = false
 
-        for root in projectRoots() {
-            for entry in jsonlFiles(under: root, modifiedAfter: cutoff) {
-                let path = entry.url.path
-                visited.insert(path)
-
-                let cachedEvents: [CachedEvent]
-                if let hit = cache.files[path], hit.matches(mtime: entry.mtime, size: entry.size) {
-                    cachedEvents = hit.events
-                } else {
-                    cachedEvents = parseFile(at: entry.url)
-                    cache.files[path] = CachedFile(
-                        mtime: entry.mtime, size: entry.size, events: cachedEvents
-                    )
-                    cacheChanged = true
+        LogParseCache.walk(
+            roots: projectRoots(),
+            cutoff: cutoff,
+            cacheFilename: "claude-parse-cache.v1.json",
+            cacheVersion: cacheVersion,
+            parse: parseFile(at:),
+            emit: { (ev: CachedEvent) in
+                guard ev.timestamp >= cutoff else { return }
+                if !ev.dedupKey.isEmpty {
+                    if seen.contains(ev.dedupKey) { return }
+                    seen.insert(ev.dedupKey)
                 }
-
-                for ev in cachedEvents {
-                    guard ev.timestamp >= cutoff else { continue }
-                    if !ev.dedupKey.isEmpty {
-                        if seen.contains(ev.dedupKey) { continue }
-                        seen.insert(ev.dedupKey)
-                    }
-                    out.append(TokenEvent(
-                        provider: .claude,
-                        timestamp: ev.timestamp,
-                        model: ev.model,
-                        inputTokens: ev.inputTokens,
-                        outputTokens: ev.outputTokens,
-                        cacheCreationTokens: ev.cacheCreationTokens,
-                        cacheReadTokens: ev.cacheReadTokens
-                    ))
-                }
+                out.append(TokenEvent(
+                    provider: .claude,
+                    timestamp: ev.timestamp,
+                    model: ev.model,
+                    inputTokens: ev.inputTokens,
+                    outputTokens: ev.outputTokens,
+                    cacheCreationTokens: ev.cacheCreationTokens,
+                    cacheReadTokens: ev.cacheReadTokens
+                ))
             }
-        }
-
-        // Drop cache entries for files that disappeared or rolled out of the
-        // cutoff — otherwise the cache grows unbounded over months.
-        let preCount = cache.files.count
-        cache.files = cache.files.filter { visited.contains($0.key) }
-        if cache.files.count != preCount { cacheChanged = true }
-
-        if cacheChanged { saveCache(cache) }
+        )
         return out
     }
 
@@ -82,83 +60,19 @@ enum ClaudeLogReader {
         ].filter { FileManager.default.fileExists(atPath: $0.path) }
     }
 
-    private struct FileEntry {
-        let url: URL
-        let mtime: Date
-        let size: Int64
-    }
-
-    private static func jsonlFiles(under root: URL, modifiedAfter cutoff: Date) -> [FileEntry] {
-        let fm = FileManager.default
-        guard let enumerator = fm.enumerator(
-            at: root,
-            includingPropertiesForKeys: [.isRegularFileKey, .contentModificationDateKey, .fileSizeKey],
-            options: [.skipsHiddenFiles, .skipsPackageDescendants]
-        ) else { return [] }
-
-        var hits: [FileEntry] = []
-        for case let url as URL in enumerator {
-            guard url.pathExtension == "jsonl" else { continue }
-            let values = try? url.resourceValues(forKeys: [.isRegularFileKey, .contentModificationDateKey, .fileSizeKey])
-            guard values?.isRegularFile == true,
-                  let mtime = values?.contentModificationDate,
-                  let size = values?.fileSize else { continue }
-            if mtime < cutoff { continue }
-            hits.append(FileEntry(url: url, mtime: mtime, size: Int64(size)))
-        }
-        return hits
-    }
-
     /// Parse a single file end-to-end. Caller is responsible for cutoff
     /// filtering — the cache keeps everything we found so a later scan with
     /// a wider window doesn't have to re-read.
     private static func parseFile(at url: URL) -> [CachedEvent] {
-        guard let handle = try? FileHandle(forReadingFrom: url) else { return [] }
-        defer { try? handle.close() }
-
         let formatter = ISO8601DateFormatter()
         formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
         let formatterNoFractional = ISO8601DateFormatter()
         formatterNoFractional.formatOptions = [.withInternetDateTime]
 
-        // Stream the file in fixed-size chunks and parse one line at a time.
-        // Session JSONLs can reach 50+ MB and we walk 30 days of them, so
-        // loading entire files via `Data(contentsOf:)` blows up peak memory.
-        var buffer = Data()
-        let chunkSize = 64 * 1024
         var out: [CachedEvent] = []
-
-        while true {
-            let chunk = handle.readData(ofLength: chunkSize)
-            if chunk.isEmpty { break }
-            buffer.append(chunk)
-
-            // Walk the buffer with a cursor and only trim the consumed
-            // prefix once per chunk. The previous version called
-            // `removeSubrange` per line, which is O(N) per call and made
-            // a single 50MB JSONL O(N²) to parse.
-            var cursor = buffer.startIndex
-            while cursor < buffer.endIndex {
-                guard let nl = buffer[cursor..<buffer.endIndex].firstIndex(of: 0x0A) else { break }
-                if nl > cursor {
-                    if let event = parseLine(
-                        buffer[cursor..<nl],
-                        formatter: formatter,
-                        formatterNoFractional: formatterNoFractional
-                    ) {
-                        out.append(event)
-                    }
-                }
-                cursor = buffer.index(after: nl)
-            }
-            if cursor > buffer.startIndex {
-                buffer.removeSubrange(buffer.startIndex..<cursor)
-            }
-        }
-        // Flush trailing line if the file did not end with a newline.
-        if !buffer.isEmpty {
+        LogParseCache.streamLines(at: url) { lineData in
             if let event = parseLine(
-                buffer,
+                lineData,
                 formatter: formatter,
                 formatterNoFractional: formatterNoFractional
             ) {
@@ -227,8 +141,7 @@ enum ClaudeLogReader {
 
     // MARK: - Per-file cache
 
-    /// Bump on any breaking change to `CachedEvent` / `CachedFile` to force
-    /// a clean re-parse on next launch.
+    /// Bump on any breaking change to `CachedEvent` to force a clean re-parse.
     private static let cacheVersion = 1
 
     private struct CachedEvent: Codable {
@@ -239,46 +152,5 @@ enum ClaudeLogReader {
         let cacheCreationTokens: Int
         let cacheReadTokens: Int
         let dedupKey: String
-    }
-
-    private struct CachedFile: Codable {
-        let mtime: Date
-        let size: Int64
-        let events: [CachedEvent]
-
-        /// Tolerate sub-millisecond drift through JSON's Double round-trip;
-        /// any real edit moves mtime by far more than that or grows size.
-        func matches(mtime other: Date, size otherSize: Int64) -> Bool {
-            guard size == otherSize else { return false }
-            return abs(mtime.timeIntervalSinceReferenceDate - other.timeIntervalSinceReferenceDate) < 0.001
-        }
-    }
-
-    private struct ParseCache: Codable {
-        var version: Int
-        var files: [String: CachedFile]
-    }
-
-    private static func cacheURL() -> URL? {
-        let fm = FileManager.default
-        guard let caches = fm.urls(for: .cachesDirectory, in: .userDomainMask).first else { return nil }
-        let dir = caches.appendingPathComponent("dev.codexisland.CodexIsland", isDirectory: true)
-        try? fm.createDirectory(at: dir, withIntermediateDirectories: true)
-        return dir.appendingPathComponent("claude-parse-cache.v1.json")
-    }
-
-    private static func loadCache() -> ParseCache {
-        guard let url = cacheURL(),
-              let data = try? Data(contentsOf: url),
-              let cache = try? JSONDecoder().decode(ParseCache.self, from: data),
-              cache.version == cacheVersion
-        else { return ParseCache(version: cacheVersion, files: [:]) }
-        return cache
-    }
-
-    private static func saveCache(_ cache: ParseCache) {
-        guard let url = cacheURL(),
-              let data = try? JSONEncoder().encode(cache) else { return }
-        try? data.write(to: url, options: .atomic)
     }
 }

--- a/Sources/Cost/CodexLogReader.swift
+++ b/Sources/Cost/CodexLogReader.swift
@@ -15,28 +15,17 @@ import Foundation
 enum CodexLogReader {
     static func scan(lookbackDays: Int = 30) -> [TokenEvent] {
         let cutoff = Date().addingTimeInterval(-Double(lookbackDays) * 86400)
-        var cache = loadCache()
         var out: [TokenEvent] = []
-        var visited = Set<String>()
-        var cacheChanged = false
 
-        for entry in jsonlFiles(under: sessionsRoot(), modifiedAfter: cutoff) {
-            let path = entry.url.path
-            visited.insert(path)
-
-            let cachedEvents: [CachedEvent]
-            if let hit = cache.files[path], hit.matches(mtime: entry.mtime, size: entry.size) {
-                cachedEvents = hit.events
-            } else {
-                cachedEvents = parseFile(at: entry.url)
-                cache.files[path] = CachedFile(
-                    mtime: entry.mtime, size: entry.size, events: cachedEvents
-                )
-                cacheChanged = true
-            }
-
-            for ev in cachedEvents {
-                guard ev.timestamp >= cutoff else { continue }
+        LogParseCache.walk(
+            roots: [sessionsRoot()],
+            cutoff: cutoff,
+            cacheFilename: "codex-parse-cache.v1.json",
+            cacheVersion: cacheVersion,
+            fileFilter: { $0.lastPathComponent.hasPrefix("rollout-") },
+            parse: parseFile(at:),
+            emit: { (ev: CachedEvent) in
+                guard ev.timestamp >= cutoff else { return }
                 out.append(TokenEvent(
                     provider: .codex,
                     timestamp: ev.timestamp,
@@ -47,13 +36,7 @@ enum CodexLogReader {
                     cacheReadTokens: ev.cacheReadTokens
                 ))
             }
-        }
-
-        let preCount = cache.files.count
-        cache.files = cache.files.filter { visited.contains($0.key) }
-        if cache.files.count != preCount { cacheChanged = true }
-
-        if cacheChanged { saveCache(cache) }
+        )
         return out
     }
 
@@ -65,41 +48,10 @@ enum CodexLogReader {
         return home.appendingPathComponent(".codex/sessions", isDirectory: true)
     }
 
-    private struct FileEntry {
-        let url: URL
-        let mtime: Date
-        let size: Int64
-    }
-
-    private static func jsonlFiles(under root: URL, modifiedAfter cutoff: Date) -> [FileEntry] {
-        let fm = FileManager.default
-        guard let enumerator = fm.enumerator(
-            at: root,
-            includingPropertiesForKeys: [.isRegularFileKey, .contentModificationDateKey, .fileSizeKey],
-            options: [.skipsHiddenFiles, .skipsPackageDescendants]
-        ) else { return [] }
-
-        var hits: [FileEntry] = []
-        for case let url as URL in enumerator {
-            guard url.pathExtension == "jsonl",
-                  url.lastPathComponent.hasPrefix("rollout-") else { continue }
-            let values = try? url.resourceValues(forKeys: [.isRegularFileKey, .contentModificationDateKey, .fileSizeKey])
-            guard values?.isRegularFile == true,
-                  let mtime = values?.contentModificationDate,
-                  let size = values?.fileSize else { continue }
-            if mtime < cutoff { continue }
-            hits.append(FileEntry(url: url, mtime: mtime, size: Int64(size)))
-        }
-        return hits
-    }
-
     /// Parse a single file end-to-end. Threads the active model through the
     /// file's lines (Codex sessions can `/model` mid-stream) and emits one
     /// CachedEvent per usage-bearing turn.
     private static func parseFile(at url: URL) -> [CachedEvent] {
-        guard let data = try? Data(contentsOf: url),
-              let text = String(data: data, encoding: .utf8) else { return [] }
-
         let formatter = ISO8601DateFormatter()
         formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
         let formatterNoFractional = ISO8601DateFormatter()
@@ -108,18 +60,15 @@ enum CodexLogReader {
         var currentModel: String?
         var out: [CachedEvent] = []
 
-        // Manual newline split rather than `enumerateLines` — its closure
-        // is escaping and can't capture our `currentModel` thread state.
-        for line in text.split(whereSeparator: { $0.isNewline }) {
-            guard let lineData = line.data(using: .utf8),
-                  let raw = try? JSONSerialization.jsonObject(with: lineData) as? [String: Any],
-                  let type = raw["type"] as? String else { continue }
+        LogParseCache.streamLines(at: url) { lineData in
+            guard let raw = try? JSONSerialization.jsonObject(with: lineData) as? [String: Any],
+                  let type = raw["type"] as? String else { return }
 
             if type == "turn_context",
                let payload = raw["payload"] as? [String: Any],
                let model = payload["model"] as? String {
                 currentModel = model
-                continue
+                return
             }
 
             guard type == "event_msg",
@@ -127,7 +76,7 @@ enum CodexLogReader {
                   (payload["type"] as? String) == "token_count",
                   let info = payload["info"] as? [String: Any],
                   let last = info["last_token_usage"] as? [String: Any]
-            else { continue }
+            else { return }
 
             let timestampString = raw["timestamp"] as? String ?? ""
             let timestamp = formatter.date(from: timestampString)
@@ -142,7 +91,7 @@ enum CodexLogReader {
             let nonCachedInput = max(0, totalInput - cached)
             let output = (last["output_tokens"] as? Int) ?? 0
 
-            if nonCachedInput == 0 && cached == 0 && output == 0 { continue }
+            if nonCachedInput == 0 && cached == 0 && output == 0 { return }
 
             // Fall back to gpt-5.4 for sessions that emit token_count before
             // any turn_context (early Codex CLI builds did this). Better
@@ -170,44 +119,5 @@ enum CodexLogReader {
         let inputTokens: Int
         let outputTokens: Int
         let cacheReadTokens: Int
-    }
-
-    private struct CachedFile: Codable {
-        let mtime: Date
-        let size: Int64
-        let events: [CachedEvent]
-
-        func matches(mtime other: Date, size otherSize: Int64) -> Bool {
-            guard size == otherSize else { return false }
-            return abs(mtime.timeIntervalSinceReferenceDate - other.timeIntervalSinceReferenceDate) < 0.001
-        }
-    }
-
-    private struct ParseCache: Codable {
-        var version: Int
-        var files: [String: CachedFile]
-    }
-
-    private static func cacheURL() -> URL? {
-        let fm = FileManager.default
-        guard let caches = fm.urls(for: .cachesDirectory, in: .userDomainMask).first else { return nil }
-        let dir = caches.appendingPathComponent("dev.codexisland.CodexIsland", isDirectory: true)
-        try? fm.createDirectory(at: dir, withIntermediateDirectories: true)
-        return dir.appendingPathComponent("codex-parse-cache.v1.json")
-    }
-
-    private static func loadCache() -> ParseCache {
-        guard let url = cacheURL(),
-              let data = try? Data(contentsOf: url),
-              let cache = try? JSONDecoder().decode(ParseCache.self, from: data),
-              cache.version == cacheVersion
-        else { return ParseCache(version: cacheVersion, files: [:]) }
-        return cache
-    }
-
-    private static func saveCache(_ cache: ParseCache) {
-        guard let url = cacheURL(),
-              let data = try? JSONEncoder().encode(cache) else { return }
-        try? data.write(to: url, options: .atomic)
     }
 }

--- a/Sources/Cost/LogParseCache.swift
+++ b/Sources/Cost/LogParseCache.swift
@@ -1,0 +1,161 @@
+import Foundation
+
+/// Shared scaffolding for the per-provider JSONL log readers (Claude, Codex).
+/// Owns the file walk, the (path, mtime, size) cache, and the chunked
+/// streaming reader so both providers behave identically on large rollout
+/// files. Each provider supplies only its `Event` Codable shape and a
+/// `parseFile` closure that consumes lines one at a time.
+enum LogParseCache {
+    struct FileEntry {
+        let url: URL
+        let mtime: Date
+        let size: Int64
+    }
+
+    /// Walks `root` and returns every `*.jsonl` modified at or after `cutoff`.
+    /// Caller can additionally filter by filename via `filter`.
+    static func jsonlFiles(
+        under root: URL,
+        modifiedAfter cutoff: Date,
+        filter: (URL) -> Bool = { _ in true }
+    ) -> [FileEntry] {
+        let fm = FileManager.default
+        guard let enumerator = fm.enumerator(
+            at: root,
+            includingPropertiesForKeys: [.isRegularFileKey, .contentModificationDateKey, .fileSizeKey],
+            options: [.skipsHiddenFiles, .skipsPackageDescendants]
+        ) else { return [] }
+
+        var hits: [FileEntry] = []
+        for case let url as URL in enumerator {
+            guard url.pathExtension == "jsonl", filter(url) else { continue }
+            let values = try? url.resourceValues(forKeys: [.isRegularFileKey, .contentModificationDateKey, .fileSizeKey])
+            guard values?.isRegularFile == true,
+                  let mtime = values?.contentModificationDate,
+                  let size = values?.fileSize else { continue }
+            if mtime < cutoff { continue }
+            hits.append(FileEntry(url: url, mtime: mtime, size: Int64(size)))
+        }
+        return hits
+    }
+
+    /// Stream `url` in 64 KB chunks and invoke `onLine` once per newline-
+    /// terminated line, plus once for any trailing line lacking a newline.
+    /// Session JSONLs can reach 50+ MB and we walk 30 days of them, so
+    /// loading entire files via `Data(contentsOf:)` blows up peak memory.
+    /// Buffer trim happens once per chunk (not per line) — `removeSubrange`
+    /// is O(N) and per-line trimming made a single 50MB JSONL O(N²).
+    static func streamLines(at url: URL, onLine: (Data) -> Void) {
+        guard let handle = try? FileHandle(forReadingFrom: url) else { return }
+        defer { try? handle.close() }
+
+        var buffer = Data()
+        let chunkSize = 64 * 1024
+
+        while true {
+            let chunk = handle.readData(ofLength: chunkSize)
+            if chunk.isEmpty { break }
+            buffer.append(chunk)
+
+            var cursor = buffer.startIndex
+            while cursor < buffer.endIndex {
+                guard let nl = buffer[cursor..<buffer.endIndex].firstIndex(of: 0x0A) else { break }
+                if nl > cursor { onLine(buffer[cursor..<nl]) }
+                cursor = buffer.index(after: nl)
+            }
+            if cursor > buffer.startIndex {
+                buffer.removeSubrange(buffer.startIndex..<cursor)
+            }
+        }
+        if !buffer.isEmpty { onLine(buffer) }
+    }
+
+    /// Per-file cache entry. Generic over the provider's `Event` Codable shape.
+    struct CachedFile<Event: Codable>: Codable {
+        let mtime: Date
+        let size: Int64
+        let events: [Event]
+
+        /// Tolerate sub-millisecond drift through JSON's Double round-trip;
+        /// any real edit moves mtime by far more than that or grows size.
+        func matches(mtime other: Date, size otherSize: Int64) -> Bool {
+            guard size == otherSize else { return false }
+            return abs(mtime.timeIntervalSinceReferenceDate - other.timeIntervalSinceReferenceDate) < 0.001
+        }
+    }
+
+    struct ParseCache<Event: Codable>: Codable {
+        var version: Int
+        var files: [String: CachedFile<Event>]
+    }
+
+    private static func cacheURL(filename: String) -> URL? {
+        let fm = FileManager.default
+        guard let caches = fm.urls(for: .cachesDirectory, in: .userDomainMask).first else { return nil }
+        let dir = caches.appendingPathComponent("dev.codexisland.CodexIsland", isDirectory: true)
+        try? fm.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir.appendingPathComponent(filename)
+    }
+
+    static func loadCache<Event: Codable>(
+        filename: String,
+        version: Int,
+        eventType: Event.Type
+    ) -> ParseCache<Event> {
+        guard let url = cacheURL(filename: filename),
+              let data = try? Data(contentsOf: url),
+              let cache = try? JSONDecoder().decode(ParseCache<Event>.self, from: data),
+              cache.version == version
+        else { return ParseCache<Event>(version: version, files: [:]) }
+        return cache
+    }
+
+    static func saveCache<Event: Codable>(_ cache: ParseCache<Event>, filename: String) {
+        guard let url = cacheURL(filename: filename),
+              let data = try? JSONEncoder().encode(cache) else { return }
+        try? data.write(to: url, options: .atomic)
+    }
+
+    /// Walk `roots`, parse uncached files, and return every cached event
+    /// from files modified on or after `cutoff`. Per-event filtering and
+    /// dedup are the caller's responsibility — this layer only handles
+    /// the cache hit/miss + stale-entry prune.
+    static func walk<Event: Codable>(
+        roots: [URL],
+        cutoff: Date,
+        cacheFilename: String,
+        cacheVersion: Int,
+        fileFilter: (URL) -> Bool = { _ in true },
+        parse: (URL) -> [Event],
+        emit: (Event) -> Void
+    ) {
+        var cache = loadCache(filename: cacheFilename, version: cacheVersion, eventType: Event.self)
+        var visited = Set<String>()
+        var cacheChanged = false
+
+        for root in roots {
+            for entry in jsonlFiles(under: root, modifiedAfter: cutoff, filter: fileFilter) {
+                let path = entry.url.path
+                visited.insert(path)
+
+                let events: [Event]
+                if let hit = cache.files[path], hit.matches(mtime: entry.mtime, size: entry.size) {
+                    events = hit.events
+                } else {
+                    events = parse(entry.url)
+                    cache.files[path] = CachedFile(mtime: entry.mtime, size: entry.size, events: events)
+                    cacheChanged = true
+                }
+                for ev in events { emit(ev) }
+            }
+        }
+
+        // Drop cache entries for files that disappeared or rolled out of the
+        // cutoff — otherwise the cache grows unbounded over months.
+        let preCount = cache.files.count
+        cache.files = cache.files.filter { visited.contains($0.key) }
+        if cache.files.count != preCount { cacheChanged = true }
+
+        if cacheChanged { saveCache(cache, filename: cacheFilename) }
+    }
+}


### PR DESCRIPTION
Addresses audit findings **A5** and **Q1** — the same refactor seen from two angles.

## Summary

`Sources/Cost/ClaudeLogReader.swift` (~285 LOC) and `Sources/Cost/CodexLogReader.swift` (~215 LOC) duplicated ~70-80% of their scaffolding: identical `FileEntry` / `CachedFile` / `ParseCache` types, identical `jsonlFiles(under:modifiedAfter:)` walker, identical (path, mtime, size) cache hit/miss + stale-entry prune.

The two readers also diverged in **one important way** that this PR fixes: `ClaudeLogReader.parseFile` streamed in 64 KB chunks (because session JSONLs reach 50+ MB), while `CodexLogReader.parseFile` used `Data(contentsOf: url)` and loaded each rollout whole. That asymmetry is the maintenance-split risk the duplication created.

## Changes

### New: `Sources/Cost/LogParseCache.swift`

Generic-over-`Event` shared scaffolding:

- `jsonlFiles(under:modifiedAfter:filter:)` — file walk, with optional filename predicate (Codex uses it to gate on the `rollout-` prefix).
- `streamLines(at:onLine:)` — chunked 64 KB `FileHandle` reader, with the `removeSubrange`-once-per-chunk fix so a 50 MB JSONL stays O(N), not O(N²). Also flushes a trailing un-newline-terminated line so the last event of a rollout isn't silently dropped.
- `CachedFile<Event>` / `ParseCache<Event>` — same on-disk Codable shape as before, just generic. Field names unchanged ⇒ byte-identical JSON ⇒ no version bump needed.
- `walk(roots:cutoff:cacheFilename:cacheVersion:fileFilter:parse:emit:)` — high-level loop that handles cache hit/miss, parse, and stale-entry prune. Per-event filtering and dedup stay in the provider's `emit` closure (Claude dedups by `messageId:requestId`; Codex doesn't dedup at all).

### `ClaudeLogReader` and `CodexLogReader` now declare only what differs

Each reader keeps its own `cacheVersion`, `CachedEvent` shape, `parseFile`, and per-event filter/emit logic. Total reduction across the two reader files: **−218 LOC**.

**Codex now uses the chunked streaming reader** — previously it loaded entire rollouts via `Data(contentsOf:)`, which risked spike RSS during scans of 30 days of rollouts. After this PR both providers use identical file I/O.

## Cache compatibility

Verified empirically before commit:

- Existing `~/Library/Caches/dev.codexisland.CodexIsland/claude-parse-cache.v1.json` (7.6 MB) and `codex-parse-cache.v1.json` (124 KB) decode against the new generic types.
- After launching the rebuilt app once, the Codex cache file's MD5 was unchanged (full cache hit, no re-parse), which is the strongest possible signal that the new `ParseCache<CachedEvent>` decoded the on-disk JSON written by the previous types.
- Claude cache file went 7.6 MB → 7.7 MB (incremental write for new live session activity, NOT a collapse-to-empty fallback).

## Test plan

- [x] `./build.sh` compiles cleanly (universal binary).
- [x] Built app launches; existing parse caches survive the round-trip without forced re-scan.
- [ ] Reviewer: optionally delete `~/Library/Caches/dev.codexisland.CodexIsland/*-parse-cache.v1.json` and confirm the cold-start scan + write produces a working cache that subsequent launches load cleanly.