### PR TITLE
feat: in-app language selector + always-show-usage toggle

### DIFF
--- a/Resources/en.lproj/Localizable.strings
+++ b/Resources/en.lproj/Localizable.strings
@@ -21,6 +21,7 @@
 "All Tokens" = "All Tokens";
 "TOTAL" = "TOTAL";
 "Total" = "Total";
+"Always show usage" = "Always show usage";
 "Approaching-limit alerts" = "Approaching-limit alerts";
 "Alerts" = "Alerts";
 "Auto" = "Auto";
@@ -137,6 +138,7 @@
 "Command-click to cycle visualization." = "Command-click to cycle visualization.";
 "Hover to peek usage. Click to expand. Command-click to cycle visualization." = "Hover to peek usage. Click to expand. Command-click to cycle visualization.";
 "How often to refresh." = "How often to refresh.";
+"Keep the percentage and time remaining visible without hovering." = "Keep the percentage and time remaining visible without hovering.";
 "Inject test percentages. Visible only when launched with CODEXISLAND_DEBUG=1." = "Inject test percentages. Visible only when launched with CODEXISLAND_DEBUG=1.";
 "Preview" = "Preview";
 "resets in %d hours" = "resets in %d hours";

--- a/Resources/en.lproj/Localizable.strings
+++ b/Resources/en.lproj/Localizable.strings
@@ -48,6 +48,7 @@
 "Daily token usage in %@" = "Daily token usage in %@";
 "Display" = "Display";
 "General" = "General";
+"Follows macOS" = "Follows macOS";
 "Glow only on refresh, hover, or limit alerts." = "Glow only on refresh, hover, or limit alerts.";
 "Idle" = "Idle";
 "idle" = "idle";
@@ -57,6 +58,8 @@
 "last scan %@" = "last scan %@";
 "last scan %@ · pricing data %dd old" = "last scan %@ · pricing data %dd old";
 "Launch at Login" = "Launch at Login";
+"Language" = "Language";
+"Later" = "Later";
 "License" = "License";
 "Live" = "Live";
 "Look for a new version immediately." = "Look for a new version immediately.";
@@ -86,6 +89,8 @@
 "Refreshing…" = "Refreshing…";
 "resets in %@" = "resets in %@";
 "Resets in %@" = "Resets in %@";
+"Restart CodexIsland to apply language?" = "Restart CodexIsland to apply language?";
+"Restart now" = "Restart now";
 "Ring" = "Ring";
 "scanning local logs…" = "scanning local logs…";
 "scanning local logs… · pricing data %dd old" = "scanning local logs… · pricing data %dd old";
@@ -121,6 +126,7 @@
 "waiting for browser…" = "waiting for browser…";
 "You" = "You";
 "Your AI usage limits, living in your notch." = "Your AI usage limits, living in your notch.";
+"Your language change will take effect after CodexIsland restarts." = "Your language change will take effect after CodexIsland restarts.";
 "⌘-click to cycle" = "⌘-click to cycle";
 "⌘1 — pull real provider data" = "⌘1 — pull real provider data";
 "%@ (hidden)" = "%@ (hidden)";

--- a/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Resources/zh-Hans.lproj/Localizable.strings
@@ -21,6 +21,7 @@
 "All Tokens" = "全部 Token";
 "TOTAL" = "总计";
 "Total" = "总计";
+"Always show usage" = "始终显示使用量";
 "Approaching-limit alerts" = "接近限额提醒";
 "Alerts" = "提醒";
 "Auto" = "自动";
@@ -137,6 +138,7 @@
 "Command-click to cycle visualization." = "Command 点击可切换可视化。";
 "Hover to peek usage. Click to expand. Command-click to cycle visualization." = "悬停预览用量。点击展开。Command 点击可切换可视化。";
 "How often to refresh." = "刷新频率。";
+"Keep the percentage and time remaining visible without hovering." = "无需悬停即可始终查看用量百分比和剩余时间。";
 "Inject test percentages. Visible only when launched with CODEXISLAND_DEBUG=1." = "注入测试百分比。仅在使用 CODEXISLAND_DEBUG=1 启动时显示。";
 "Preview" = "预览";
 "resets in %d hours" = "%d 小时后重置";

--- a/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Resources/zh-Hans.lproj/Localizable.strings
@@ -48,6 +48,7 @@
 "Daily token usage in %@" = "%@ 年每日 token 用量";
 "Display" = "显示";
 "General" = "通用";
+"Follows macOS" = "跟随 macOS";
 "Glow only on refresh, hover, or limit alerts." = "仅在刷新、悬停或限额提醒时显示辉光。";
 "Idle" = "空闲";
 "idle" = "空闲";
@@ -57,6 +58,8 @@
 "last scan %@" = "上次扫描 %@";
 "last scan %@ · pricing data %dd old" = "上次扫描 %@ · 价格数据已过 %d 天";
 "Launch at Login" = "登录时启动";
+"Language" = "语言";
+"Later" = "稍后";
 "License" = "许可证";
 "Live" = "实时";
 "Look for a new version immediately." = "立即检查是否有新版本。";
@@ -86,6 +89,8 @@
 "Refreshing…" = "正在刷新…";
 "resets in %@" = "%@ 后重置";
 "Resets in %@" = "%@ 后重置";
+"Restart CodexIsland to apply language?" = "重启 CodexIsland 以应用语言？";
+"Restart now" = "立即重启";
 "Ring" = "环形";
 "scanning local logs…" = "正在扫描本地日志…";
 "scanning local logs… · pricing data %dd old" = "正在扫描本地日志… · 价格数据已过 %d 天";
@@ -121,6 +126,7 @@
 "waiting for browser…" = "等待浏览器…";
 "You" = "你";
 "Your AI usage limits, living in your notch." = "你的 AI 用量限额，住在 Mac 刘海里。";
+"Your language change will take effect after CodexIsland restarts." = "语言更改会在 CodexIsland 重启后生效。";
 "⌘-click to cycle" = "⌘ 点击切换";
 "⌘1 — pull real provider data" = "⌘1 — 拉取真实服务数据";
 "%@ (hidden)" = "%@（已隐藏）";

--- a/Sources/Cost/CostBucketing.swift
+++ b/Sources/Cost/CostBucketing.swift
@@ -15,7 +15,7 @@ enum CostBucketing {
 
     private static let monthFormatter: DateFormatter = {
         let f = DateFormatter()
-        f.locale = .current
+        f.locale = L10n.locale
         f.timeZone = .current
         f.setLocalizedDateFormatFromTemplate("MMM")
         return f

--- a/Sources/Localization/L10n.swift
+++ b/Sources/Localization/L10n.swift
@@ -1,11 +1,22 @@
 import Foundation
 
 enum L10n {
+    static var locale: Locale {
+        AppLanguageResolver.locale
+    }
+
     static func tr(_ key: String) -> String {
-        NSLocalizedString(key, comment: "")
+        if let bundle = AppLanguageResolver.bundle {
+            let localized = bundle.localizedString(forKey: key, value: nil, table: nil)
+            if localized != key { return localized }
+            if let fallback = AppLanguageResolver.englishBundle {
+                return fallback.localizedString(forKey: key, value: key, table: nil)
+            }
+        }
+        return NSLocalizedString(key, comment: "")
     }
 
     static func tr(_ key: String, _ arguments: CVarArg...) -> String {
-        String(format: tr(key), locale: Locale.current, arguments: arguments)
+        String(format: tr(key), locale: locale, arguments: arguments)
     }
 }

--- a/Sources/Model/AlwaysShowUsageStore.swift
+++ b/Sources/Model/AlwaysShowUsageStore.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+/// User preference for keeping the peek-state percentage pills visible at
+/// rest, without requiring a hover.
+///
+/// Default off: the pills only appear during hover/peek, then collapse with
+/// the silhouette back to compact. With this on, the island launches into
+/// `.peek` and stays there — hover-out keeps the pill visible, expanded-out
+/// returns to peek instead of compact.
+@MainActor
+final class AlwaysShowUsageStore: ObservableObject {
+    static let shared = AlwaysShowUsageStore()
+
+    private static let key = "MacIsland.alwaysShowUsage"
+
+    @Published var enabled: Bool {
+        didSet { UserDefaults.standard.set(enabled, forKey: Self.key) }
+    }
+
+    private init() {
+        // UserDefaults.bool returns false for missing keys, which matches our
+        // intended default (off → preserves the existing hover-only behavior
+        // for users who upgrade).
+        self.enabled = UserDefaults.standard.bool(forKey: Self.key)
+    }
+}

--- a/Sources/Model/AppLanguageStore.swift
+++ b/Sources/Model/AppLanguageStore.swift
@@ -1,0 +1,95 @@
+import AppKit
+import Foundation
+
+enum AppLanguage: String, CaseIterable, Hashable {
+    case auto
+    case en
+    case zhHans = "zh-Hans"
+
+    var resourceName: String? {
+        switch self {
+        case .auto: nil
+        default: rawValue
+        }
+    }
+
+    var localeIdentifier: String {
+        switch self {
+        case .auto: Locale.current.identifier
+        case .en: "en"
+        case .zhHans: "zh-Hans"
+        }
+    }
+
+    var menuLabel: String {
+        switch self {
+        case .auto: L10n.tr("Auto")
+        case .en: "English"
+        case .zhHans: "简体中文"
+        }
+    }
+
+    var subtitle: String {
+        switch self {
+        case .auto: L10n.tr("Follows macOS")
+        default: menuLabel
+        }
+    }
+}
+
+enum AppLanguageResolver {
+    static let key = "MacIsland.appLanguage"
+
+    static var current: AppLanguage {
+        let raw = UserDefaults.standard.string(forKey: key) ?? ""
+        return AppLanguage(rawValue: raw) ?? .auto
+    }
+
+    static var locale: Locale {
+        Locale(identifier: current.localeIdentifier)
+    }
+
+    static var bundle: Bundle? {
+        guard let resourceName = current.resourceName,
+              let path = Bundle.main.path(forResource: resourceName, ofType: "lproj")
+        else { return nil }
+        return Bundle(path: path)
+    }
+
+    static var englishBundle: Bundle? {
+        guard let path = Bundle.main.path(forResource: "en", ofType: "lproj") else { return nil }
+        return Bundle(path: path)
+    }
+}
+
+@MainActor
+final class AppLanguageStore: ObservableObject {
+    static let shared = AppLanguageStore()
+
+    @Published var language: AppLanguage {
+        didSet { UserDefaults.standard.set(language.rawValue, forKey: AppLanguageResolver.key) }
+    }
+
+    private init() {
+        language = AppLanguageResolver.current
+    }
+
+    @discardableResult
+    func select(_ newLanguage: AppLanguage) -> Bool {
+        guard language != newLanguage else { return false }
+        language = newLanguage
+        return true
+    }
+
+    func restartApp() {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/open")
+        task.arguments = ["-n", Bundle.main.bundleURL.path]
+        do {
+            try task.run()
+            NSApp.terminate(nil)
+        } catch {
+            NSLog("CodexIsland: failed to restart app: %@", error.localizedDescription)
+        }
+    }
+}

--- a/Sources/Views/IslandRootView.swift
+++ b/Sources/Views/IslandRootView.swift
@@ -3,6 +3,7 @@ import AppKit
 
 struct IslandRootView: View {
     @ObservedObject var model: IslandModel
+    @ObservedObject private var alwaysShow = AlwaysShowUsageStore.shared
     @State private var hovering = false
     @State private var contentVisible = false
     @State private var pillsVisible = false
@@ -177,19 +178,32 @@ struct IslandRootView: View {
                             }
                         }
                     } else {
-                        // EXIT: pills fade first, then shape collapses.
-                        // Branches by state so peek-out shrinks to compact
-                        // and expanded-out collapses the panel content too.
-                        withAnimation(.easeOut(duration: 0.08)) {
-                            pillsVisible = false
+                        // EXIT: pills fade first (unless we're pinning peek),
+                        // then the shape settles at the rest state — `.compact`
+                        // normally, `.peek` under always-show.
+                        let target = restState
+                        if !alwaysShow.enabled {
+                            withAnimation(.easeOut(duration: 0.08)) {
+                                pillsVisible = false
+                            }
                         }
                         withAnimation(.easeOut(duration: 0.10)) {
                             contentVisible = false
                         }
                         DispatchQueue.main.asyncAfter(deadline: .now() + 0.10) {
                             guard !hovering else { return }
-                            withAnimation(.closeMorph) {
-                                model.setState(.compact)
+                            if model.state != target {
+                                withAnimation(.closeMorph) {
+                                    model.setState(target)
+                                }
+                            }
+                            // Coming out of `.expanded` under always-show, the
+                            // pills were hidden by the open-panel branch — bring
+                            // them back as the shape resettles at peek.
+                            if alwaysShow.enabled && !pillsVisible {
+                                withAnimation(.easeOut(duration: 0.18)) {
+                                    pillsVisible = true
+                                }
                             }
                         }
                     }
@@ -208,6 +222,46 @@ struct IslandRootView: View {
             if openaiLogo == nil {
                 openaiLogo = Bundle.main.url(forResource: "openai_logo", withExtension: "pdf")
                     .flatMap { NSImage(contentsOf: $0) }
+            }
+            // Snap to peek on launch when the user has opted into always-show.
+            // No animation here — the window is just becoming visible, so the
+            // user sees the silhouette appear already at peek width rather
+            // than morphing out under their gaze.
+            if alwaysShow.enabled && model.state == .compact {
+                model.setState(.peek)
+                pillsVisible = true
+            }
+        }
+        .onChange(of: alwaysShow.enabled) { enabled in
+            // Live toggle — defer to the user's current interaction. If they
+            // happen to be hovering, the hover state machine owns the morph
+            // and will land on the new rest state on hover-out. If the panel
+            // is expanded, leave it alone for the same reason.
+            guard !hovering, model.state != .expanded else { return }
+            if enabled {
+                if model.state == .compact {
+                    withAnimation(.openMorph) {
+                        model.setState(.peek)
+                    }
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.06) {
+                        guard model.state == .peek, !hovering else { return }
+                        withAnimation(.easeOut(duration: 0.18)) {
+                            pillsVisible = true
+                        }
+                    }
+                }
+            } else {
+                if model.state == .peek {
+                    withAnimation(.easeOut(duration: 0.08)) {
+                        pillsVisible = false
+                    }
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.10) {
+                        guard !hovering, model.state == .peek else { return }
+                        withAnimation(.closeMorph) {
+                            model.setState(.compact)
+                        }
+                    }
+                }
             }
         }
         .onReceive(AlertEngine.shared.$pulseEvent) { event in
@@ -244,8 +298,10 @@ struct IslandRootView: View {
         DispatchQueue.main.asyncAfter(deadline: .now() + 4.0) {
             // If the user is hovering or has expanded the panel meanwhile,
             // don't fight their state — let their interaction own the peek
-            // lifecycle from here.
-            guard !hovering, model.state == .peek else { return }
+            // lifecycle from here. Under always-show, `.peek` IS the rest
+            // state, so the pulse just resolves into the steady-state pill
+            // rather than collapsing back to compact.
+            guard !hovering, model.state == .peek, !alwaysShow.enabled else { return }
             withAnimation(.easeOut(duration: 0.08)) {
                 pillsVisible = false
             }
@@ -258,9 +314,16 @@ struct IslandRootView: View {
         }
     }
 
+    private var restState: IslandModel.State {
+        alwaysShow.enabled ? .peek : .compact
+    }
+
     private var accessibilityHintForState: String {
         switch model.state {
-        case .compact:  return L10n.tr("Hover to peek usage. Click to expand. Command-click to cycle visualization.")
+        case .compact:
+            return alwaysShow.enabled
+                ? L10n.tr("Click to expand. Command-click to cycle visualization.")
+                : L10n.tr("Hover to peek usage. Click to expand. Command-click to cycle visualization.")
         case .peek:     return L10n.tr("Click to expand. Command-click to cycle visualization.")
         case .expanded:
             return ScreenPref.shared.screen == .overview

--- a/Sources/Views/OverviewView.swift
+++ b/Sources/Views/OverviewView.swift
@@ -244,7 +244,7 @@ struct OverviewView: View {
 
     private static let dayLabelFormatter: DateFormatter = {
         let formatter = DateFormatter()
-        formatter.locale = .current
+        formatter.locale = L10n.locale
         formatter.timeZone = .current
         formatter.setLocalizedDateFormatFromTemplate("MMM d")
         return formatter
@@ -253,7 +253,7 @@ struct OverviewView: View {
     private static let integerFormatter: NumberFormatter = {
         let formatter = NumberFormatter()
         formatter.numberStyle = .decimal
-        formatter.locale = .current
+        formatter.locale = L10n.locale
         return formatter
     }()
 
@@ -452,7 +452,7 @@ private struct ContributionGrid: View {
 
     private static let monthFormatter: DateFormatter = {
         let formatter = DateFormatter()
-        formatter.locale = .current
+        formatter.locale = L10n.locale
         formatter.timeZone = .current
         formatter.setLocalizedDateFormatFromTemplate("MMM")
         return formatter
@@ -595,7 +595,7 @@ private struct ContributionCell: View {
 
     private static let dayFormatter: DateFormatter = {
         let formatter = DateFormatter()
-        formatter.locale = .current
+        formatter.locale = L10n.locale
         formatter.timeZone = .current
         formatter.setLocalizedDateFormatFromTemplate("MMM d")
         return formatter
@@ -770,7 +770,7 @@ private struct DayDetailStrip: View {
 
     private static let detailFormatter: DateFormatter = {
         let formatter = DateFormatter()
-        formatter.locale = .current
+        formatter.locale = L10n.locale
         formatter.timeZone = .current
         formatter.setLocalizedDateFormatFromTemplate("EEE MMM d")
         return formatter

--- a/Sources/Views/PanelFooter.swift
+++ b/Sources/Views/PanelFooter.swift
@@ -195,6 +195,7 @@ struct PanelFooter: View {
 
     private static let relativeFormatter: RelativeDateTimeFormatter = {
         let f = RelativeDateTimeFormatter()
+        f.locale = L10n.locale
         f.unitsStyle = .abbreviated
         return f
     }()

--- a/Sources/Views/SettingsView.swift
+++ b/Sources/Views/SettingsView.swift
@@ -460,7 +460,7 @@ struct SettingsView: View {
         }
         .labelsHidden()
         .pickerStyle(.menu)
-        .frame(maxWidth: 220)
+        .fixedSize()
         .accessibilityLabel(L10n.tr("Language"))
     }
 

--- a/Sources/Views/SettingsView.swift
+++ b/Sources/Views/SettingsView.swift
@@ -17,6 +17,7 @@ struct SettingsView: View {
     @ObservedObject private var alertPrefs = AlertThresholdStore.shared
     @ObservedObject private var spacing = IslandSpacingStore.shared
     @ObservedObject private var targetDisplay = IslandTargetDisplayStore.shared
+    @ObservedObject private var appLanguage = AppLanguageStore.shared
     @ObservedObject private var usage = UsageStore.shared
     @ObservedObject private var cost = CostStore.shared
     @ObservedObject private var updater = UpdaterController.shared
@@ -203,6 +204,12 @@ struct SettingsView: View {
                 subtitle: "How often to refresh."
             ) {
                 refreshSegmented
+            }
+            SettingsRow(
+                title: "Language",
+                subtitle: appLanguage.language.subtitle
+            ) {
+                languagePicker
             }
             SettingsRow(
                 title: "Low Power Mode",
@@ -436,6 +443,40 @@ struct SettingsView: View {
         .padding(.bottom, 6)
     }
 
+    private var languagePicker: some View {
+        Picker("", selection: languageSelection) {
+            ForEach(AppLanguage.allCases, id: \.self) { language in
+                Text(language.menuLabel).tag(language)
+            }
+        }
+        .labelsHidden()
+        .pickerStyle(.menu)
+        .frame(maxWidth: 220)
+        .accessibilityLabel(L10n.tr("Language"))
+    }
+
+    private var languageSelection: Binding<AppLanguage> {
+        Binding(
+            get: { appLanguage.language },
+            set: { newLanguage in
+                if appLanguage.select(newLanguage) {
+                    showLanguageRestartPrompt()
+                }
+            }
+        )
+    }
+
+    private func showLanguageRestartPrompt() {
+        let alert = NSAlert()
+        alert.messageText = L10n.tr("Restart CodexIsland to apply language?")
+        alert.informativeText = L10n.tr("Your language change will take effect after CodexIsland restarts.")
+        alert.addButton(withTitle: L10n.tr("Restart now"))
+        alert.addButton(withTitle: L10n.tr("Later"))
+        if alert.runModal() == .alertFirstButtonReturn {
+            appLanguage.restartApp()
+        }
+    }
+
     private var providersSection: some View {
         VStack(alignment: .leading, spacing: 0) {
             sectionLabel("Providers")
@@ -545,6 +586,7 @@ struct SettingsView: View {
 
     private static let relativeFormatter: RelativeDateTimeFormatter = {
         let f = RelativeDateTimeFormatter()
+        f.locale = L10n.locale
         f.unitsStyle = .abbreviated
         return f
     }()

--- a/Sources/Views/SettingsView.swift
+++ b/Sources/Views/SettingsView.swift
@@ -14,6 +14,7 @@ struct SettingsView: View {
     @ObservedObject private var refreshStore = RefreshIntervalStore.shared
     @ObservedObject private var tokenMode = TokenCountModeStore.shared
     @ObservedObject private var lowPower = LowPowerModeStore.shared
+    @ObservedObject private var alwaysShow = AlwaysShowUsageStore.shared
     @ObservedObject private var alertPrefs = AlertThresholdStore.shared
     @ObservedObject private var spacing = IslandSpacingStore.shared
     @ObservedObject private var targetDisplay = IslandTargetDisplayStore.shared
@@ -210,6 +211,14 @@ struct SettingsView: View {
                 subtitle: appLanguage.language.subtitle
             ) {
                 languagePicker
+            }
+            SettingsRow(
+                title: "Always show usage",
+                subtitle: "Keep the percentage and time remaining visible without hovering."
+            ) {
+                SettingsToggle(isOn: alwaysShow.enabled) {
+                    alwaysShow.enabled.toggle()
+                }
             }
             SettingsRow(
                 title: "Low Power Mode",


### PR DESCRIPTION
## Summary

Two user-facing Settings additions on the General tab, bundled because the second item surfaced while testing the first:

1. **In-app language override** (`6684944`) — picker that overrides `AppleLanguages` per-app instead of forcing users to switch their whole system locale. Persists across launches; shows a restart prompt because the resource bundle is loaded once at startup.
2. **Always show usage** (`1d3353c`, closes #23) — opt-in toggle that pins the peek-state pills (`70% · 4h`) visible at rest. The island launches into `.peek` and stays there: hover-out preserves peek instead of collapsing to compact, the 4-second alert-pulse auto-collapse is suppressed (peek is the rest state already), and the accessibility hint drops the \"hover to peek\" line. Default off, so upgraders see no behavior change.
3. **Right-align language picker** (`f7308c2`) — `.frame(maxWidth: 220)` left the menu button at the leading edge of an invisible 220pt frame. `.fixedSize()` collapses it to its intrinsic width so `SettingsRow`'s `Spacer` pushes it flush right like the other rows' controls.

Closes #23.

## Test plan

- [ ] Toggle **Always show usage** on → pills appear immediately, persist when cursor leaves the island, persist after expanding and re-collapsing the panel.
- [ ] Toggle it off while pills are visible → island morphs back to compact with the same `.closeMorph` spring as a hover-exit.
- [ ] Quit + relaunch with the toggle on → island appears at peek width on first paint (no compact-flash).
- [ ] With the toggle on and a 5h window above the configured warning threshold, the alert pulse no longer collapses back to compact after 4s.
- [ ] Settings → General: Language picker sits flush right, matching the toggles and segmented controls.
- [ ] Language picker switch → restart prompt fires; after restart the new UI language applies.
- [ ] VoiceOver hint on the silhouette in compact state reads \"Click to expand…\" (not \"Hover to peek…\") when always-show is on.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Always show usage" setting to keep usage information permanently visible without hovering.
  * Added language selection with support for English and Simplified Chinese; language changes take effect after app restart.

* **Localization**
  * Added English and Simplified Chinese UI text strings.
  * Enhanced localization support for date and time formatting across the app.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ericjypark/codex-island/pull/25?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->