### PR TITLE
feat: add idle logo visibility setting

### DIFF
--- a/Resources/en.lproj/Localizable.strings
+++ b/Resources/en.lproj/Localizable.strings
@@ -48,10 +48,12 @@
 "Critical" = "Critical";
 "Daily token usage in %@" = "Daily token usage in %@";
 "Display" = "Display";
+"Show provider logos before hover or expand." = "Show provider logos before hover or expand.";
 "General" = "General";
 "Follows macOS" = "Follows macOS";
 "Glow only on refresh, hover, or limit alerts." = "Glow only on refresh, hover, or limit alerts.";
 "Idle" = "Idle";
+"Idle logos" = "Idle logos";
 "idle" = "idle";
 "Input + output" = "Input + output";
 "Input + output only. Matches Anthropic's claude.ai stats." = "Input + output only. Matches Anthropic's claude.ai stats.";

--- a/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Resources/zh-Hans.lproj/Localizable.strings
@@ -48,10 +48,12 @@
 "Critical" = "危急";
 "Daily token usage in %@" = "%@ 年每日 token 用量";
 "Display" = "显示";
+"Show provider logos before hover or expand." = "在悬停或展开前显示服务图标。";
 "General" = "通用";
 "Follows macOS" = "跟随 macOS";
 "Glow only on refresh, hover, or limit alerts." = "仅在刷新、悬停或限额提醒时显示辉光。";
 "Idle" = "空闲";
+"Idle logos" = "空闲图标";
 "idle" = "空闲";
 "Input + output" = "输入 + 输出";
 "Input + output only. Matches Anthropic's claude.ai stats." = "只统计输入 + 输出；与 Anthropic 的 claude.ai 统计一致。";

--- a/Sources/Model/IslandModel.swift
+++ b/Sources/Model/IslandModel.swift
@@ -47,7 +47,7 @@ final class IslandModel: ObservableObject {
     private var rawNotch: NotchInfo
     private var activeScreen = ScreenPref.shared.screen
     private var overviewDayDetailVisible = false
-    private(set) var compactLogosVisible = LogoVisibilityStore.shared.visible
+    private var compactLogoPreferenceVisible = LogoVisibilityStore.shared.visible
 
     private var subs: Set<AnyCancellable> = []
 
@@ -153,7 +153,7 @@ final class IslandModel: ObservableObject {
             .sink { [weak self] visible in
                 guard let self else { return }
                 withAnimation(.openMorph) {
-                    self.compactLogosVisible = visible
+                    self.compactLogoPreferenceVisible = visible
                     if self.state == .compact {
                         self.recomputeSize()
                     }
@@ -201,6 +201,10 @@ final class IslandModel: ObservableObject {
 
     private var compactLogoTabWidth: CGFloat {
         compactLogosVisible ? tabWidth : 0
+    }
+
+    var compactLogosVisible: Bool {
+        !notch.hasNotch || compactLogoPreferenceVisible
     }
 
     private var expandedContentHeight: CGFloat {

--- a/Sources/Model/IslandModel.swift
+++ b/Sources/Model/IslandModel.swift
@@ -47,6 +47,7 @@ final class IslandModel: ObservableObject {
     private var rawNotch: NotchInfo
     private var activeScreen = ScreenPref.shared.screen
     private var overviewDayDetailVisible = false
+    private(set) var compactLogosVisible = LogoVisibilityStore.shared.visible
 
     private var subs: Set<AnyCancellable> = []
 
@@ -55,6 +56,7 @@ final class IslandModel: ObservableObject {
         self.notch = Self.applyOverride(to: notch, width: IslandSpacingStore.shared.width)
         recomputeSize()
         subscribeToSpacingStore()
+        subscribeToLogoVisibilityStore()
         subscribeToScreenPref()
     }
 
@@ -145,6 +147,21 @@ final class IslandModel: ObservableObject {
             .store(in: &subs)
     }
 
+    private func subscribeToLogoVisibilityStore() {
+        LogoVisibilityStore.shared.$visible
+            .dropFirst()
+            .sink { [weak self] visible in
+                guard let self else { return }
+                withAnimation(.openMorph) {
+                    self.compactLogosVisible = visible
+                    if self.state == .compact {
+                        self.recomputeSize()
+                    }
+                }
+            }
+            .store(in: &subs)
+    }
+
     private func subscribeToScreenPref() {
         ScreenPref.shared.$screen
             .dropFirst()
@@ -166,7 +183,7 @@ final class IslandModel: ObservableObject {
         switch state {
         case .compact:
             size = CGSize(
-                width: notch.width + tabWidth * 2,
+                width: notch.width + compactLogoTabWidth * 2,
                 height: notch.height
             )
         case .peek:
@@ -180,6 +197,10 @@ final class IslandModel: ObservableObject {
                 height: expandedContentHeight + notch.height
             )
         }
+    }
+
+    private var compactLogoTabWidth: CGFloat {
+        compactLogosVisible ? tabWidth : 0
     }
 
     private var expandedContentHeight: CGFloat {

--- a/Sources/Model/LogoVisibilityStore.swift
+++ b/Sources/Model/LogoVisibilityStore.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+/// User preference for showing the provider logos in the compact rest state.
+///
+/// Default on preserves the current branded island. Turning it off affects
+/// only `.compact`: the rest-state silhouette shrinks to the notch width, so
+/// loading sweeps and alert glow stay fitted to the hardware notch.
+@MainActor
+final class LogoVisibilityStore: ObservableObject {
+    static let shared = LogoVisibilityStore()
+
+    private static let key = "MacIsland.compactLogosVisible"
+
+    @Published var visible: Bool {
+        didSet { UserDefaults.standard.set(visible, forKey: Self.key) }
+    }
+
+    private init() {
+        self.visible = Pref.seededBool(key: Self.key, default: true)
+    }
+}

--- a/Sources/Model/LogoVisibilityStore.swift
+++ b/Sources/Model/LogoVisibilityStore.swift
@@ -2,9 +2,11 @@ import Foundation
 
 /// User preference for showing the provider logos in the compact rest state.
 ///
-/// Default on preserves the current branded island. Turning it off affects
-/// only `.compact`: the rest-state silhouette shrinks to the notch width, so
-/// loading sweeps and alert glow stay fitted to the hardware notch.
+/// Default on preserves the current branded island. On notched displays,
+/// turning it off affects only `.compact`: the rest-state silhouette shrinks
+/// to the physical notch width, so loading sweeps and alert glow stay fitted
+/// to the hardware notch. Non-notched displays ignore the hidden state to
+/// avoid leaving an empty synthetic pill at top-center.
 @MainActor
 final class LogoVisibilityStore: ObservableObject {
     static let shared = LogoVisibilityStore()

--- a/Sources/Views/IslandRootView.swift
+++ b/Sources/Views/IslandRootView.swift
@@ -74,6 +74,8 @@ struct IslandRootView: View {
                         image: claudeLogo,
                         color: IslandColor.claude,
                         provider: .claude,
+                        state: model.state,
+                        compactLogosVisible: model.compactLogosVisible,
                         edgePadding: logoEdgePadding,
                         topPadding: max(0, (model.notch.height - 20) / 2)
                     )
@@ -83,6 +85,8 @@ struct IslandRootView: View {
                         image: openaiLogo,
                         color: IslandColor.codex,
                         provider: .codex,
+                        state: model.state,
+                        compactLogosVisible: model.compactLogosVisible,
                         edgePadding: logoEdgePadding,
                         topPadding: max(0, (model.notch.height - 20) / 2)
                     )
@@ -440,18 +444,17 @@ private struct LogoOverlay: View {
     let image: NSImage?
     let color: Color
     let provider: AlertEngine.Provider
+    let state: IslandModel.State
+    let compactLogosVisible: Bool
     let edgePadding: CGFloat
     let topPadding: CGFloat
 
     @ObservedObject private var visibility = ProviderVisibilityStore.shared
 
     var body: some View {
-        // Hidden providers fully drop out — header / peek pill / chrome
-        // are gated identically. `.opacity(isVisible ? 1 : 0)` keeps the
-        // view in the layout (so other overlays don't reflow) but makes
-        // it invisible, and the explicit `.animation(.openMorph, value:)`
-        // pairs the chrome fade with the panel layout swap when the user
-        // toggles a provider in Settings.
+        // The logo preference applies only to the compact rest state.
+        // Peek/expanded remain exactly as before so hover, pills, and panel
+        // chrome keep their current geometry.
         if let image {
             Image(nsImage: image)
                 .resizable()
@@ -470,6 +473,7 @@ private struct LogoOverlay: View {
 
     private var isVisible: Bool {
         visibility.effectiveVisible(provider: provider)
+            && (state != .compact || compactLogosVisible)
     }
 
     private var providerLabel: String {

--- a/Sources/Views/SettingsView.swift
+++ b/Sources/Views/SettingsView.swift
@@ -17,6 +17,7 @@ struct SettingsView: View {
     @ObservedObject private var alwaysShow = AlwaysShowUsageStore.shared
     @ObservedObject private var alertPrefs = AlertThresholdStore.shared
     @ObservedObject private var spacing = IslandSpacingStore.shared
+    @ObservedObject private var logos = LogoVisibilityStore.shared
     @ObservedObject private var targetDisplay = IslandTargetDisplayStore.shared
     @ObservedObject private var appLanguage = AppLanguageStore.shared
     @ObservedObject private var usage = UsageStore.shared
@@ -138,6 +139,7 @@ struct SettingsView: View {
             chartSection
             costStyleSection
             targetDisplaySection
+            restChromeSection
             if spacingSectionVisible {
                 spacingSection
             }
@@ -652,6 +654,23 @@ struct SettingsView: View {
                 subtitle: "Tightens the gap between logos when the island is on a screen without a hardware notch."
             ) {
                 spacingSegmented
+            }
+        }
+        .padding(.horizontal, 14)
+        .padding(.top, 14)
+        .padding(.bottom, 14)
+    }
+
+    private var restChromeSection: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            sectionLabel("Idle")
+            SettingsRow(
+                title: "Idle logos",
+                subtitle: "Show provider logos before hover or expand."
+            ) {
+                SettingsToggle(isOn: logos.visible) {
+                    logos.visible.toggle()
+                }
             }
         }
         .padding(.horizontal, 14)

--- a/Sources/Views/SettingsView.swift
+++ b/Sources/Views/SettingsView.swift
@@ -139,7 +139,9 @@ struct SettingsView: View {
             chartSection
             costStyleSection
             targetDisplaySection
-            restChromeSection
+            if restChromeSectionVisible {
+                restChromeSection
+            }
             if spacingSectionVisible {
                 spacingSection
             }
@@ -152,6 +154,13 @@ struct SettingsView: View {
     /// the gate stays in sync with where the island actually is.
     private var spacingSectionVisible: Bool {
         DisplayInfo.currentTarget()?.notch.hasNotch == false
+    }
+
+    /// The idle-logo toggle only makes sense on a physical notch. On
+    /// non-notched displays, hiding the rest-state logos would leave an empty
+    /// synthetic pill floating at top-center.
+    private var restChromeSectionVisible: Bool {
+        DisplayInfo.currentTarget()?.notch.hasNotch == true
     }
 
     private var providersTab: some View {


### PR DESCRIPTION
## Summary
- Add an `Idle logos` setting on the Display tab.
- When disabled, only the compact/rest island hides the Claude/Codex logos and shrinks to the notch width.
- Keep hover peek and expanded layouts unchanged so provider context remains visible outside idle mode.

## Why
- Lets users reduce the idle menu-bar footprint around the hardware notch without losing logos during hover or expanded usage views.
- Keeps loading sweeps and alert glow aligned to the compact notch-sized silhouette when idle logos are hidden.

Fixes #28

## Testing
- ./scripts/verify.sh
- Launched locally in CODEXISLAND_DEMO=1 and checked idle/hover/expanded behavior during iteration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an "Idle logos" toggle in Display settings to control provider logo visibility when the app is compact/idle.
  * Provider logos can now appear before hover/expand based on the new setting.

* **Behavior Changes**
  * Compact/idle display respects device notch and the new toggle when showing or hiding provider logos.

* **Localization**
  * Added English and Simplified Chinese strings for the new options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->