### PR TITLE
perf(cost): fix Codex cost-tab CPU/memory blowup on large session logs

### DIFF
--- a/Sources/Cost/CodexLogReader.swift
+++ b/Sources/Cost/CodexLogReader.swift
@@ -60,7 +60,16 @@ enum CodexLogReader {
         var currentModel: String?
         var out: [CachedEvent] = []
 
-        LogParseCache.streamLines(at: url) { lineData in
+        // `maxLineBytes` skips the multi-MB `response_item` blobs (base64
+        // screenshots, large tool output) at the reader level — they're never
+        // the records we want and assembling them is what stalls big sessions.
+        LogParseCache.streamLines(at: url, maxLineBytes: maxUsefulLineBytes) { lineData in
+            // The only lines we care about — `turn_context` (model) and
+            // `event_msg`/`token_count` (usage) — carry these markers. A cheap
+            // byte-scan rejects everything else before paying for JSON parsing.
+            guard lineData.range(of: tokenCountMarker) != nil
+                    || lineData.range(of: turnContextMarker) != nil else { return }
+
             guard let raw = try? JSONSerialization.jsonObject(with: lineData) as? [String: Any],
                   let type = raw["type"] as? String else { return }
 
@@ -108,6 +117,16 @@ enum CodexLogReader {
         }
         return out
     }
+
+    // MARK: - Line pre-filter
+
+    /// Upper bound for a usage/model line. `token_count` payloads are well
+    /// under 1KB and even a tool-heavy `turn_context` stays small; 1MB leaves
+    /// generous headroom while skipping the multi-MB image/payload lines that
+    /// dominate large sessions.
+    private static let maxUsefulLineBytes = 1 << 20
+    private static let tokenCountMarker = Data("token_count".utf8)
+    private static let turnContextMarker = Data("turn_context".utf8)
 
     // MARK: - Per-file cache
 

--- a/Sources/Cost/LogParseCache.swift
+++ b/Sources/Cost/LogParseCache.swift
@@ -43,31 +43,58 @@ enum LogParseCache {
     /// terminated line, plus once for any trailing line lacking a newline.
     /// Session JSONLs can reach 50+ MB and we may walk months of them, so
     /// loading entire files via `Data(contentsOf:)` blows up peak memory.
-    /// Buffer trim happens once per chunk (not per line) — `removeSubrange`
-    /// is O(N) and per-line trimming made a single 50MB JSONL O(N²).
-    static func streamLines(at url: URL, onLine: (Data) -> Void) {
+    ///
+    /// Newline scanning happens on each freshly-read chunk (always ≤64KB), and
+    /// only the in-progress partial line is carried forward in `pending`. The
+    /// previous implementation appended every chunk to one growing buffer and
+    /// re-scanned it from the cursor each time, which is O(N²) for a single
+    /// long line — a Codex session that embeds base64 images produces lines
+    /// up to ~50MB, and a 10GB home of them pegged a core for minutes. Here a
+    /// long line only ever costs the per-chunk scan plus appends to `pending`.
+    ///
+    /// `maxLineBytes` caps a single line: once `pending` exceeds it, the line
+    /// is abandoned (never buffered further, never delivered) and bytes are
+    /// dropped until the next newline. Defaults to no cap so existing callers
+    /// (Claude) are byte-for-byte unchanged; the Codex reader opts in to skip
+    /// the image/payload blobs it never needs to parse.
+    static func streamLines(at url: URL, maxLineBytes: Int = .max, onLine: (Data) -> Void) {
         guard let handle = try? FileHandle(forReadingFrom: url) else { return }
         defer { try? handle.close() }
 
-        var buffer = Data()
         let chunkSize = 64 * 1024
+        var pending = Data()          // partial line carried across chunk reads
+        var skippingLongLine = false  // discarding an over-cap line until its '\n'
 
         while true {
             let chunk = handle.readData(ofLength: chunkSize)
             if chunk.isEmpty { break }
-            buffer.append(chunk)
 
-            var cursor = buffer.startIndex
-            while cursor < buffer.endIndex {
-                guard let nl = buffer[cursor..<buffer.endIndex].firstIndex(of: 0x0A) else { break }
-                if nl > cursor { onLine(buffer[cursor..<nl]) }
-                cursor = buffer.index(after: nl)
+            var lineStart = chunk.startIndex
+            while let nl = chunk[lineStart..<chunk.endIndex].firstIndex(of: 0x0A) {
+                if skippingLongLine {
+                    // Reached the end of the abandoned line; resume normally.
+                    skippingLongLine = false
+                    pending.removeAll(keepingCapacity: true)
+                } else if pending.isEmpty {
+                    if nl > lineStart { onLine(chunk[lineStart..<nl]) }
+                } else {
+                    pending.append(chunk[lineStart..<nl])
+                    onLine(pending)
+                    pending.removeAll(keepingCapacity: true)
+                }
+                lineStart = chunk.index(after: nl)
             }
-            if cursor > buffer.startIndex {
-                buffer.removeSubrange(buffer.startIndex..<cursor)
+
+            // Bytes after the last newline form (the start of) the next line.
+            if lineStart < chunk.endIndex, !skippingLongLine {
+                pending.append(chunk[lineStart..<chunk.endIndex])
+                if pending.count > maxLineBytes {
+                    pending.removeAll(keepingCapacity: true)
+                    skippingLongLine = true
+                }
             }
         }
-        if !buffer.isEmpty { onLine(buffer) }
+        if !skippingLongLine, !pending.isEmpty { onLine(pending) }
     }
 
     /// Per-file cache entry. Generic over the provider's `Event` Codable shape.

--- a/Sources/Cost/LogParseCache.swift
+++ b/Sources/Cost/LogParseCache.swift
@@ -44,8 +44,10 @@ enum LogParseCache {
     /// Session JSONLs can reach 50+ MB and we may walk months of them, so
     /// loading entire files via `Data(contentsOf:)` blows up peak memory.
     ///
-    /// Newline scanning happens on each freshly-read chunk (always ≤64KB), and
-    /// only the in-progress partial line is carried forward in `pending`. The
+    /// Newline scanning happens on each freshly-read chunk (always ≤64KB) via
+    /// `memchr` — vectorized, and it skips the per-byte bounds-checked `Data`
+    /// subscript that dominated the scan profile — and only the in-progress
+    /// partial line is carried forward in `pending`. The
     /// previous implementation appended every chunk to one growing buffer and
     /// re-scanned it from the cursor each time, which is O(N²) for a single
     /// long line — a Codex session that embeds base64 images produces lines
@@ -69,25 +71,30 @@ enum LogParseCache {
             let chunk = handle.readData(ofLength: chunkSize)
             if chunk.isEmpty { break }
 
-            var lineStart = chunk.startIndex
-            while let nl = chunk[lineStart..<chunk.endIndex].firstIndex(of: 0x0A) {
+            var lineStart = 0
+            while let nl = firstNewline(in: chunk, from: lineStart) {
                 if skippingLongLine {
                     // Reached the end of the abandoned line; resume normally.
                     skippingLongLine = false
                     pending.removeAll(keepingCapacity: true)
                 } else if pending.isEmpty {
-                    if nl > lineStart { onLine(chunk[lineStart..<nl]) }
+                    // A line wholly inside one chunk never touches `pending`, so
+                    // honor the cap here too — otherwise the "over-cap line is
+                    // never delivered" contract would silently break for any
+                    // caller whose cap is below the 64KB chunk size.
+                    let len = nl - lineStart
+                    if len > 0, len <= maxLineBytes { onLine(chunk[lineStart..<nl]) }
                 } else {
                     pending.append(chunk[lineStart..<nl])
                     onLine(pending)
                     pending.removeAll(keepingCapacity: true)
                 }
-                lineStart = chunk.index(after: nl)
+                lineStart = nl + 1
             }
 
             // Bytes after the last newline form (the start of) the next line.
-            if lineStart < chunk.endIndex, !skippingLongLine {
-                pending.append(chunk[lineStart..<chunk.endIndex])
+            if lineStart < chunk.count, !skippingLongLine {
+                pending.append(chunk[lineStart..<chunk.count])
                 if pending.count > maxLineBytes {
                     pending.removeAll(keepingCapacity: true)
                     skippingLongLine = true
@@ -95,6 +102,20 @@ enum LogParseCache {
             }
         }
         if !skippingLongLine, !pending.isEmpty { onLine(pending) }
+    }
+
+    /// Offset of the first 0x0A at or after `start` within `data`, or nil.
+    /// `memchr` is vectorized and skips the per-byte bounds-checked `Data`
+    /// subscript that dominated the scan profile on large session logs.
+    /// Callers pass a fresh chunk (startIndex 0), so the returned offset is a
+    /// valid `Int` subscript into it.
+    private static func firstNewline(in data: Data, from start: Int) -> Int? {
+        guard start < data.count else { return nil }
+        return data.withUnsafeBytes { raw -> Int? in
+            guard let base = raw.baseAddress else { return nil }
+            guard let hit = memchr(base + start, 0x0A, data.count - start) else { return nil }
+            return UnsafeRawPointer(hit) - base
+        }
     }
 
     /// Per-file cache entry. Generic over the provider's `Event` Codable shape.

--- a/Sources/Usage/ClaudeCredentials.swift
+++ b/Sources/Usage/ClaudeCredentials.swift
@@ -12,12 +12,20 @@ import Foundation
 ///   - A keychain-token (or refreshed-token) scope-insufficient short-circuits
 ///     to re-auth, because refresh re-issues the same scope set and cannot
 ///     recover a missing `user:profile`.
+///   - A rate-limited probe short-circuits from ANY source: the limiter is
+///     keyed per account, not per token (anthropics/claude-code#30930), so
+///     trying another token or refreshing only feeds the limiter.
 enum ClaudeCredentials {
     /// Emitted as `WindowUsage.error` when the keychain token is structurally
     /// valid but missing a scope the Claude usage endpoint now requires
     /// (`user:profile`, added mid-2026). The UI layer matches on this exact
     /// string to swap the error caption for an in-app re-auth button.
     static let reauthRequiredMessage = "re-login: claude /login"
+
+    /// Emitted as `WindowUsage.error` when the usage endpoint rate-limits us
+    /// (HTTP 429, or 200 with a rate_limit_error body). `UsageStore` matches
+    /// on this exact string to arm the post-429 fetch cooldown.
+    static let rateLimitedMessage = "rate limited"
 
     /// Outcome of a single usage-endpoint probe against one token. The fetcher
     /// owns the HTTP + parsing and reports back through this; `ClaudeCredentials`
@@ -75,7 +83,9 @@ enum ClaudeCredentials {
            !envToken.isEmpty {
             switch await probe(envToken, plan) {
             case .success(let u):       return .usage(u)
-            case .rateLimited:          lastError = "rate limited"
+            // Account-level limit: the keychain token shares the bucket, so a
+            // second probe is just another hit on a tripped limiter.
+            case .rateLimited:          return .failed(rateLimitedMessage)
             case .unauthorized:         break
             case .scopeInsufficient:    lastError = reauthRequiredMessage
             case .otherError(let e):    lastError = e
@@ -85,7 +95,11 @@ enum ClaudeCredentials {
         if let creds = cachedCreds {
             switch await probe(creds.accessToken, plan) {
             case .success(let u):       return .usage(u)
-            case .rateLimited:          lastError = "rate limited"
+            // The token is valid — the account is throttled. Refreshing
+            // rotates the token family for nothing and the re-probe doubles
+            // pressure on a limiter that is sticky once tripped
+            // (429 + retry-after: 0 until the account goes quiet).
+            case .rateLimited:          return .failed(rateLimitedMessage)
             case .unauthorized:         break
             // Refresh hands back tokens with the same scope set, so it cannot
             // recover from a missing-scope 403. Bail out and surface the only
@@ -109,7 +123,7 @@ enum ClaudeCredentials {
 
                 switch await probe(refreshed.accessToken, plan) {
                 case .success(let u):       return .usage(u)
-                case .rateLimited:          lastError = "rate limited"
+                case .rateLimited:          return .failed(rateLimitedMessage)
                 case .unauthorized:         break
                 case .scopeInsufficient:    return .reauthRequired(reauthRequiredMessage)
                 case .otherError(let e):    lastError = e

--- a/Sources/Usage/UsageStore.swift
+++ b/Sources/Usage/UsageStore.swift
@@ -32,6 +32,14 @@ final class UsageStore: ObservableObject {
         TimeInterval(RefreshIntervalStore.shared.seconds)
     }
 
+    /// The /api/oauth/usage limiter is sticky once tripped: it returns 429
+    /// with `retry-after: 0` until the account has gone quiet for a while
+    /// (anthropics/claude-code#30930), so polling through it never recovers.
+    /// After a rate-limited fetch, skip Claude fetches for this long.
+    /// Deliberately in-memory only — a quit+relaunch retries immediately.
+    private static let rateLimitCooldown: TimeInterval = 900
+    private var claudeCooldownUntil: Date?
+
     func refresh() {
         if loading { return }
         // Demo mode for screen recordings: skip the network entirely and
@@ -75,9 +83,12 @@ final class UsageStore: ObservableObject {
         refreshTask?.cancel()
         refreshTask = Task {
             async let codexResult = UsageFetcher.fetchCodex()
-            async let claudeResult = UsageFetcher.fetchClaude()
+            let coolingDown = claudeCooldownUntil.map { Date() < $0 } ?? false
+            var cl: AppUsage?
+            if !coolingDown {
+                cl = await UsageFetcher.fetchClaude()
+            }
             let c = await codexResult
-            let cl = await claudeResult
 
             // Cancellation = network monitor saw the path come up while we
             // were mid-flight on a dead one. The fetched values are the
@@ -98,8 +109,16 @@ final class UsageStore: ObservableObject {
             if !UsageStore.isErrorOnly(c) || UsageStore.isErrorOnly(self.codex) {
                 self.codex = c
             }
-            if !UsageStore.isErrorOnly(cl) || UsageStore.isErrorOnly(self.claude) {
-                self.claude = cl
+            if let cl {
+                if UsageStore.isRateLimited(cl) {
+                    self.claudeCooldownUntil = Date().addingTimeInterval(UsageStore.rateLimitCooldown)
+                    NSLog("CodexIsland: Claude usage rate-limited; skipping Claude fetches for %.0fs", UsageStore.rateLimitCooldown)
+                } else {
+                    self.claudeCooldownUntil = nil
+                }
+                if !UsageStore.isErrorOnly(cl) || UsageStore.isErrorOnly(self.claude) {
+                    self.claude = cl
+                }
             }
             self.lastUpdated = Date()
             self.loading = false
@@ -111,6 +130,13 @@ final class UsageStore: ObservableObject {
     private static func isErrorOnly(_ u: AppUsage) -> Bool {
         u.fiveHour.error != nil && u.weekly.error != nil
             && u.fiveHour.usedPercent == 0 && u.weekly.usedPercent == 0
+    }
+
+    /// True when the fetch resolved to the rate-limited error (both windows
+    /// carry the same message — see `UsageFetcher.errorPair`).
+    private static func isRateLimited(_ u: AppUsage) -> Bool {
+        u.fiveHour.error == ClaudeCredentials.rateLimitedMessage
+            && u.weekly.error == ClaudeCredentials.rateLimitedMessage
     }
 
     /// Replace current usage values with hand-tuned percentages so the

--- a/Tests/ResolveUsageTests.swift
+++ b/Tests/ResolveUsageTests.swift
@@ -1,0 +1,86 @@
+import Foundation
+
+/// Regression tests for ClaudeCredentials.resolveUsage, run by
+/// scripts/run-tests.sh (no XCTest — the app builds with bare swiftc, so the
+/// harness does too). The runner sets CLAUDE_CODE_OAUTH_TOKEN to a stub value
+/// so the env-token path drives the injected probe deterministically on any
+/// machine, with or without a real "Claude Code-credentials" keychain item.
+///
+/// Why the rate-limited case is locked down (issue #35): Anthropic's
+/// /api/oauth/usage limiter is account-keyed and sticky once tripped
+/// (anthropics/claude-code#30930). resolveUsage must short-circuit on the
+/// first rate-limited probe — if a regression reintroduces the old
+/// fall-through, every poll cycle re-probes and rotates the refresh-token
+/// family against a throttled account. (On a dev machine with real keychain
+/// creds, such a regression would also make THIS test perform one live token
+/// rotation before the probe-count assertion catches it — noisy but
+/// recoverable, since the rotation writeback path is exercised by the app
+/// daily.)
+@main
+struct ResolveUsageTests {
+    final class ProbeCounter {
+        var calls = 0
+    }
+
+    static var failures = 0
+
+    static func expect(_ condition: Bool, _ label: String) {
+        if condition {
+            print("PASS \(label)")
+        } else {
+            print("FAIL \(label)")
+            failures += 1
+        }
+    }
+
+    static func main() async {
+        guard ProcessInfo.processInfo.environment["CLAUDE_CODE_OAUTH_TOKEN"] == "test-stub-token" else {
+            print("FAIL harness must run via scripts/run-tests.sh (env token stub missing)")
+            exit(1)
+        }
+
+        // T1 — a rate-limited probe short-circuits the whole resolution:
+        // exactly one probe (no fallback to the next token source, no
+        // refresh + re-probe) and the exact error string the UI and
+        // UsageStore cooldown match on.
+        let t1 = ProbeCounter()
+        let r1 = await ClaudeCredentials.resolveUsage { _, _ in
+            t1.calls += 1
+            return .rateLimited
+        }
+        if case .failed(let msg) = r1 {
+            expect(msg == ClaudeCredentials.rateLimitedMessage, "T1 resolution is .failed(rateLimitedMessage)")
+        } else {
+            expect(false, "T1 resolution is .failed(rateLimitedMessage)")
+        }
+        expect(t1.calls == 1, "T1 probes exactly once (got \(t1.calls))")
+
+        // T2 — a successful probe passes usage through untouched.
+        let t2 = ProbeCounter()
+        let fetched = AppUsage(
+            fiveHour: WindowUsage(usedPercent: 0.13, resetAt: nil, error: nil),
+            weekly: WindowUsage(usedPercent: 0.14, resetAt: nil, error: nil)
+        )
+        let r2 = await ClaudeCredentials.resolveUsage { _, _ in
+            t2.calls += 1
+            return .success(fetched)
+        }
+        if case .usage(let u) = r2 {
+            expect(u.fiveHour.usedPercent == 0.13 && u.weekly.usedPercent == 0.14, "T2 usage passes through")
+        } else {
+            expect(false, "T2 usage passes through")
+        }
+        expect(t2.calls == 1, "T2 probes exactly once (got \(t2.calls))")
+
+        // The store and views match these exact strings; a reword is a
+        // breaking change for them, not a copy edit.
+        expect(ClaudeCredentials.rateLimitedMessage == "rate limited", "rateLimitedMessage literal is stable")
+        expect(ClaudeCredentials.reauthRequiredMessage == "re-login: claude /login", "reauthRequiredMessage literal is stable")
+
+        if failures > 0 {
+            print("\(failures) failure(s)")
+            exit(1)
+        }
+        print("all tests passed")
+    }
+}

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Compiles the usage-resolution sources together with the test harness and
+# runs it. No XCTest/SPM — mirrors build.sh's bare-swiftc approach. The env
+# token stub routes resolveUsage through the injected probe deterministically
+# (see Tests/ResolveUsageTests.swift).
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+OUT_DIR=$(mktemp -d)
+trap 'rm -rf "$OUT_DIR"' EXIT
+
+swiftc \
+  -parse-as-library \
+  -o "$OUT_DIR/resolve-usage-tests" \
+  Sources/Usage/AppUsage.swift \
+  Sources/Usage/ClaudeCredentials.swift \
+  Tests/ResolveUsageTests.swift
+
+CLAUDE_CODE_OAUTH_TOKEN="test-stub-token" "$OUT_DIR/resolve-usage-tests"


### PR DESCRIPTION
Resolves the Cost-tab CPU-pegging and memory spike on large `~/.codex` corpora (#41) by combining the two community PRs that targeted it, taking the best of each.

## What this does

The Codex rollout JSONLs embed multi-MB single lines (base64 screenshots, large tool output). Three costs piled up on those lines:

1. **O(N²) newline re-scan** — the old reader appended every chunk to one growing buffer and re-scanned from the cursor each read, so a single 50MB line cost minutes of CPU.
2. **Buffering the full line** — the whole multi-MB line sat in memory before delivery.
3. **JSON-parsing the blob** — `parseFile` ran `JSONSerialization` on every line, including the giant ones it immediately discards.

This branch fixes all three:

- **From #39 (@tristan666666):** chunk-local reader that carries only the in-progress partial line in `pending`, a `maxLineBytes` cap (1MB for Codex, `.max`/unchanged for Claude) that abandons over-cap lines instead of buffering them, and a cheap `token_count`/`turn_context` byte-marker pre-filter that skips JSON parsing for every non-usage line.
- **From #42 (@TengTu0311):** the newline scan uses vectorized `memchr` instead of the per-byte bounds-checked `Data` subscript that dominated the scan profile.
- **One extra guard:** the cap is now enforced on lines that fit wholly within a single chunk too, not just chunk-spanning ones — so the "over-cap line is never delivered" contract holds for any cap/chunk ratio. No behavior change for the real configs (Claude `.max`, Codex 1MB ≫ 64KB chunk).

## Credit

- #39 by @tristan666666 — cherry-picked, authorship preserved.
- #42 by @TengTu0311 — `memchr` scan grafted in; #42 closed in favor of this combined change.

## Verification

- Universal build green (`./build.sh`, arm64 + x86_64).
- 12-case streaming harness passing: multi-chunk lines, empty lines, no-trailing-newline, over-cap drop + resume, under-cap survival — across both single-read and tiny-chunk paths.

Closes #41

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of API rate limiting with automatic cooldown to prevent repeated failed requests.

* **Performance**
  * Optimized log file parsing for faster processing and reduced memory usage on large files.

* **Tests**
  * Added comprehensive test coverage for usage resolution and rate limiting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->