### PR TITLE
fix(usage): 키체인 중복 항목을 로그인 누락과 구분

### DIFF
--- a/Sources/Usage/ClaudeCredentials.swift
+++ b/Sources/Usage/ClaudeCredentials.swift
@@ -63,7 +63,8 @@ enum ClaudeCredentials {
     ///      to platform.claude.com — old URL still resolves but is not the
     ///      canonical issuer for fresh tokens.)
     static func resolveUsage(probe: (_ token: String, _ plan: String?) async -> ProbeOutcome) async -> Resolution {
-        var lastError = "auth required — run claude"
+        let defaultError = "auth required — run claude"
+        var lastError = defaultError
         // Plan tier ships in the keychain dict only — Anthropic's usage
         // endpoint doesn't echo it back. We peek the keychain even on the
         // env-token path so the chip works for users whose token came from
@@ -115,6 +116,14 @@ enum ClaudeCredentials {
                 case .otherError(let e):    lastError = e
                 }
             }
+        }
+
+        // No usage, and no probe set a more specific error: if we never had a
+        // login because the keychain returned a stray item (its account isn't
+        // the current user), say so rather than the generic "auth required".
+        if lastError == defaultError, cachedCreds == nil,
+           let account = readClaudeKeychainAccount(), account != NSUserName() {
+            lastError = "multiple keychain logins"
         }
 
         return .failed(lastError)


### PR DESCRIPTION
### 배경
키체인에 `Claude Code-credentials` 항목이 **2개 이상** 존재해 Claude 인증이 실패하는 문제가 있었습니다 (정상 로그인 항목 + `unknown` 등 다른 계정의 **로그인 없는 항목**).

### 원인
`security find-generic-password -s "Claude Code-credentials"`(`-a` 없음)는 항목이 여러 개여도 **하나만** 반환합니다. 로그인 없는 항목이 먼저 잡히면 `claudeAiOauth`가 없어, 정상 로그인이 다른 항목에 있어도 `auth required — run claude`만 표시됐습니다.

### 변경
반환된 항목에 로그인이 없고(`cachedCreds == nil`) 계정이 현재 사용자와 다르면(`account != NSUserName()`), `auth required` 대신 `multiple keychain logins`를 노출합니다.
- 맨 끝에서 기본 메시지일 때만 교체 → `rate limited` 등 더 구체적인 에러는 유지.
- 정상 로그인은 `claudeAiOauth`가 있어 분기 진입 안 함(오탐 없음).

### 동작 화면
![multiple keychain logins](https://raw.githubusercontent.com/junghyunbak/codex-island/assets/pr-assets/keychain-multiple-logins.png)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages for authentication issues, specifically when multiple keychain accounts are detected, providing clearer feedback to help resolve credential problems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->