### PR TITLE
feat(island): add always-show-usage toggle + right-align language picker

### DIFF
--- a/Resources/en.lproj/Localizable.strings
+++ b/Resources/en.lproj/Localizable.strings
@@ -21,6 +21,7 @@
 "All Tokens" = "All Tokens";
 "TOTAL" = "TOTAL";
 "Total" = "Total";
+"Always show usage" = "Always show usage";
 "Approaching-limit alerts" = "Approaching-limit alerts";
 "Alerts" = "Alerts";
 "Auto" = "Auto";
@@ -137,6 +138,7 @@
 "Command-click to cycle visualization." = "Command-click to cycle visualization.";
 "Hover to peek usage. Click to expand. Command-click to cycle visualization." = "Hover to peek usage. Click to expand. Command-click to cycle visualization.";
 "How often to refresh." = "How often to refresh.";
+"Keep the percentage and time remaining visible without hovering." = "Keep the percentage and time remaining visible without hovering.";
 "Inject test percentages. Visible only when launched with CODEXISLAND_DEBUG=1." = "Inject test percentages. Visible only when launched with CODEXISLAND_DEBUG=1.";
 "Preview" = "Preview";
 "resets in %d hours" = "resets in %d hours";

--- a/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Resources/zh-Hans.lproj/Localizable.strings
@@ -21,6 +21,7 @@
 "All Tokens" = "全部 Token";
 "TOTAL" = "总计";
 "Total" = "总计";
+"Always show usage" = "始终显示使用量";
 "Approaching-limit alerts" = "接近限额提醒";
 "Alerts" = "提醒";
 "Auto" = "自动";
@@ -137,6 +138,7 @@
 "Command-click to cycle visualization." = "Command 点击可切换可视化。";
 "Hover to peek usage. Click to expand. Command-click to cycle visualization." = "悬停预览用量。点击展开。Command 点击可切换可视化。";
 "How often to refresh." = "刷新频率。";
+"Keep the percentage and time remaining visible without hovering." = "无需悬停即可始终查看用量百分比和剩余时间。";
 "Inject test percentages. Visible only when launched with CODEXISLAND_DEBUG=1." = "注入测试百分比。仅在使用 CODEXISLAND_DEBUG=1 启动时显示。";
 "Preview" = "预览";
 "resets in %d hours" = "%d 小时后重置";

--- a/Sources/Model/AlwaysShowUsageStore.swift
+++ b/Sources/Model/AlwaysShowUsageStore.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+/// User preference for keeping the peek-state percentage pills visible at
+/// rest, without requiring a hover.
+///
+/// Default off: the pills only appear during hover/peek, then collapse with
+/// the silhouette back to compact. With this on, the island launches into
+/// `.peek` and stays there — hover-out keeps the pill visible, expanded-out
+/// returns to peek instead of compact.
+@MainActor
+final class AlwaysShowUsageStore: ObservableObject {
+    static let shared = AlwaysShowUsageStore()
+
+    private static let key = "MacIsland.alwaysShowUsage"
+
+    @Published var enabled: Bool {
+        didSet { UserDefaults.standard.set(enabled, forKey: Self.key) }
+    }
+
+    private init() {
+        // UserDefaults.bool returns false for missing keys, which matches our
+        // intended default (off → preserves the existing hover-only behavior
+        // for users who upgrade).
+        self.enabled = UserDefaults.standard.bool(forKey: Self.key)
+    }
+}

--- a/Sources/Views/IslandRootView.swift
+++ b/Sources/Views/IslandRootView.swift
@@ -3,6 +3,7 @@ import AppKit
 
 struct IslandRootView: View {
     @ObservedObject var model: IslandModel
+    @ObservedObject private var alwaysShow = AlwaysShowUsageStore.shared
     @State private var hovering = false
     @State private var contentVisible = false
     @State private var pillsVisible = false
@@ -177,19 +178,32 @@ struct IslandRootView: View {
                             }
                         }
                     } else {
-                        // EXIT: pills fade first, then shape collapses.
-                        // Branches by state so peek-out shrinks to compact
-                        // and expanded-out collapses the panel content too.
-                        withAnimation(.easeOut(duration: 0.08)) {
-                            pillsVisible = false
+                        // EXIT: pills fade first (unless we're pinning peek),
+                        // then the shape settles at the rest state — `.compact`
+                        // normally, `.peek` under always-show.
+                        let target = restState
+                        if !alwaysShow.enabled {
+                            withAnimation(.easeOut(duration: 0.08)) {
+                                pillsVisible = false
+                            }
                         }
                         withAnimation(.easeOut(duration: 0.10)) {
                             contentVisible = false
                         }
                         DispatchQueue.main.asyncAfter(deadline: .now() + 0.10) {
                             guard !hovering else { return }
-                            withAnimation(.closeMorph) {
-                                model.setState(.compact)
+                            if model.state != target {
+                                withAnimation(.closeMorph) {
+                                    model.setState(target)
+                                }
+                            }
+                            // Coming out of `.expanded` under always-show, the
+                            // pills were hidden by the open-panel branch — bring
+                            // them back as the shape resettles at peek.
+                            if alwaysShow.enabled && !pillsVisible {
+                                withAnimation(.easeOut(duration: 0.18)) {
+                                    pillsVisible = true
+                                }
                             }
                         }
                     }
@@ -208,6 +222,46 @@ struct IslandRootView: View {
             if openaiLogo == nil {
                 openaiLogo = Bundle.main.url(forResource: "openai_logo", withExtension: "pdf")
                     .flatMap { NSImage(contentsOf: $0) }
+            }
+            // Snap to peek on launch when the user has opted into always-show.
+            // No animation here — the window is just becoming visible, so the
+            // user sees the silhouette appear already at peek width rather
+            // than morphing out under their gaze.
+            if alwaysShow.enabled && model.state == .compact {
+                model.setState(.peek)
+                pillsVisible = true
+            }
+        }
+        .onChange(of: alwaysShow.enabled) { enabled in
+            // Live toggle — defer to the user's current interaction. If they
+            // happen to be hovering, the hover state machine owns the morph
+            // and will land on the new rest state on hover-out. If the panel
+            // is expanded, leave it alone for the same reason.
+            guard !hovering, model.state != .expanded else { return }
+            if enabled {
+                if model.state == .compact {
+                    withAnimation(.openMorph) {
+                        model.setState(.peek)
+                    }
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.06) {
+                        guard model.state == .peek, !hovering else { return }
+                        withAnimation(.easeOut(duration: 0.18)) {
+                            pillsVisible = true
+                        }
+                    }
+                }
+            } else {
+                if model.state == .peek {
+                    withAnimation(.easeOut(duration: 0.08)) {
+                        pillsVisible = false
+                    }
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.10) {
+                        guard !hovering, model.state == .peek else { return }
+                        withAnimation(.closeMorph) {
+                            model.setState(.compact)
+                        }
+                    }
+                }
             }
         }
         .onReceive(AlertEngine.shared.$pulseEvent) { event in
@@ -244,8 +298,10 @@ struct IslandRootView: View {
         DispatchQueue.main.asyncAfter(deadline: .now() + 4.0) {
             // If the user is hovering or has expanded the panel meanwhile,
             // don't fight their state — let their interaction own the peek
-            // lifecycle from here.
-            guard !hovering, model.state == .peek else { return }
+            // lifecycle from here. Under always-show, `.peek` IS the rest
+            // state, so the pulse just resolves into the steady-state pill
+            // rather than collapsing back to compact.
+            guard !hovering, model.state == .peek, !alwaysShow.enabled else { return }
             withAnimation(.easeOut(duration: 0.08)) {
                 pillsVisible = false
             }
@@ -258,9 +314,16 @@ struct IslandRootView: View {
         }
     }
 
+    private var restState: IslandModel.State {
+        alwaysShow.enabled ? .peek : .compact
+    }
+
     private var accessibilityHintForState: String {
         switch model.state {
-        case .compact:  return L10n.tr("Hover to peek usage. Click to expand. Command-click to cycle visualization.")
+        case .compact:
+            return alwaysShow.enabled
+                ? L10n.tr("Click to expand. Command-click to cycle visualization.")
+                : L10n.tr("Hover to peek usage. Click to expand. Command-click to cycle visualization.")
         case .peek:     return L10n.tr("Click to expand. Command-click to cycle visualization.")
         case .expanded:
             return ScreenPref.shared.screen == .overview

--- a/Sources/Views/IslandRootView.swift
+++ b/Sources/Views/IslandRootView.swift
@@ -181,7 +181,6 @@ struct IslandRootView: View {
                         // EXIT: pills fade first (unless we're pinning peek),
                         // then the shape settles at the rest state — `.compact`
                         // normally, `.peek` under always-show.
-                        let target = restState
                         if !alwaysShow.enabled {
                             withAnimation(.easeOut(duration: 0.08)) {
                                 pillsVisible = false
@@ -192,6 +191,11 @@ struct IslandRootView: View {
                         }
                         DispatchQueue.main.asyncAfter(deadline: .now() + 0.10) {
                             guard !hovering else { return }
+                            // Re-read restState here — the user may have flipped
+                            // the always-show toggle during the 100ms wait, and
+                            // a captured-at-creation-time `target` would settle
+                            // at the wrong state for them.
+                            let target = restState
                             if model.state != target {
                                 withAnimation(.closeMorph) {
                                     model.setState(target)
@@ -256,7 +260,10 @@ struct IslandRootView: View {
                         pillsVisible = false
                     }
                     DispatchQueue.main.asyncAfter(deadline: .now() + 0.10) {
-                        guard !hovering, model.state == .peek else { return }
+                        // Re-check `alwaysShow.enabled` — if the user toggled
+                        // back on inside the 100ms wait, leave the peek state
+                        // alone instead of fighting their newer intent.
+                        guard !hovering, model.state == .peek, !alwaysShow.enabled else { return }
                         withAnimation(.closeMorph) {
                             model.setState(.compact)
                         }
@@ -306,7 +313,9 @@ struct IslandRootView: View {
                 pillsVisible = false
             }
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.10) {
-                guard !hovering, model.state == .peek else { return }
+                // Mirror the outer 4-second guard — if always-show flipped on
+                // during the tiny inner wait, leave the peek state alone.
+                guard !hovering, model.state == .peek, !alwaysShow.enabled else { return }
                 withAnimation(.closeMorph) {
                     model.setState(.compact)
                 }

--- a/Sources/Views/SettingsView.swift
+++ b/Sources/Views/SettingsView.swift
@@ -460,7 +460,7 @@ struct SettingsView: View {
         }
         .labelsHidden()
         .pickerStyle(.menu)
-        .frame(maxWidth: 220)
+        .fixedSize()
         .accessibilityLabel(L10n.tr("Language"))
     }
 

--- a/Sources/Views/SettingsView.swift
+++ b/Sources/Views/SettingsView.swift
@@ -14,6 +14,7 @@ struct SettingsView: View {
     @ObservedObject private var refreshStore = RefreshIntervalStore.shared
     @ObservedObject private var tokenMode = TokenCountModeStore.shared
     @ObservedObject private var lowPower = LowPowerModeStore.shared
+    @ObservedObject private var alwaysShow = AlwaysShowUsageStore.shared
     @ObservedObject private var alertPrefs = AlertThresholdStore.shared
     @ObservedObject private var spacing = IslandSpacingStore.shared
     @ObservedObject private var targetDisplay = IslandTargetDisplayStore.shared
@@ -210,6 +211,14 @@ struct SettingsView: View {
                 subtitle: appLanguage.language.subtitle
             ) {
                 languagePicker
+            }
+            SettingsRow(
+                title: "Always show usage",
+                subtitle: "Keep the percentage and time remaining visible without hovering."
+            ) {
+                SettingsToggle(isOn: alwaysShow.enabled) {
+                    alwaysShow.enabled.toggle()
+                }
             }
             SettingsRow(
                 title: "Low Power Mode",


### PR DESCRIPTION
## Summary

Resolves #23.

1. **Always show usage** (`81f51a8`) — opt-in toggle in Settings → General that pins the peek-state percentage pills (`70% · 4h`) visible at rest. The island launches into `.peek` and stays there: hover-out preserves peek instead of collapsing to compact, the 4-second alert-pulse auto-collapse is suppressed (peek is the rest state already), and the accessibility hint drops the \"hover to peek\" line when the pref is on. Default off, so upgraders see no behavior change.

2. **Right-align language picker** (`93e89da`) — small companion fix. The Language row landed in #21 with `.frame(maxWidth: 220)` and no alignment, which left the menu button at the leading edge of an invisible 220pt frame. `.fixedSize()` collapses it to its intrinsic width so `SettingsRow`'s `Spacer` pushes it flush right like the row's other controls.

## Test plan

- [ ] Toggle **Always show usage** on → pills appear immediately, persist when cursor leaves the island, persist after expanding and re-collapsing the panel.
- [ ] Toggle it off while pills are visible → island morphs back to compact with the same `.closeMorph` spring as a hover-exit.
- [ ] Quit + relaunch with the toggle on → island appears at peek width on first paint (no compact-flash).
- [ ] With the toggle on and a 5h window above the configured warning threshold, the alert pulse no longer collapses back to compact after 4s.
- [ ] Settings → General: Language picker sits flush right, matching the toggles and segmented controls.
- [ ] VoiceOver hint on the silhouette in compact state reads \"Click to expand…\" (not \"Hover to peek…\") when always-show is on.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an “Always show usage” toggle in Settings to keep usage percentage and time remaining visible without hovering; enabling it preserves the peek state on launch and when toggled at runtime.

* **Localization**
  * Added English and Simplified Chinese translations for the new strings.

* **UI Updates**
  * Language picker sizing adjusted in Settings.
  * Alert/pulse behavior updated so pulses no longer force collapse when always-show is enabled.

* **Accessibility**
  * Compact-state hint text updated to reflect always-show behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ericjypark/codex-island/pull/26?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->