### PR TITLE
feat(usage): plot real recorded history in the SparkChart

### DIFF
--- a/Sources/Usage/UsageHistory.swift
+++ b/Sources/Usage/UsageHistory.swift
@@ -1,0 +1,91 @@
+import Foundation
+import Combine
+
+/// One observed reading of a single rate-limit window. `used` is the 0...1
+/// fraction the API reported at `at`.
+struct UsageSample: Codable {
+    let at: Date
+    let used: Double
+}
+
+enum UsageWindow: String, Codable {
+    case fiveHour
+    case weekly
+}
+
+/// Records the usage percentages the app already polls so the SparkChart can
+/// plot the user's real trajectory instead of a synthesized curve. Neither
+/// provider exposes a usage time-series, but we sample one ourselves on every
+/// successful refresh and persist it across launches. A failed poll, a
+/// rate-limit cooldown, or a closed app leaves a gap rather than a fabricated
+/// point — the chart only ever shows readings that actually happened.
+@MainActor
+final class UsageHistoryStore: ObservableObject {
+    static let shared = UsageHistoryStore()
+
+    /// Bumped whenever a sample lands so SwiftUI tiles observing the store
+    /// re-read. The samples themselves stay private — callers ask per series.
+    @Published private(set) var revision = 0
+
+    /// Keep a week of readings. At the 5-minute polling floor that is ~2000
+    /// points per window, so a count cap also guards against a tighter
+    /// interval filling memory.
+    private static let maxAge: TimeInterval = 7 * 86400
+    private static let maxSamples = 1000
+    private static let storageKey = "CodexIsland.usageHistory.v1"
+
+    private var series: [String: [UsageSample]]
+
+    private init() {
+        if let data = UserDefaults.standard.data(forKey: Self.storageKey),
+           let decoded = try? JSONDecoder().decode([String: [UsageSample]].self, from: data) {
+            series = decoded
+        } else {
+            series = [:]
+        }
+    }
+
+    /// Append the non-errored windows of a fresh fetch. Errored windows are
+    /// skipped so a failed poll leaves a gap rather than a fabricated point.
+    func record(provider: AlertEngine.Provider, usage: AppUsage, at: Date) {
+        var changed = append(provider, .fiveHour, usage.fiveHour, at)
+        changed = append(provider, .weekly, usage.weekly, at) || changed
+        if changed {
+            persist()
+            revision &+= 1
+        }
+    }
+
+    /// Readings for one series, oldest first. The latest entry is the most
+    /// recent successful poll.
+    func samples(provider: AlertEngine.Provider, window: UsageWindow) -> [UsageSample] {
+        series[key(provider, window)] ?? []
+    }
+
+    private func append(
+        _ provider: AlertEngine.Provider,
+        _ window: UsageWindow,
+        _ reading: WindowUsage,
+        _ at: Date
+    ) -> Bool {
+        guard reading.error == nil else { return false }
+        let k = key(provider, window)
+        var arr = series[k] ?? []
+        arr.append(UsageSample(at: at, used: max(0, min(1, reading.usedPercent))))
+        let cutoff = at.addingTimeInterval(-Self.maxAge)
+        arr.removeAll { $0.at < cutoff }
+        if arr.count > Self.maxSamples { arr.removeFirst(arr.count - Self.maxSamples) }
+        series[k] = arr
+        return true
+    }
+
+    private func key(_ p: AlertEngine.Provider, _ w: UsageWindow) -> String {
+        "\(p.rawValue).\(w.rawValue)"
+    }
+
+    private func persist() {
+        if let data = try? JSONEncoder().encode(series) {
+            UserDefaults.standard.set(data, forKey: Self.storageKey)
+        }
+    }
+}

--- a/Sources/Usage/UsageStore.swift
+++ b/Sources/Usage/UsageStore.swift
@@ -120,7 +120,14 @@ final class UsageStore: ObservableObject {
                     self.claude = cl
                 }
             }
-            self.lastUpdated = Date()
+
+            // Record this poll's readings so the SparkChart can plot real
+            // history. `record` keeps only non-errored windows, so a failed
+            // or rate-limited fetch leaves a gap instead of a flat fake line.
+            let now = Date()
+            UsageHistoryStore.shared.record(provider: .codex, usage: c, at: now)
+            if let cl { UsageHistoryStore.shared.record(provider: .claude, usage: cl, at: now) }
+            self.lastUpdated = now
             self.loading = false
         }
     }

--- a/Sources/Views/Charts/SparkChart.swift
+++ b/Sources/Views/Charts/SparkChart.swift
@@ -6,11 +6,15 @@ struct SparkChart: View {
     let label: String
     let sub: String
     let seed: Int
+    /// Real observed history for this window, oldest first, in display
+    /// percent (0-100). Empty until enough polls accrue, at which point the
+    /// curve switches from synthesized to real.
+    var history: [Double] = []
 
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
             ChartHead(value: value, label: label)
-            SparkSVG(value: value, color: color, seed: seed)
+            SparkSVG(value: value, color: color, seed: seed, history: history)
                 .frame(height: 50)
                 .animation(.strongEaseOut, value: value)
             ChartFoot(caption: sub)
@@ -22,6 +26,11 @@ private struct SparkSVG: View {
     let value: Double
     let color: Color
     let seed: Int
+    let history: [Double]
+
+    /// Below this many real samples the curve reads as a stub, not a trend,
+    /// so the synthesized shape stands in until enough polls have landed.
+    private static let minRealPoints = 6
 
     /// Synthesize 36 plausible-looking historical points around the current
     /// value. Real history would need a usage time-series API neither
@@ -55,10 +64,27 @@ private struct SparkSVG: View {
         }
     }
 
+    /// Map the recorded readings onto the plot. nil (too few samples, or demo
+    /// mode, which keeps the staged synthetic shape) tells the caller to fall
+    /// back to `generatePoints`. The last point is pinned to the live `value`
+    /// so the end cursor and the dotted "now" baseline agree exactly.
+    private func realPoints(width: CGFloat, height: CGFloat) -> [CGPoint]? {
+        guard !AppEnvironment.isDemo, history.count >= Self.minRealPoints else { return nil }
+        var pts = history
+        pts[pts.count - 1] = value
+        let n = pts.count
+        return pts.enumerated().map { (i, p) in
+            CGPoint(
+                x: CGFloat(i) * (width / CGFloat(n - 1)),
+                y: height - CGFloat(min(100, max(0, p)) / 100) * (height - 8) - 4
+            )
+        }
+    }
+
     var body: some View {
         GeometryReader { geo in
             let w = geo.size.width, h = geo.size.height
-            let pts = generatePoints(width: w, height: h)
+            let pts = realPoints(width: w, height: h) ?? generatePoints(width: w, height: h)
             let baselineY = h - CGFloat(value / 100) * (h - 8) - 4
             ZStack {
                 // Quartile rules at 4% white, barely there.

--- a/Sources/Views/UsageView.swift
+++ b/Sources/Views/UsageView.swift
@@ -25,13 +25,13 @@ struct UsageView: View {
             switch (claudeOn, codexOn) {
             case (true, true):
                 ChartsBlock(color: IslandColor.claude, usage: store.claude,
-                            style: style, seed: 1)
+                            style: style, seed: 1, provider: .claude)
                 hairline
                 ChartsBlock(color: IslandColor.codex, usage: store.codex,
-                            style: style, seed: 3)
+                            style: style, seed: 3, provider: .codex)
             case (true, false):
                 ChartsBlock(color: IslandColor.claude, usage: store.claude,
-                            style: style, seed: 1)
+                            style: style, seed: 1, provider: .claude)
                 hairline
                 PerModelBreakdown(provider: .claude, metric: .tokens)
                     .frame(maxWidth: .infinity, alignment: .top)
@@ -44,7 +44,7 @@ struct UsageView: View {
                     .transition(breakdownTransition)
                 hairline
                 ChartsBlock(color: IslandColor.codex, usage: store.codex,
-                            style: style, seed: 3)
+                            style: style, seed: 3, provider: .codex)
             case (false, false):
                 BothHiddenPlaceholder()
                     .transition(.opacity)
@@ -80,6 +80,7 @@ struct ChartsBlock: View {
     let usage: AppUsage
     let style: ChartStyle
     let seed: Int
+    let provider: AlertEngine.Provider
 
     /// Treat the block as needing re-auth when both windows are stuck on the
     /// scope-insufficient sentinel. Either tile alone could be a transient
@@ -94,9 +95,11 @@ struct ChartsBlock: View {
         VStack(spacing: 6) {
             HStack(spacing: 18) {
                 ChartTile(style: style, color: color, labelKey: "5h",
-                          window: usage.fiveHour, seed: seed)
+                          window: usage.fiveHour, seed: seed,
+                          provider: provider, windowKind: .fiveHour)
                 ChartTile(style: style, color: color, labelKey: "week",
-                          window: usage.weekly, seed: seed + 1)
+                          window: usage.weekly, seed: seed + 1,
+                          provider: provider, windowKind: .weekly)
             }
             if needsReauth && ClaudeCredentials.canPromptReauth() {
                 ReauthButton()
@@ -142,7 +145,10 @@ struct ChartTile: View {
     let labelKey: String
     let window: WindowUsage
     let seed: Int
+    let provider: AlertEngine.Provider
+    let windowKind: UsageWindow
     @ObservedObject private var usageDisplay = UsageDisplayModeStore.shared
+    @ObservedObject private var historyStore = UsageHistoryStore.shared
 
     /// Locked tile height across all 5 styles so the panel size is
     /// identical regardless of what the user picks.
@@ -159,7 +165,8 @@ struct ChartTile: View {
             case .bar:     BarChart(value: value, color: color, label: label, sub: sub)
             case .stepped: SteppedChart(value: value, color: color, label: label, sub: sub)
             case .numeric: NumericChart(value: value, color: color, label: label, sub: compactSubCaption())
-            case .spark:   SparkChart(value: value, color: color, label: label, sub: sub, seed: seed)
+            case .spark:   SparkChart(value: value, color: color, label: label, sub: sub,
+                                      seed: seed, history: historyPoints())
             }
         }
         .id(style)
@@ -172,6 +179,17 @@ struct ChartTile: View {
         .accessibilityElement(children: .combine)
         .accessibilityLabel(L10n.tr("%@, %d%%", label, Int(value)))
         .accessibilityValue(subCaption())
+    }
+
+    /// Recorded readings for this window, mapped through the active
+    /// used/remaining mode into display percent (0-100), oldest first — the
+    /// same transform `value` uses, so the history and the live point agree.
+    private func historyPoints() -> [Double] {
+        let mode = usageDisplay.mode
+        return historyStore.samples(provider: provider, window: windowKind).map { sample in
+            WindowUsage(usedPercent: sample.used, resetAt: nil, error: nil)
+                .displayedFraction(mode: mode) * 100
+        }
     }
 
     private func subCaption() -> String {


### PR DESCRIPTION
## The problem (the maintainer's own ask)

CONTRIBUTING lists this under "Things that need work":

> Real history for the SparkChart. The synthesized noise is honestly
> decorative. If either Anthropic or OpenAI exposes a usage time-series,
> we should switch.

Today the SparkChart fabricates its curve from the current value plus sine
noise — `Sources/Views/Charts/SparkChart.swift`, unchanged in `main`:

```swift
/// Synthesize 36 plausible-looking historical points around the current
/// value. Real history would need a usage time-series API neither
/// provider exposes — this is decorative and clearly so.
private func generatePoints(width: CGFloat, height: CGFloat) -> [CGPoint] {
    ...
    var acc = value * startFactor
    for i in 0..<n {
        let noise = sin(Double(i + seed) * 1.3) * noiseAmpA + cos(Double(i + seed) * 0.7) * noiseAmpB
        acc = acc * 0.65 + (value * targetFactor + noise) * 0.35
        ...
    }
}
```

So the "trend" carries no information — it looks the same no matter how the
window actually filled or reset.

## The insight

No provider exposes a usage time-series, but the app already polls usage on
every refresh — so it can record that series itself instead of waiting for
an upstream API.

## How

- `UsageHistoryStore` persists per-(provider, window) samples to UserDefaults,
  capped to 7 days / 1000 points.
- `UsageStore` appends one sample per window on every non-errored poll. A
  failed or rate-limited fetch records nothing for that window, so gaps stay
  honest instead of a flat fake line.
- `SparkChart` plots the recorded readings, mapped through the used/remaining
  toggle with the last point pinned to the live value. Until six samples
  accrue it keeps the synthesized shape; demo mode is unchanged so screen
  recordings still read full.

## Verification

- Build green (universal arm64 + x86_64).
- Store-logic harness (append, skip-errored, age + count caps, render switch): 9/9.
- End-to-end on real logs: after one live poll all four series recorded real
  readings; errored windows skipped.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Usage charts now learn from recent polling history, so spark lines can reflect real usage trends when enough data is available.
  * Usage data is now remembered across app launches, allowing charts to continue from previously collected history.

* **Bug Fixes**
  * Chart updates now use a consistent timestamp during refreshes, improving display consistency.
  * Old usage samples are automatically trimmed so charts stay responsive and up to date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->