### PR TITLE
fix(release): abort if sign_update emits an empty EdDSA signature

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -70,6 +70,14 @@ if [[ -x "$SIGN_TOOL" && $have_key -eq 1 ]]; then
   SIG_LINE="$("$SIGN_TOOL" ${sign_args[@]+"${sign_args[@]}"} "$DMG")"
   EDSIG="$(echo "$SIG_LINE" | sed -n 's/.*sparkle:edSignature="\([^"]*\)".*/\1/p')"
 
+  # set -euo pipefail only catches non-zero exits; sign_update can exit 0 with
+  # malformed output, which would ship an appcast Sparkle clients reject silently.
+  if [[ -z "${EDSIG:-}" ]]; then
+    echo "error: sign_update produced empty EdDSA signature; aborting release" >&2
+    echo "  raw output: $SIG_LINE" >&2
+    exit 1
+  fi
+
   RELEASE_URL="https://github.com/ericjypark/codex-island/releases/download/v${VERSION}/$(basename "$DMG")"
   PUBDATE="$(LC_TIME=en_US.UTF-8 date -u "+%a, %d %b %Y %H:%M:%S +0000")"
 


### PR DESCRIPTION
## Summary

Adds a non-empty assertion on the EdDSA signature `release.sh` extracts from `sign_update`, before the appcast is written. If the signature is empty, the script aborts.

## Why

`set -euo pipefail` only catches non-zero exits. `sign_update` can exit 0 while emitting malformed output — a format change, stderr-on-stdout, or any other reason that breaks the existing `sed` extraction — and feed an empty signature into the appcast.

Sparkle clients verify the EdDSA signature on every update. An appcast carrying `sparkle:edSignature=""` is rejected silently: no error is surfaced, the update channel just goes dark for every existing install. CLAUDE.md hard rule #2 (never break the public-key chain) applies in spirit here too.

## What changed

`release.sh` — 8-line guard inserted directly after the `EDSIG="$(...)"` extraction. If `EDSIG` is empty, the script writes the raw `sign_update` output to stderr (so CI logs preserve a debugging trail) and exits 1 before any appcast is generated.

## Verification

- `bash -n release.sh` — passes.
- Walked the new branch in `if/else`: empty `EDSIG` triggers the abort; non-empty falls through unchanged.
- No other paths in `release.sh` touched.

Cites audit finding **B1** from the recent improvement audit.