### PR TITLE
feat(display): add used/remaining toggle for usage percentage

### DIFF
--- a/Resources/en.lproj/Localizable.strings
+++ b/Resources/en.lproj/Localizable.strings
@@ -131,6 +131,8 @@
 "⌘-click to cycle" = "⌘-click to cycle";
 "⌘1 — pull real provider data" = "⌘1 — pull real provider data";
 "%@ (hidden)" = "%@ (hidden)";
+"%@: %d percent of 5-hour window remaining" = "%@: %d percent of 5-hour window remaining";
+"%@: %d percent of 5-hour window remaining, %@" = "%@: %d percent of 5-hour window remaining, %@";
 "%@: %d percent of 5-hour window used" = "%@: %d percent of 5-hour window used";
 "%@: %d percent of 5-hour window used, %@" = "%@: %d percent of 5-hour window used, %@";
 "%@: no data for 5-hour window" = "%@: no data for 5-hour window";
@@ -138,6 +140,11 @@
 "Command-click to cycle visualization." = "Command-click to cycle visualization.";
 "Hover to peek usage. Click to expand. Command-click to cycle visualization." = "Hover to peek usage. Click to expand. Command-click to cycle visualization.";
 "How often to refresh." = "How often to refresh.";
+"Percentages" = "Percentages";
+"Remaining" = "Remaining";
+"Show usage as used or remaining quota." = "Show usage as used or remaining quota.";
+"Usage display" = "Usage display";
+"Used" = "Used";
 "Keep the percentage and time remaining visible without hovering." = "Keep the percentage and time remaining visible without hovering.";
 "Inject test percentages. Visible only when launched with CODEXISLAND_DEBUG=1." = "Inject test percentages. Visible only when launched with CODEXISLAND_DEBUG=1.";
 "Preview" = "Preview";

--- a/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Resources/zh-Hans.lproj/Localizable.strings
@@ -131,6 +131,8 @@
 "⌘-click to cycle" = "⌘ 点击切换";
 "⌘1 — pull real provider data" = "⌘1 — 拉取真实服务数据";
 "%@ (hidden)" = "%@（已隐藏）";
+"%@: %d percent of 5-hour window remaining" = "%@：5 小时窗口剩余 %d%%";
+"%@: %d percent of 5-hour window remaining, %@" = "%@：5 小时窗口剩余 %d%%，%@";
 "%@: %d percent of 5-hour window used" = "%@：已使用 5 小时窗口的 %d%%";
 "%@: %d percent of 5-hour window used, %@" = "%@：已使用 5 小时窗口的 %d%%，%@";
 "%@: no data for 5-hour window" = "%@：5 小时窗口暂无数据";
@@ -138,6 +140,11 @@
 "Command-click to cycle visualization." = "Command 点击可切换可视化。";
 "Hover to peek usage. Click to expand. Command-click to cycle visualization." = "悬停预览用量。点击展开。Command 点击可切换可视化。";
 "How often to refresh." = "刷新频率。";
+"Percentages" = "百分比";
+"Remaining" = "剩余";
+"Show usage as used or remaining quota." = "将用量百分比显示为已用或剩余额度。";
+"Usage display" = "用量显示";
+"Used" = "已用";
 "Keep the percentage and time remaining visible without hovering." = "无需悬停即可始终查看用量百分比和剩余时间。";
 "Inject test percentages. Visible only when launched with CODEXISLAND_DEBUG=1." = "注入测试百分比。仅在使用 CODEXISLAND_DEBUG=1 启动时显示。";
 "Preview" = "预览";

--- a/Sources/Model/UsageDisplayModeStore.swift
+++ b/Sources/Model/UsageDisplayModeStore.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+enum UsageDisplayMode: String, CaseIterable {
+    case used
+    case remaining
+
+    var label: String {
+        switch self {
+        case .used: return "Used"
+        case .remaining: return "Remaining"
+        }
+    }
+}
+
+@MainActor
+final class UsageDisplayModeStore: ObservableObject {
+    static let shared = UsageDisplayModeStore()
+
+    private static let key = "MacIsland.usageDisplayMode"
+
+    @Published var mode: UsageDisplayMode {
+        didSet { UserDefaults.standard.set(mode.rawValue, forKey: Self.key) }
+    }
+
+    private init() {
+        let raw = UserDefaults.standard.string(forKey: Self.key)
+        self.mode = UsageDisplayMode(rawValue: raw ?? "") ?? .used
+    }
+}

--- a/Sources/Theme/UrgencyColor.swift
+++ b/Sources/Theme/UrgencyColor.swift
@@ -9,9 +9,10 @@ enum UrgencyColor {
     /// #E65F5F — over 90%.
     static let red = Color(red: 230/255, green: 95/255, blue: 95/255)
 
-    static func value(_ percent: Double) -> Color {
-        if percent >= 90 { return red }
-        if percent >= 70 { return amber }
+    static func value(_ percent: Double, mode: UsageDisplayMode) -> Color {
+        let usedPercent = mode == .used ? percent : 100 - percent
+        if usedPercent >= 90 { return red }
+        if usedPercent >= 70 { return amber }
         return .white
     }
 }

--- a/Sources/Usage/AppUsage.swift
+++ b/Sources/Usage/AppUsage.swift
@@ -10,6 +10,19 @@ struct WindowUsage {
     static let unknown = WindowUsage(usedPercent: 0, resetAt: nil, error: "no data")
 
     var percentInt: Int { Int((usedPercent * 100).rounded()) }
+
+    func displayedFraction(mode: UsageDisplayMode) -> Double {
+        switch mode {
+        case .used:
+            return usedPercent
+        case .remaining:
+            return max(0, 1 - usedPercent)
+        }
+    }
+
+    func displayedPercentInt(mode: UsageDisplayMode) -> Int {
+        Int((displayedFraction(mode: mode) * 100).rounded())
+    }
 }
 
 struct AppUsage {

--- a/Sources/Views/Charts/ChartHead.swift
+++ b/Sources/Views/Charts/ChartHead.swift
@@ -16,7 +16,7 @@ struct ChartHead: View {
             HStack(alignment: .firstTextBaseline, spacing: 1) {
                 Text("\(Int(value))")
                     .font(Typography.chartValue)
-                    .foregroundStyle(UrgencyColor.value(value))
+                    .foregroundStyle(UrgencyColor.value(value, mode: UsageDisplayModeStore.shared.mode))
                     .numericTransition(value: value)
                     .animation(.strongEaseOut, value: value)
                 Text("%")

--- a/Sources/Views/Charts/NumericChart.swift
+++ b/Sources/Views/Charts/NumericChart.swift
@@ -21,7 +21,7 @@ struct NumericChart: View {
             HStack(alignment: .firstTextBaseline, spacing: 2) {
                 Text("\(Int(value))")
                     .font(Typography.bigNumber)
-                    .foregroundStyle(UrgencyColor.value(value))
+                    .foregroundStyle(UrgencyColor.value(value, mode: UsageDisplayModeStore.shared.mode))
                     .numericTransition(value: value)
                     .animation(.strongEaseOut, value: value)
                 Text("%")

--- a/Sources/Views/Charts/RingChart.swift
+++ b/Sources/Views/Charts/RingChart.swift
@@ -31,7 +31,7 @@ struct RingChart: View {
                     HStack(alignment: .firstTextBaseline, spacing: 1) {
                         Text("\(Int(value))")
                             .font(Typography.chartValue)
-                            .foregroundStyle(UrgencyColor.value(value))
+                            .foregroundStyle(UrgencyColor.value(value, mode: UsageDisplayModeStore.shared.mode))
                             .numericTransition(value: value)
                             .animation(.strongEaseOut, value: value)
                         Text("%")

--- a/Sources/Views/IslandRootView.swift
+++ b/Sources/Views/IslandRootView.swift
@@ -558,15 +558,20 @@ private struct PeekPillOverlay: View {
         if window.error != nil && window.usedPercent == 0 {
             return L10n.tr("%@: no data for 5-hour window", provider)
         }
-        let pct = window.percentInt
+        let mode = UsageDisplayModeStore.shared.mode
+        let pct = window.displayedPercentInt(mode: mode)
         guard let resetAt = window.resetAt else {
-            return L10n.tr("%@: %d percent of 5-hour window used", provider, pct)
+            return mode == .used
+                ? L10n.tr("%@: %d percent of 5-hour window used", provider, pct)
+                : L10n.tr("%@: %d percent of 5-hour window remaining", provider, pct)
         }
         let remaining = max(0, resetAt.timeIntervalSinceNow)
         let resetPhrase: String = remaining >= 3600
             ? L10n.tr("resets in %d hours", Int((remaining / 3600).rounded(.down)))
             : L10n.tr("resets in %d minutes", max(1, Int((remaining / 60).rounded(.down))))
-        return L10n.tr("%@: %d percent of 5-hour window used, %@", provider, pct, resetPhrase)
+        return mode == .used
+            ? L10n.tr("%@: %d percent of 5-hour window used, %@", provider, pct, resetPhrase)
+            : L10n.tr("%@: %d percent of 5-hour window remaining, %@", provider, pct, resetPhrase)
     }
 }
 

--- a/Sources/Views/NotchPeekPill.swift
+++ b/Sources/Views/NotchPeekPill.swift
@@ -17,6 +17,7 @@ struct NotchPeekPill: View {
     let tint: Color
     let alignment: HorizontalAlignment
     var severity: AlertEngine.Severity = .none
+    @ObservedObject private var usageDisplay = UsageDisplayModeStore.shared
 
     var body: some View {
         Group {
@@ -109,7 +110,7 @@ struct NotchPeekPill: View {
     }
 
     private var percentText: String {
-        "\(usage.percentInt)%"
+        "\(usage.displayedPercentInt(mode: usageDisplay.mode))%"
     }
 
     /// `Nh` when ≥ 1h remaining, `Nm` under 1h. Returns nil if there's no

--- a/Sources/Views/SettingsView.swift
+++ b/Sources/Views/SettingsView.swift
@@ -17,6 +17,7 @@ struct SettingsView: View {
     @ObservedObject private var alwaysShow = AlwaysShowUsageStore.shared
     @ObservedObject private var alertPrefs = AlertThresholdStore.shared
     @ObservedObject private var spacing = IslandSpacingStore.shared
+    @ObservedObject private var usageDisplay = UsageDisplayModeStore.shared
     @ObservedObject private var targetDisplay = IslandTargetDisplayStore.shared
     @ObservedObject private var appLanguage = AppLanguageStore.shared
     @ObservedObject private var usage = UsageStore.shared
@@ -135,6 +136,7 @@ struct SettingsView: View {
 
     private var displayTab: some View {
         VStack(alignment: .leading, spacing: 0) {
+            usageDisplaySection
             chartSection
             costStyleSection
             targetDisplaySection
@@ -632,6 +634,21 @@ struct SettingsView: View {
         .padding(.bottom, 14)
     }
 
+    private var usageDisplaySection: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            sectionLabel("Usage display")
+            SettingsRow(
+                title: "Percentages",
+                subtitle: "Show usage as used or remaining quota."
+            ) {
+                usageDisplaySegmented
+            }
+        }
+        .padding(.horizontal, 14)
+        .padding(.top, 18)
+        .padding(.bottom, 14)
+    }
+
     private var costStyleSection: some View {
         VStack(alignment: .leading, spacing: 0) {
             sectionLabel("Cost view", hint: "⌘-click to cycle")
@@ -667,6 +684,15 @@ struct SettingsView: View {
             selected: $spacing.mode,
             label: { $0 == .compact ? "Compact" : "Notch-style" },
             accessibilityPrefix: "Island width"
+        )
+    }
+
+    private var usageDisplaySegmented: some View {
+        SegmentedControl(
+            items: UsageDisplayMode.allCases,
+            selected: $usageDisplay.mode,
+            label: \.label,
+            accessibilityPrefix: "Usage display"
         )
     }
 
@@ -754,12 +780,12 @@ struct SettingsView: View {
             guard let updated = usage.lastUpdated else { return L10n.tr("idle") }
             return L10n.tr("synced %@", Self.relativeFormatter.localizedString(for: updated, relativeTo: Date()))
         }()
-        let nums = "\(Self.windowCaption(u.fiveHour)) / \(Self.windowCaption(u.weekly))"
+        let nums = "\(windowCaption(u.fiveHour)) / \(windowCaption(u.weekly))"
         return "\(synced) · \(nums)"
     }
 
-    private static func windowCaption(_ w: WindowUsage) -> String {
+    private func windowCaption(_ w: WindowUsage) -> String {
         if let err = w.error, w.percentInt == 0 { return "⚠ \(err)" }
-        return "\(w.percentInt)%"
+        return "\(w.displayedPercentInt(mode: usageDisplay.mode))%"
     }
 }

--- a/Sources/Views/UsageView.swift
+++ b/Sources/Views/UsageView.swift
@@ -142,13 +142,14 @@ struct ChartTile: View {
     let labelKey: String
     let window: WindowUsage
     let seed: Int
+    @ObservedObject private var usageDisplay = UsageDisplayModeStore.shared
 
     /// Locked tile height across all 5 styles so the panel size is
     /// identical regardless of what the user picks.
     private static let tileHeight: CGFloat = 96
 
     var body: some View {
-        let value = window.usedPercent * 100   // 0-100
+        let value = window.displayedFraction(mode: usageDisplay.mode) * 100   // 0-100
         let sub = subCaption()
         let label = L10n.tr(labelKey)
 


### PR DESCRIPTION
## Summary
Some users think in "how much is left" rather than "how much I've used", and Codex itself defaults to remaining quota. Adds a segmented control in Settings > Display so users can pick the view that matches how they think.

Default stays "Used" so existing installs see no change, and urgency coloring stays aligned with the displayed mode by mapping remaining back to used thresholds.

## Verification
- Ran `./scripts/verify.sh`
- Built and launched successfully
- Manually checked the display toggle and percentage coloring behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new "Usage display" setting allowing users to toggle between viewing quota as "used" or "remaining" percentage.
  * All quota displays throughout the app now respect this preference, including lock screen indicators and usage charts.
  * User's display mode choice is automatically saved and persists across sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->