### PR TITLE
fix(animation): eliminate black flash on island hover-out

### DIFF
--- a/Sources/Model/IslandModel.swift
+++ b/Sources/Model/IslandModel.swift
@@ -83,7 +83,8 @@ final class IslandModel: ObservableObject {
     func updateNotch(_ raw: NotchInfo) {
         guard raw.width != rawNotch.width
             || raw.height != rawNotch.height
-            || raw.hasNotch != rawNotch.hasNotch else { return }
+            || raw.hasNotch != rawNotch.hasNotch
+            || raw.sideSpace != rawNotch.sideSpace else { return }
         rawNotch = raw
         notch = Self.applyOverride(to: raw, width: IslandSpacingStore.shared.width)
         recomputeSize()

--- a/Sources/Model/IslandModel.swift
+++ b/Sources/Model/IslandModel.swift
@@ -13,16 +13,32 @@ final class IslandModel: ObservableObject {
     @Published var size: CGSize = .zero
     @Published var notch: NotchInfo
 
-    /// Side extension that houses each brand logo in compact state.
-    let tabWidth: CGFloat = 38
+    /// Maximum side extension for the brand logo tab in compact state.
+    private let maxTabWidth: CGFloat = 38
+    /// Maximum per-side outboard slot for the peek-state percentage pill.
+    private let maxPillSlotWidth: CGFloat = 78
+    /// Safety gap (pt) between our outermost edge and the nearest menu item.
+    private let sideMargin: CGFloat = 8
 
-    /// Per-side outboard slot that houses the peek-state percentage pill.
-    /// Sized for "100% · Nh" worst case at the chosen pill typography.
-    /// Fixed (not text-measured) so percentage updates don't jitter the
-    /// silhouette width during refresh. Grown symmetrically on both sides
-    /// regardless of which provider is visible — keeps the silhouette
-    /// balanced over the physical notch.
-    let pillSlotWidth: CGFloat = 78
+    /// Actual tab width, clamped to the space available beside the notch
+    /// before menu items begin (macOS 27+). Falls back to maxTabWidth when
+    /// there is no constraint (older macOS / non-notch screens).
+    var tabWidth: CGFloat {
+        let available = notch.sideSpace == .infinity ? maxTabWidth : max(0, notch.sideSpace - sideMargin)
+        return min(maxTabWidth, available)
+    }
+
+    /// Actual peek pill slot width, clamped to whatever space remains after
+    /// the tab and safety margin are accounted for.
+    var pillSlotWidth: CGFloat {
+        let available = notch.sideSpace == .infinity ? maxPillSlotWidth : max(0, notch.sideSpace - sideMargin - tabWidth)
+        return min(maxPillSlotWidth, available)
+    }
+
+    /// True when compact-state logo tabs are suppressed because menu items are
+    /// too close. Logos reappear as soon as the user hovers (peek state always
+    /// expands to full width regardless of this constraint).
+    var compactLogosHidden: Bool { tabWidth < maxTabWidth }
 
     /// Visible expanded panel width.
     private let expandedWidth: CGFloat = 800
@@ -118,7 +134,7 @@ final class IslandModel: ObservableObject {
     /// notch).
     private static func applyOverride(to raw: NotchInfo, width: CGFloat) -> NotchInfo {
         if raw.hasNotch { return raw }
-        return NotchInfo(width: width, height: raw.height, hasNotch: false)
+        return NotchInfo(width: width, height: raw.height, hasNotch: false, sideSpace: .infinity)
     }
 
     /// Re-applies the override and re-computes size whenever the user
@@ -170,8 +186,11 @@ final class IslandModel: ObservableObject {
                 height: notch.height
             )
         case .peek:
+            // Always expand to full peek width on hover even when compact is
+            // constrained — the user is actively interacting, brief menu
+            // overlap is acceptable and logos/pills must always be reachable.
             size = CGSize(
-                width: notch.width + tabWidth * 2 + pillSlotWidth * 2,
+                width: notch.width + maxTabWidth * 2 + maxPillSlotWidth * 2,
                 height: notch.height
             )
         case .expanded:

--- a/Sources/Model/NotchInfo.swift
+++ b/Sources/Model/NotchInfo.swift
@@ -4,6 +4,10 @@ struct NotchInfo {
     let width: CGFloat
     let height: CGFloat
     let hasNotch: Bool
+    /// Available points on each side of the notch before menu items begin.
+    /// Only meaningful on macOS 27+ notched screens where menu items flow
+    /// around the notch; set to .infinity on older systems (no constraint).
+    let sideSpace: CGFloat
 
     /// `screen.frame.maxY - screen.visibleFrame.maxY` reports the actual
     /// pixel distance between the top of the screen and the top of the app
@@ -22,7 +26,7 @@ struct NotchInfo {
     /// (screen width - left - right).
     static func detect(from screen: NSScreen?) -> NotchInfo {
         guard let screen else {
-            return NotchInfo(width: IslandSpacingStore.compactWidth, height: menuBarFallback(), hasNotch: false)
+            return NotchInfo(width: IslandSpacingStore.compactWidth, height: menuBarFallback(), hasNotch: false, sideSpace: .infinity)
         }
         let safeTop = screen.safeAreaInsets.top
         let visualHeight = visibleMenuBarHeight(of: screen)
@@ -33,9 +37,24 @@ struct NotchInfo {
             let width: CGFloat = (leftW > 0 && rightW > 0)
                 ? screen.frame.width - leftW - rightW
                 : 200
-            return NotchInfo(width: width, height: visualHeight, hasNotch: true)
+
+            // On macOS 27+ menu items flow into the aux areas beside the notch,
+            // so we calculate how much space remains on each side after they end.
+            // On older macOS the aux areas are dead zones — no constraint needed.
+            let sideSpace: CGFloat
+            if #available(macOS 27, *) {
+                let halfScreen = screen.frame.width / 2
+                let halfNotch  = width / 2
+                let leftFree   = halfScreen - halfNotch - leftW
+                let rightFree  = halfScreen - halfNotch - rightW
+                sideSpace = max(0, min(leftFree, rightFree))
+            } else {
+                sideSpace = .infinity
+            }
+
+            return NotchInfo(width: width, height: visualHeight, hasNotch: true, sideSpace: sideSpace)
         }
-        return NotchInfo(width: IslandSpacingStore.compactWidth, height: visualHeight, hasNotch: false)
+        return NotchInfo(width: IslandSpacingStore.compactWidth, height: visualHeight, hasNotch: false, sideSpace: .infinity)
     }
 
     private static func visibleMenuBarHeight(of screen: NSScreen) -> CGFloat {

--- a/Sources/Usage/CodexResetCredits.swift
+++ b/Sources/Usage/CodexResetCredits.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+struct CodexResetCredit: Identifiable, Equatable {
+    let id: String
+    let status: String
+    let expiresAt: Date
+    let title: String
+    let description: String
+
+    var isAvailable: Bool {
+        status.lowercased() == "available"
+    }
+}
+
+struct CodexResetCredits: Equatable {
+    var availableCount: Int
+    var credits: [CodexResetCredit]
+
+    static let empty = CodexResetCredits(availableCount: 0, credits: [])
+
+    var availableCredits: [CodexResetCredit] {
+        credits.filter(\.isAvailable)
+            .sorted { $0.expiresAt < $1.expiresAt }
+    }
+}

--- a/Sources/Usage/UsageFetcher.swift
+++ b/Sources/Usage/UsageFetcher.swift
@@ -65,6 +65,50 @@ enum UsageFetcher {
         return WindowUsage(usedPercent: used / 100, resetAt: resetAt, error: nil)
     }
 
+    static func fetchCodexResetCredits() async -> CodexResetCredits? {
+        guard let token = readCodexAccessToken() else { return nil }
+
+        var req = URLRequest(url: URL(string: "https://chatgpt.com/backend-api/wham/rate-limit-reset-credits")!)
+        req.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        req.setValue("application/json", forHTTPHeaderField: "Accept")
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: req)
+            let status = (response as? HTTPURLResponse)?.statusCode ?? 0
+            guard status == 200,
+                  let obj = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+            else { return nil }
+
+            let availableCount = (obj["available_count"] as? Int) ?? 0
+            let formatter = ISO8601DateFormatter()
+            formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+            let fallbackFormatter = ISO8601DateFormatter()
+            fallbackFormatter.formatOptions = [.withInternetDateTime]
+
+            let rawCredits: [[String: Any]] = (obj["credits"] as? [[String: Any]]) ?? []
+            let credits: [CodexResetCredit] = rawCredits.compactMap { item -> CodexResetCredit? in
+                guard let id = item["id"] as? String,
+                      let status = item["status"] as? String,
+                      let expiresRaw = item["expires_at"] as? String,
+                      let expiresAt = formatter.date(from: expiresRaw)
+                        ?? fallbackFormatter.date(from: expiresRaw)
+                else { return nil }
+
+                return CodexResetCredit(
+                    id: id,
+                    status: status,
+                    expiresAt: expiresAt,
+                    title: item["title"] as? String ?? "",
+                    description: item["description"] as? String ?? ""
+                )
+            }
+
+            return CodexResetCredits(availableCount: availableCount, credits: credits)
+        } catch {
+            return nil
+        }
+    }
+
     // MARK: - Claude
 
     /// Anthropic doesn't ship a usage endpoint for end users — Claude Code

--- a/Sources/Usage/UsageStore.swift
+++ b/Sources/Usage/UsageStore.swift
@@ -9,6 +9,7 @@ final class UsageStore: ObservableObject {
 
     @Published var claude: AppUsage = .empty
     @Published var codex: AppUsage = .empty
+    @Published var codexResetCredits: CodexResetCredits = .empty
     @Published var lastUpdated: Date?
     @Published var loading = false
     /// Set while a `claude auth login` flow is in progress (spawned + still
@@ -67,6 +68,25 @@ final class UsageStore: ObservableObject {
                 ),
                 plan: "pro"
             )
+            self.codexResetCredits = CodexResetCredits(
+                availableCount: 2,
+                credits: [
+                    CodexResetCredit(
+                        id: "demo-reset-1",
+                        status: "available",
+                        expiresAt: now.addingTimeInterval(3 * 86400 + 4 * 3600),
+                        title: "One free rate limit reset",
+                        description: "Thanks for using Codex! You've been granted one free rate limit reset."
+                    ),
+                    CodexResetCredit(
+                        id: "demo-reset-2",
+                        status: "available",
+                        expiresAt: now.addingTimeInterval(9 * 86400 + 3600),
+                        title: "One free rate limit reset",
+                        description: "Thanks for using Codex! You've been granted one free rate limit reset."
+                    )
+                ]
+            )
             self.lastUpdated = now
             return
         }
@@ -75,8 +95,10 @@ final class UsageStore: ObservableObject {
         refreshTask?.cancel()
         refreshTask = Task {
             async let codexResult = UsageFetcher.fetchCodex()
+            async let codexResetCreditsResult = UsageFetcher.fetchCodexResetCredits()
             async let claudeResult = UsageFetcher.fetchClaude()
             let c = await codexResult
+            let codexResetCredits = await codexResetCreditsResult
             let cl = await claudeResult
 
             // Cancellation = network monitor saw the path come up while we
@@ -100,6 +122,9 @@ final class UsageStore: ObservableObject {
             }
             if !UsageStore.isErrorOnly(cl) || UsageStore.isErrorOnly(self.claude) {
                 self.claude = cl
+            }
+            if let codexResetCredits {
+                self.codexResetCredits = codexResetCredits
             }
             self.lastUpdated = Date()
             self.loading = false

--- a/Sources/Views/CodexResetStatus.swift
+++ b/Sources/Views/CodexResetStatus.swift
@@ -62,7 +62,7 @@ struct CodexResetStatus: View {
     }
 
     private var popoverYOffset: CGFloat {
-        usageStore.codexResetCredits.availableCredits.count == 1 ? -92 : -118
+        usageStore.codexResetCredits.availableCredits.count == 1 ? -56 : -118
     }
 
     private var popover: some View {

--- a/Sources/Views/CodexResetStatus.swift
+++ b/Sources/Views/CodexResetStatus.swift
@@ -1,0 +1,213 @@
+import SwiftUI
+
+struct CodexResetStatus: View {
+    @ObservedObject private var usageStore = UsageStore.shared
+    @ObservedObject private var visibility = ProviderVisibilityStore.shared
+
+    @State private var showPopover = false
+    @State private var badgeHovered = false
+    @State private var popoverHovered = false
+    @State private var hideWorkItem: DispatchWorkItem?
+
+    var body: some View {
+        if shouldShowBadge {
+            badge
+                .overlay(alignment: .topTrailing) {
+                    if showPopover {
+                        popover
+                            .offset(x: 42, y: popoverYOffset)
+                            .transition(.opacity.combined(with: .scale(scale: 0.97, anchor: .bottomTrailing)))
+                    }
+                }
+                .zIndex(showPopover ? 10 : 0)
+        }
+    }
+
+    private var shouldShowBadge: Bool {
+        visibility.codexVisible && usageStore.codexResetCredits.availableCount > 0
+            && !usageStore.codexResetCredits.availableCredits.isEmpty
+    }
+
+    private var badge: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "arrow.counterclockwise")
+                .font(Typography.caption.weight(.semibold))
+                .foregroundStyle(.white.opacity(badgeHovered || showPopover ? 0.84 : 0.72))
+            Text(resetAvailabilityText)
+                .font(Typography.caption.weight(.semibold))
+                .foregroundStyle(.white.opacity(badgeHovered || showPopover ? 0.96 : 0.86))
+        }
+        .padding(.horizontal, 2)
+        .padding(.vertical, 2)
+        .contentShape(RoundedRectangle(cornerRadius: 8))
+        .onHover { hovered in
+            badgeHovered = hovered
+            hovered ? presentPopover() : scheduleHide()
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(resetAvailabilityAccessibilityLabel)
+        .accessibilityHint(L10n.tr("Hover to show reset expiration details"))
+        .animation(.easeOut(duration: 0.12), value: badgeHovered)
+        .animation(.strongEaseOut, value: showPopover)
+    }
+
+    private var resetAvailabilityText: String {
+        let count = usageStore.codexResetCredits.availableCount
+        return count == 1 ? L10n.tr("1 reset available") : L10n.tr("%d resets available", count)
+    }
+
+    private var resetAvailabilityAccessibilityLabel: String {
+        let count = usageStore.codexResetCredits.availableCount
+        return count == 1 ? L10n.tr("1 Codex reset available") : L10n.tr("%d Codex resets available", count)
+    }
+
+    private var popoverYOffset: CGFloat {
+        usageStore.codexResetCredits.availableCredits.count == 1 ? -92 : -118
+    }
+
+    private var popover: some View {
+        VStack(spacing: 6) {
+            ForEach(Array(usageStore.codexResetCredits.availableCredits.prefix(3)), id: \.id) { credit in
+                resetRow(credit)
+            }
+        }
+        .padding(5)
+        .frame(width: 330, alignment: .leading)
+        .background(alignment: .top) {
+            ZStack(alignment: .topTrailing) {
+                RoundedRectangle(cornerRadius: 20)
+                    .fill(Color(red: 0.17, green: 0.20, blue: 0.28).opacity(0.92))
+                RoundedRectangle(cornerRadius: 16)
+                    .fill(
+                        LinearGradient(
+                            colors: [
+                                Color.white.opacity(0.08),
+                                Color.white.opacity(0.03)
+                            ],
+                            startPoint: .top,
+                            endPoint: .bottom
+                        )
+                    )
+                RoundedRectangle(cornerRadius: 20)
+                    .strokeBorder(.white.opacity(0.10), lineWidth: 0.75)
+            }
+        }
+        .shadow(color: .black.opacity(0.42), radius: 28, y: 14)
+        .shadow(color: Color.white.opacity(0.03), radius: 4)
+        .onHover { hovered in
+            popoverHovered = hovered
+            hovered ? cancelHide() : scheduleHide()
+        }
+    }
+
+    private func resetRow(_ credit: CodexResetCredit) -> some View {
+        HStack(alignment: .center, spacing: 7) {
+            Image(systemName: "checkmark.seal")
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundStyle(Color(red: 0.43, green: 0.95, blue: 0.74))
+                .frame(width: 18, height: 18)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text("EXPIRES")
+                    .font(.system(size: 9, weight: .semibold))
+                    .tracking(0.9)
+                    .foregroundStyle(.white.opacity(0.52))
+                Text(absolute(credit.expiresAt))
+                    .font(.system(size: 13, weight: .semibold, design: .monospaced))
+                    .foregroundStyle(.white.opacity(0.95))
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.5)
+                    .layoutPriority(1)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            Spacer(minLength: 10)
+
+            Text(L10n.tr("Available"))
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundStyle(Color(red: 0.52, green: 0.95, blue: 0.71))
+                .frame(width: 68, height: 26)
+                .padding(.horizontal, 2)
+                .padding(.vertical, 1)
+                .background(
+                    RoundedRectangle(cornerRadius: 8, style: .continuous)
+                        .fill(Color(red: 0.29, green: 0.55, blue: 0.42).opacity(0.26))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                                .strokeBorder(Color(red: 0.37, green: 0.83, blue: 0.60).opacity(0.28), lineWidth: 0.75)
+                        )
+                )
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 8)
+        .padding(.vertical, 7)
+        .background(
+            RoundedRectangle(cornerRadius: 14)
+                .fill(Color.white.opacity(0.055))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 14)
+                        .fill(
+                            LinearGradient(
+                                colors: [
+                                    Color.white.opacity(0.04),
+                                    Color.clear
+                                ],
+                                startPoint: .top,
+                                endPoint: .bottom
+                            )
+                        )
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 14)
+                        .strokeBorder(Color(red: 0.25, green: 0.62, blue: 0.42).opacity(0.18), lineWidth: 0.75)
+                )
+        )
+    }
+
+    private func presentPopover() {
+        cancelHide()
+        withAnimation(.strongEaseOut) {
+            showPopover = true
+        }
+    }
+
+    private func scheduleHide() {
+        cancelHide()
+        let workItem = DispatchWorkItem {
+            if !badgeHovered && !popoverHovered {
+                withAnimation(.easeOut(duration: 0.14)) {
+                    showPopover = false
+                }
+            }
+        }
+        hideWorkItem = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.12, execute: workItem)
+    }
+
+    private func cancelHide() {
+        hideWorkItem?.cancel()
+        hideWorkItem = nil
+    }
+
+    private static let relativeFormatter: RelativeDateTimeFormatter = {
+        let formatter = RelativeDateTimeFormatter()
+        formatter.locale = L10n.locale
+        formatter.unitsStyle = .abbreviated
+        return formatter
+    }()
+
+    private static let absoluteFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = L10n.locale
+        formatter.setLocalizedDateFormatFromTemplate("yMMMdahmm")
+        return formatter
+    }()
+
+    private func relative(_ date: Date) -> String {
+        Self.relativeFormatter.localizedString(for: date, relativeTo: Date())
+    }
+
+    private func absolute(_ date: Date) -> String {
+        Self.absoluteFormatter.locale = L10n.locale
+        return Self.absoluteFormatter.string(from: date)
+    }
+}

--- a/Sources/Views/CodexResetStatus.swift
+++ b/Sources/Views/CodexResetStatus.swift
@@ -62,7 +62,8 @@ struct CodexResetStatus: View {
     }
 
     private var popoverYOffset: CGFloat {
-        usageStore.codexResetCredits.availableCredits.count == 1 ? -56 : -118
+        let extraRows = max(0, min(2, usageStore.codexResetCredits.availableCredits.count - 1))
+        return -56 - CGFloat(extraRows * 50)
     }
 
     private var popover: some View {

--- a/Sources/Views/IslandRootView.swift
+++ b/Sources/Views/IslandRootView.swift
@@ -189,7 +189,13 @@ struct IslandRootView: View {
                         withAnimation(.easeOut(duration: 0.10)) {
                             contentVisible = false
                         }
-                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.10) {
+                        // Start the shape morph after only 20ms — overlapping
+                        // with the content fade — so the silhouette begins
+                        // shrinking while the content is still fading out.
+                        // The original 100ms wait caused a visible "flash black"
+                        // because the full-size black shape was exposed for the
+                        // entire fade before the closeMorph fired.
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.02) {
                             guard !hovering else { return }
                             // Re-read restState here — the user may have flipped
                             // the always-show toggle during the 100ms wait, and

--- a/Sources/Views/IslandRootView.swift
+++ b/Sources/Views/IslandRootView.swift
@@ -78,6 +78,7 @@ struct IslandRootView: View {
                         topPadding: max(0, (model.notch.height - 20) / 2)
                     )
                     .opacity(model.state == .compact && model.compactLogosHidden ? 0 : 1)
+                    .accessibilityHidden(model.state == .compact && model.compactLogosHidden)
                 }
                 .overlay(alignment: .topTrailing) {
                     LogoOverlay(
@@ -88,6 +89,7 @@ struct IslandRootView: View {
                         topPadding: max(0, (model.notch.height - 20) / 2)
                     )
                     .opacity(model.state == .compact && model.compactLogosHidden ? 0 : 1)
+                    .accessibilityHidden(model.state == .compact && model.compactLogosHidden)
                 }
                 .overlay(alignment: .topLeading) {
                     // Pill lives in the new outboard slot (the 78pt the

--- a/Sources/Views/IslandRootView.swift
+++ b/Sources/Views/IslandRootView.swift
@@ -116,10 +116,16 @@ struct IslandRootView: View {
                 .overlay(alignment: .bottomLeading) {
                     // Utility control, not dashboard status. Keep it in a
                     // quiet corner so the footer remains about live data.
+                    // Bottom padding (23) centers the 26pt-tall button on
+                    // PanelFooter's content row: that row sits 14pt
+                    // (ExpandedView's outer vertical padding) + 10pt
+                    // (the footer's own bottom padding) + 12pt (half its
+                    // 24pt height) = 36pt above the panel's bottom edge.
                     if model.state == .expanded {
                         SettingsButton()
                             .opacity(contentVisible ? 1 : 0)
-                            .padding(6)
+                            .padding(.leading, 6)
+                            .padding(.bottom, 23)
                     }
                 }
                 .contentShape(IslandShape())

--- a/Sources/Views/IslandRootView.swift
+++ b/Sources/Views/IslandRootView.swift
@@ -77,6 +77,7 @@ struct IslandRootView: View {
                         edgePadding: logoEdgePadding,
                         topPadding: max(0, (model.notch.height - 20) / 2)
                     )
+                    .opacity(model.state == .compact && model.compactLogosHidden ? 0 : 1)
                 }
                 .overlay(alignment: .topTrailing) {
                     LogoOverlay(
@@ -86,6 +87,7 @@ struct IslandRootView: View {
                         edgePadding: logoEdgePadding,
                         topPadding: max(0, (model.notch.height - 20) / 2)
                     )
+                    .opacity(model.state == .compact && model.compactLogosHidden ? 0 : 1)
                 }
                 .overlay(alignment: .topLeading) {
                     // Pill lives in the new outboard slot (the 78pt the
@@ -356,7 +358,10 @@ struct IslandRootView: View {
     private var logoEdgePadding: CGFloat {
         switch model.state {
         case .compact, .expanded: return 9
-        case .peek:               return model.pillSlotWidth + 9
+        // Peek always expands to maxPillSlotWidth (78pt) regardless of the
+        // compact-state sideSpace constraint, so pin the logo to that fixed
+        // offset — model.pillSlotWidth may be 0 in constrained compact.
+        case .peek:               return 78 + 9
         }
     }
 }

--- a/Sources/Views/PanelFooter.swift
+++ b/Sources/Views/PanelFooter.swift
@@ -51,6 +51,10 @@ struct PanelFooter: View {
 
                     Spacer()
 
+                    if screenPref.screen == .usage {
+                        CodexResetStatus()
+                    }
+
                     liveStatus
                 }
 


### PR DESCRIPTION
Overlap the closeMorph with the content fade (20ms delay instead of 100ms) so the silhouette begins shrinking while content is still fading out, preventing the full-size black shape from being visible between the two animations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced the brief “black flash” during the hover-exit close transition for smoother perceived timing.
* **New Features**
  * Added a Codex reset availability badge with a hover popover listing upcoming reset credits (limited results, localized/absolute expiration).
  * Display the badge in the usage footer when the usage screen is active (including demo data).
* **Improvements**
  * Enhanced notch-aware sizing using available side space, with fuller “peek” reach on hover.
  * Refined compact-mode logo hiding for better accessibility, and adjusted logo/controls spacing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->