### PR TITLE
fix(settings): route Cmd+, to the Settings window instead of an empty…

### DIFF
--- a/Sources/App.swift
+++ b/Sources/App.swift
@@ -16,11 +16,25 @@ struct CodexIslandApp: App {
 @MainActor
 final class AppDelegate: NSObject, NSApplicationDelegate {
     var island: IslandWindowController?
+    private var settingsShortcutMonitor: Any?
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         NSApp.setActivationPolicy(.accessory)
         island = IslandWindowController()
         island?.show()
+
+        // Route Cmd+, to our hand-rolled Settings window. Without this, the
+        // inert `Settings { EmptyView() }` scene below claims the shortcut and
+        // opens a blank window. Consuming the event (returning nil) keeps that
+        // empty scene from ever surfacing.
+        settingsShortcutMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
+            if event.modifierFlags.contains(.command),
+               event.charactersIgnoringModifiers == "," {
+                SettingsWindowController.shared.show()
+                return nil
+            }
+            return event
+        }
 
         // Start fetching at app launch — NOT on view appear — so the panel
         // already has cached values the first time the user hovers, instead


### PR DESCRIPTION
… scene

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The Cmd+, keyboard shortcut now properly opens the Settings window.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ericjypark/codex-island/pull/29?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->