### PR TITLE
feat(window): hide island on lock screen and support Cmd+Q to quit

### DIFF
--- a/Sources/Window/IslandWindowController.swift
+++ b/Sources/Window/IslandWindowController.swift
@@ -12,8 +12,12 @@ final class IslandWindowController {
     private var trackingTimer: Timer?
     private var screenChangeObserver: NSObjectProtocol?
     private var occlusionObserver: NSObjectProtocol?
+    private var sessionResignObserver: NSObjectProtocol?
+    private var sessionActiveObserver: NSObjectProtocol?
     private var subs: Set<AnyCancellable> = []
     private var hasSeenMouseEvent = false
+    private var isMouseInsideIsland = false
+    private var cmdQMonitor: Any?
 
     static let windowSize = CGSize(width: 900, height: 360)
 
@@ -50,6 +54,7 @@ final class IslandWindowController {
         observeScreenChanges()
         observeTargetChoice()
         observeOcclusion()
+        observeSessionState()
     }
 
     deinit {
@@ -59,8 +64,15 @@ final class IslandWindowController {
         if let observer = occlusionObserver {
             NotificationCenter.default.removeObserver(observer)
         }
+        if let observer = sessionResignObserver {
+            DistributedNotificationCenter.default().removeObserver(observer)
+        }
+        if let observer = sessionActiveObserver {
+            DistributedNotificationCenter.default().removeObserver(observer)
+        }
         if let m = globalMouseMonitor { NSEvent.removeMonitor(m) }
         if let m = localMouseMonitor { NSEvent.removeMonitor(m) }
+        if let m = cmdQMonitor { NSEvent.removeMonitor(m) }
         trackingTimer?.invalidate()
     }
 
@@ -119,6 +131,24 @@ final class IslandWindowController {
         if window.ignoresMouseEvents == inside {
             window.ignoresMouseEvents = !inside
         }
+        if inside != isMouseInsideIsland {
+            isMouseInsideIsland = inside
+            if inside {
+                NSApp.activate(ignoringOtherApps: true)
+                window.makeKey()
+                cmdQMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
+                    if event.modifierFlags.contains(.command),
+                       event.charactersIgnoringModifiers == "q" {
+                        NSApp.terminate(nil)
+                        return nil
+                    }
+                    return event
+                }
+            } else {
+                if let m = cmdQMonitor { NSEvent.removeMonitor(m) }
+                cmdQMonitor = nil
+            }
+        }
     }
 
     @MainActor
@@ -156,6 +186,42 @@ final class IslandWindowController {
             Task { @MainActor in
                 WindowOcclusionStore.shared.update(isVisible: visible)
             }
+        }
+    }
+
+    /// Hides the island when the screen locks so it doesn't ride the
+    /// lock-screen slide animation (which makes the notch appear to fall).
+    /// DistributedNotificationCenter "com.apple.screenIsLocked" fires as soon
+    /// as the lock is initiated, before the slide animation completes.
+    private func observeSessionState() {
+        let dc = DistributedNotificationCenter.default()
+        sessionResignObserver = dc.addObserver(
+            forName: NSNotification.Name("com.apple.screenIsLocked"),
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in self?.fadeOut() }
+        }
+        sessionActiveObserver = dc.addObserver(
+            forName: NSNotification.Name("com.apple.screenIsUnlocked"),
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in self?.fadeIn() }
+        }
+    }
+
+    private func fadeOut() {
+        window.orderOut(nil)
+    }
+
+    private func fadeIn() {
+        window.alphaValue = 0
+        window.orderFrontRegardless()
+        NSAnimationContext.runAnimationGroup { ctx in
+            ctx.duration = 0.4
+            ctx.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+            window.animator().alphaValue = 1
         }
     }
 


### PR DESCRIPTION
- Hide island immediately when screen locks (com.apple.screenIsLocked via DistributedNotificationCenter) to prevent it from riding the lock-screen slide animation; fade in with 0.4s ease-in-out on unlock
- Track mouse hover state over the island pill; on enter, activate the app and install a local key monitor so Cmd+Q quits the app; monitor is torn down immediately on mouse leave to avoid interfering with other apps

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Island window now automatically responds to macOS screen lock and unlock events, hiding when locked and appearing when unlocked.
  * Command-Q keyboard shortcut behavior improved: the app will only terminate when the shortcut is used while your cursor is positioned within the island area, preventing accidental exits when outside.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ericjypark/codex-island/pull/27?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->