### PR TITLE
feat(localization): add app language override

### DIFF
--- a/Resources/en.lproj/Localizable.strings
+++ b/Resources/en.lproj/Localizable.strings
@@ -48,6 +48,7 @@
 "Daily token usage in %@" = "Daily token usage in %@";
 "Display" = "Display";
 "General" = "General";
+"Follows macOS" = "Follows macOS";
 "Glow only on refresh, hover, or limit alerts." = "Glow only on refresh, hover, or limit alerts.";
 "Idle" = "Idle";
 "idle" = "idle";
@@ -57,6 +58,8 @@
 "last scan %@" = "last scan %@";
 "last scan %@ · pricing data %dd old" = "last scan %@ · pricing data %dd old";
 "Launch at Login" = "Launch at Login";
+"Language" = "Language";
+"Later" = "Later";
 "License" = "License";
 "Live" = "Live";
 "Look for a new version immediately." = "Look for a new version immediately.";
@@ -86,6 +89,8 @@
 "Refreshing…" = "Refreshing…";
 "resets in %@" = "resets in %@";
 "Resets in %@" = "Resets in %@";
+"Restart CodexIsland to apply language?" = "Restart CodexIsland to apply language?";
+"Restart now" = "Restart now";
 "Ring" = "Ring";
 "scanning local logs…" = "scanning local logs…";
 "scanning local logs… · pricing data %dd old" = "scanning local logs… · pricing data %dd old";
@@ -121,6 +126,7 @@
 "waiting for browser…" = "waiting for browser…";
 "You" = "You";
 "Your AI usage limits, living in your notch." = "Your AI usage limits, living in your notch.";
+"Your language change will take effect after CodexIsland restarts." = "Your language change will take effect after CodexIsland restarts.";
 "⌘-click to cycle" = "⌘-click to cycle";
 "⌘1 — pull real provider data" = "⌘1 — pull real provider data";
 "%@ (hidden)" = "%@ (hidden)";

--- a/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Resources/zh-Hans.lproj/Localizable.strings
@@ -48,6 +48,7 @@
 "Daily token usage in %@" = "%@ 年每日 token 用量";
 "Display" = "显示";
 "General" = "通用";
+"Follows macOS" = "跟随 macOS";
 "Glow only on refresh, hover, or limit alerts." = "仅在刷新、悬停或限额提醒时显示辉光。";
 "Idle" = "空闲";
 "idle" = "空闲";
@@ -57,6 +58,8 @@
 "last scan %@" = "上次扫描 %@";
 "last scan %@ · pricing data %dd old" = "上次扫描 %@ · 价格数据已过 %d 天";
 "Launch at Login" = "登录时启动";
+"Language" = "语言";
+"Later" = "稍后";
 "License" = "许可证";
 "Live" = "实时";
 "Look for a new version immediately." = "立即检查是否有新版本。";
@@ -86,6 +89,8 @@
 "Refreshing…" = "正在刷新…";
 "resets in %@" = "%@ 后重置";
 "Resets in %@" = "%@ 后重置";
+"Restart CodexIsland to apply language?" = "重启 CodexIsland 以应用语言？";
+"Restart now" = "立即重启";
 "Ring" = "环形";
 "scanning local logs…" = "正在扫描本地日志…";
 "scanning local logs… · pricing data %dd old" = "正在扫描本地日志… · 价格数据已过 %d 天";
@@ -121,6 +126,7 @@
 "waiting for browser…" = "等待浏览器…";
 "You" = "你";
 "Your AI usage limits, living in your notch." = "你的 AI 用量限额，住在 Mac 刘海里。";
+"Your language change will take effect after CodexIsland restarts." = "语言更改会在 CodexIsland 重启后生效。";
 "⌘-click to cycle" = "⌘ 点击切换";
 "⌘1 — pull real provider data" = "⌘1 — 拉取真实服务数据";
 "%@ (hidden)" = "%@（已隐藏）";

--- a/Sources/Cost/CostBucketing.swift
+++ b/Sources/Cost/CostBucketing.swift
@@ -15,7 +15,7 @@ enum CostBucketing {
 
     private static let monthFormatter: DateFormatter = {
         let f = DateFormatter()
-        f.locale = .current
+        f.locale = L10n.locale
         f.timeZone = .current
         f.setLocalizedDateFormatFromTemplate("MMM")
         return f

--- a/Sources/Localization/L10n.swift
+++ b/Sources/Localization/L10n.swift
@@ -1,11 +1,22 @@
 import Foundation
 
 enum L10n {
+    static var locale: Locale {
+        AppLanguageResolver.locale
+    }
+
     static func tr(_ key: String) -> String {
-        NSLocalizedString(key, comment: "")
+        if let bundle = AppLanguageResolver.bundle {
+            let localized = bundle.localizedString(forKey: key, value: nil, table: nil)
+            if localized != key { return localized }
+            if let fallback = AppLanguageResolver.englishBundle {
+                return fallback.localizedString(forKey: key, value: key, table: nil)
+            }
+        }
+        return NSLocalizedString(key, comment: "")
     }
 
     static func tr(_ key: String, _ arguments: CVarArg...) -> String {
-        String(format: tr(key), locale: Locale.current, arguments: arguments)
+        String(format: tr(key), locale: locale, arguments: arguments)
     }
 }

--- a/Sources/Model/AppLanguageStore.swift
+++ b/Sources/Model/AppLanguageStore.swift
@@ -1,0 +1,95 @@
+import AppKit
+import Foundation
+
+enum AppLanguage: String, CaseIterable, Hashable {
+    case auto
+    case en
+    case zhHans = "zh-Hans"
+
+    var resourceName: String? {
+        switch self {
+        case .auto: nil
+        default: rawValue
+        }
+    }
+
+    var localeIdentifier: String {
+        switch self {
+        case .auto: Locale.current.identifier
+        case .en: "en"
+        case .zhHans: "zh-Hans"
+        }
+    }
+
+    var menuLabel: String {
+        switch self {
+        case .auto: L10n.tr("Auto")
+        case .en: "English"
+        case .zhHans: "简体中文"
+        }
+    }
+
+    var subtitle: String {
+        switch self {
+        case .auto: L10n.tr("Follows macOS")
+        default: menuLabel
+        }
+    }
+}
+
+enum AppLanguageResolver {
+    static let key = "MacIsland.appLanguage"
+
+    static var current: AppLanguage {
+        let raw = UserDefaults.standard.string(forKey: key) ?? ""
+        return AppLanguage(rawValue: raw) ?? .auto
+    }
+
+    static var locale: Locale {
+        Locale(identifier: current.localeIdentifier)
+    }
+
+    static var bundle: Bundle? {
+        guard let resourceName = current.resourceName,
+              let path = Bundle.main.path(forResource: resourceName, ofType: "lproj")
+        else { return nil }
+        return Bundle(path: path)
+    }
+
+    static var englishBundle: Bundle? {
+        guard let path = Bundle.main.path(forResource: "en", ofType: "lproj") else { return nil }
+        return Bundle(path: path)
+    }
+}
+
+@MainActor
+final class AppLanguageStore: ObservableObject {
+    static let shared = AppLanguageStore()
+
+    @Published var language: AppLanguage {
+        didSet { UserDefaults.standard.set(language.rawValue, forKey: AppLanguageResolver.key) }
+    }
+
+    private init() {
+        language = AppLanguageResolver.current
+    }
+
+    @discardableResult
+    func select(_ newLanguage: AppLanguage) -> Bool {
+        guard language != newLanguage else { return false }
+        language = newLanguage
+        return true
+    }
+
+    func restartApp() {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/open")
+        task.arguments = ["-n", Bundle.main.bundleURL.path]
+        do {
+            try task.run()
+            NSApp.terminate(nil)
+        } catch {
+            NSLog("CodexIsland: failed to restart app: %@", error.localizedDescription)
+        }
+    }
+}

--- a/Sources/Views/OverviewView.swift
+++ b/Sources/Views/OverviewView.swift
@@ -244,7 +244,7 @@ struct OverviewView: View {
 
     private static let dayLabelFormatter: DateFormatter = {
         let formatter = DateFormatter()
-        formatter.locale = .current
+        formatter.locale = L10n.locale
         formatter.timeZone = .current
         formatter.setLocalizedDateFormatFromTemplate("MMM d")
         return formatter
@@ -253,7 +253,7 @@ struct OverviewView: View {
     private static let integerFormatter: NumberFormatter = {
         let formatter = NumberFormatter()
         formatter.numberStyle = .decimal
-        formatter.locale = .current
+        formatter.locale = L10n.locale
         return formatter
     }()
 
@@ -452,7 +452,7 @@ private struct ContributionGrid: View {
 
     private static let monthFormatter: DateFormatter = {
         let formatter = DateFormatter()
-        formatter.locale = .current
+        formatter.locale = L10n.locale
         formatter.timeZone = .current
         formatter.setLocalizedDateFormatFromTemplate("MMM")
         return formatter
@@ -595,7 +595,7 @@ private struct ContributionCell: View {
 
     private static let dayFormatter: DateFormatter = {
         let formatter = DateFormatter()
-        formatter.locale = .current
+        formatter.locale = L10n.locale
         formatter.timeZone = .current
         formatter.setLocalizedDateFormatFromTemplate("MMM d")
         return formatter
@@ -770,7 +770,7 @@ private struct DayDetailStrip: View {
 
     private static let detailFormatter: DateFormatter = {
         let formatter = DateFormatter()
-        formatter.locale = .current
+        formatter.locale = L10n.locale
         formatter.timeZone = .current
         formatter.setLocalizedDateFormatFromTemplate("EEE MMM d")
         return formatter

--- a/Sources/Views/PanelFooter.swift
+++ b/Sources/Views/PanelFooter.swift
@@ -195,6 +195,7 @@ struct PanelFooter: View {
 
     private static let relativeFormatter: RelativeDateTimeFormatter = {
         let f = RelativeDateTimeFormatter()
+        f.locale = L10n.locale
         f.unitsStyle = .abbreviated
         return f
     }()

--- a/Sources/Views/SettingsView.swift
+++ b/Sources/Views/SettingsView.swift
@@ -17,6 +17,7 @@ struct SettingsView: View {
     @ObservedObject private var alertPrefs = AlertThresholdStore.shared
     @ObservedObject private var spacing = IslandSpacingStore.shared
     @ObservedObject private var targetDisplay = IslandTargetDisplayStore.shared
+    @ObservedObject private var appLanguage = AppLanguageStore.shared
     @ObservedObject private var usage = UsageStore.shared
     @ObservedObject private var cost = CostStore.shared
     @ObservedObject private var updater = UpdaterController.shared
@@ -203,6 +204,12 @@ struct SettingsView: View {
                 subtitle: "How often to refresh."
             ) {
                 refreshSegmented
+            }
+            SettingsRow(
+                title: "Language",
+                subtitle: appLanguage.language.subtitle
+            ) {
+                languagePicker
             }
             SettingsRow(
                 title: "Low Power Mode",
@@ -436,6 +443,40 @@ struct SettingsView: View {
         .padding(.bottom, 6)
     }
 
+    private var languagePicker: some View {
+        Picker("", selection: languageSelection) {
+            ForEach(AppLanguage.allCases, id: \.self) { language in
+                Text(language.menuLabel).tag(language)
+            }
+        }
+        .labelsHidden()
+        .pickerStyle(.menu)
+        .frame(maxWidth: 220)
+        .accessibilityLabel(L10n.tr("Language"))
+    }
+
+    private var languageSelection: Binding<AppLanguage> {
+        Binding(
+            get: { appLanguage.language },
+            set: { newLanguage in
+                if appLanguage.select(newLanguage) {
+                    showLanguageRestartPrompt()
+                }
+            }
+        )
+    }
+
+    private func showLanguageRestartPrompt() {
+        let alert = NSAlert()
+        alert.messageText = L10n.tr("Restart CodexIsland to apply language?")
+        alert.informativeText = L10n.tr("Your language change will take effect after CodexIsland restarts.")
+        alert.addButton(withTitle: L10n.tr("Restart now"))
+        alert.addButton(withTitle: L10n.tr("Later"))
+        if alert.runModal() == .alertFirstButtonReturn {
+            appLanguage.restartApp()
+        }
+    }
+
     private var providersSection: some View {
         VStack(alignment: .leading, spacing: 0) {
             sectionLabel("Providers")
@@ -545,6 +586,7 @@ struct SettingsView: View {
 
     private static let relativeFormatter: RelativeDateTimeFormatter = {
         let f = RelativeDateTimeFormatter()
+        f.locale = L10n.locale
         f.unitsStyle = .abbreviated
         return f
     }()


### PR DESCRIPTION
## Summary
- add an app language override setting with Auto following macOS
- keep this PR limited to the app localization infrastructure slice requested by the maintainer
- support the current reviewed app locales: English and Simplified Chinese
- route date, relative time, and number formatting through the selected app locale after restart

## Scope
This PR intentionally does not include the broader global locale resources, localized README files, localization guide, or validation scripts. Those are better handled in smaller follow-up PRs.

## Validation
- plutil -lint Resources/en.lproj/Localizable.strings Resources/zh-Hans.lproj/Localizable.strings
- checked en / zh-Hans Localizable.strings key parity
- git diff --cached --check
- ./scripts/verify.sh
- find build/CodexIsland.app/Contents/Resources -maxdepth 2 -name Localizable.strings -print | sort

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added language selection to Settings with support for following macOS system language or choosing a specific language
  * App now prompts users to restart when language preference changes
  
* **Localization**
  * Added English and Chinese localization strings for language selection interface and restart messaging
  * Date and time formatting now respects app language preference instead of system locale

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ericjypark/codex-island/pull/21?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->