### PR TITLE
fix(claude): show usage when multiple keychain logins share the service name

### DIFF
--- a/Sources/Usage/ClaudeCredentials.swift
+++ b/Sources/Usage/ClaudeCredentials.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Security
 
 /// Deep module owning Claude OAuth credential acquisition: the
 /// env → keychain → refresh → rotation-writeback flow, plus the in-app
@@ -116,11 +117,16 @@ enum ClaudeCredentials {
                 // attempt 401s and forces the user to re-run /login. Persist
                 // the rotated tokens so the keychain stays in sync with what
                 // the server considers valid.
-                var updated = creds.oauth
-                updated["accessToken"] = refreshed.accessToken
-                updated["refreshToken"] = refreshed.refreshToken
-                updated["expiresAt"] = refreshed.expiresAt
-                writeClaudeCreds(account: creds.account, oauth: updated)
+                var updatedOAuth = creds.oauth
+                updatedOAuth["accessToken"] = refreshed.accessToken
+                updatedOAuth["refreshToken"] = refreshed.refreshToken
+                updatedOAuth["expiresAt"] = refreshed.expiresAt
+                // Rewrite the FULL item, not just claudeAiOauth. The selected
+                // account's blob can also carry sibling top-level keys (e.g.
+                // mcpOAuth, per-MCP-server tokens); a {"claudeAiOauth": …}-only
+                // payload would clobber them and break Claude Code's MCP auth.
+                writeClaudeCreds(account: creds.account,
+                                 payload: rotatedPayload(outer: creds.outer, oauth: updatedOAuth))
 
                 switch await probe(refreshed.accessToken, plan) {
                 case .success(let u):       return .usage(u)
@@ -145,22 +151,109 @@ enum ClaudeCredentials {
 
     // MARK: - Keychain
 
-    private struct ClaudeCreds {
+    /// Internal (not private) so ResolveUsageTests can assert which item the
+    /// multi-account selection picks and that the rotation writeback keeps
+    /// sibling keys.
+    struct ClaudeCreds {
         let account: String
         let accessToken: String
         let refreshToken: String
+        /// The `claudeAiOauth` subdict only.
         let oauth: [String: Any]
+        /// The entire decoded keychain blob (e.g. `{mcpOAuth, claudeAiOauth}`),
+        /// carried so a token refresh can rewrite the item without dropping
+        /// sibling top-level keys.
+        let outer: [String: Any]
         let subscriptionType: String?
     }
 
-    /// Reads the keychain item Claude Code writes on first login. Returns
-    /// nil silently on any error — the caller falls through to the next
-    /// token source. Captures the account name and the full claudeAiOauth
-    /// dict so a refresh can be written back via writeClaudeCreds without
-    /// dropping unrelated fields (scopes, subscriptionType, rateLimitTier).
-    private static func readClaudeCreds() -> ClaudeCreds? {
-        guard let account = readClaudeKeychainAccount() else { return nil }
+    /// One decoded keychain item under the Claude service.
+    struct KeychainCandidate {
+        let account: String
+        let blob: [String: Any]
+    }
 
+    /// Reads Claude Code's login from the keychain, or nil if there isn't a
+    /// usable one — the caller then falls through to the next token source.
+    /// Claude Code stores several generic-password items under the SAME service
+    /// "Claude Code-credentials": the subscription tokens live in
+    /// `claudeAiOauth`, but a separate item written with acct="unknown" holds
+    /// only `mcpOAuth` (per-MCP-server tokens). `security find-generic-password
+    /// -s` returns an arbitrary one, so a single blind lookup can land on the
+    /// mcpOAuth item and miss the real login — the bug where the panel showed
+    /// no Claude usage. Read every item and let `selectClaudeCreds` pick by
+    /// content rather than by "first item". The full blob is carried through so
+    /// a token refresh can rewrite the item without dropping sibling keys.
+    private static func readClaudeCreds() -> ClaudeCreds? {
+        selectClaudeCreds(from: readClaudeKeychainCandidates())
+    }
+
+    /// First candidate carrying a usable `claudeAiOauth` (non-empty access +
+    /// refresh tokens). Pure — exposed for ResolveUsageTests, which locks down
+    /// both the multi-item selection and that `outer` retains sibling keys for
+    /// the rotation writeback. An empty-token item is a logged-out remnant,
+    /// skipped so a later account still gets its chance.
+    static func selectClaudeCreds(from candidates: [KeychainCandidate]) -> ClaudeCreds? {
+        for candidate in candidates {
+            guard let oauth = candidate.blob["claudeAiOauth"] as? [String: Any],
+                  let access = oauth["accessToken"] as? String, !access.isEmpty,
+                  let refresh = oauth["refreshToken"] as? String, !refresh.isEmpty else { continue }
+            return ClaudeCreds(
+                account: candidate.account,
+                accessToken: access,
+                refreshToken: refresh,
+                oauth: oauth,
+                outer: candidate.blob,
+                subscriptionType: oauth["subscriptionType"] as? String
+            )
+        }
+        return nil
+    }
+
+    /// Full keychain payload to persist after a token rotation: every sibling
+    /// top-level key from `outer` kept, with only `claudeAiOauth` swapped for
+    /// the rotated subdict. A partial `{"claudeAiOauth": …}` payload would drop
+    /// siblings like `mcpOAuth`. Pure — exercised by ResolveUsageTests.
+    static func rotatedPayload(outer: [String: Any], oauth: [String: Any]) -> [String: Any] {
+        var merged = outer
+        merged["claudeAiOauth"] = oauth
+        return merged
+    }
+
+    /// Decoded blob for every account under the service. Side-effecting: shells
+    /// out to `security` per account. (An attributes-only SecItem query
+    /// enumerates the accounts without an ACL prompt; reading the secret value
+    /// stays on the already-trusted `security` CLI path.)
+    private static func readClaudeKeychainCandidates() -> [KeychainCandidate] {
+        var accounts = claudeKeychainAccounts()
+        if accounts.isEmpty, let legacy = readClaudeKeychainAccount() {
+            accounts = [legacy]
+        }
+        return accounts.compactMap { account in
+            readClaudeKeychainBlob(account: account).map {
+                KeychainCandidate(account: account, blob: $0)
+            }
+        }
+    }
+
+    /// Every account name under the "Claude Code-credentials" service. An
+    /// attributes-only SecItem query (no `kSecReturnData`) does not trip the
+    /// keychain ACL prompt — only reading the secret value would.
+    private static func claudeKeychainAccounts() -> [String] {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: "Claude Code-credentials",
+            kSecMatchLimit as String: kSecMatchLimitAll,
+            kSecReturnAttributes as String: true,
+        ]
+        var result: CFTypeRef?
+        guard SecItemCopyMatching(query as CFDictionary, &result) == errSecSuccess,
+              let items = result as? [[String: Any]] else { return [] }
+        return items.compactMap { $0[kSecAttrAccount as String] as? String }
+    }
+
+    /// Decoded JSON blob of one account's item, or nil on any read/parse error.
+    private static func readClaudeKeychainBlob(account: String) -> [String: Any]? {
         let task = Process()
         task.launchPath = "/usr/bin/security"
         task.arguments = [
@@ -179,12 +272,8 @@ enum ClaudeCredentials {
             guard let raw = String(data: data, encoding: .utf8)?
                     .trimmingCharacters(in: .whitespacesAndNewlines),
                   let jsonData = raw.data(using: .utf8),
-                  let outer = try JSONSerialization.jsonObject(with: jsonData) as? [String: Any],
-                  let oauth = outer["claudeAiOauth"] as? [String: Any],
-                  let access = oauth["accessToken"] as? String,
-                  let refresh = oauth["refreshToken"] as? String else { return nil }
-            let plan = oauth["subscriptionType"] as? String
-            return ClaudeCreds(account: account, accessToken: access, refreshToken: refresh, oauth: oauth, subscriptionType: plan)
+                  let outer = try JSONSerialization.jsonObject(with: jsonData) as? [String: Any] else { return nil }
+            return outer
         } catch {
             return nil
         }
@@ -222,16 +311,18 @@ enum ClaudeCredentials {
     }
 
     /// Updates the existing `Claude Code-credentials` keychain item in place
-    /// (`-U` flag) so the rotated OAuth tokens persist. Best-effort: a
-    /// failure here means the next CodexIsland refresh will pay the same
-    /// rotation cost again, but Claude Code itself recovers because the
-    /// fresh refresh_token we wrote — if the write actually landed — works.
+    /// (`-U` flag) so the rotated OAuth tokens persist. `payload` MUST be the
+    /// complete top-level blob (build it with `rotatedPayload`) — `security`
+    /// replaces the whole secret, so a partial payload silently drops the
+    /// omitted keys. Best-effort: a failure here means the next CodexIsland
+    /// refresh pays the same rotation cost again, but Claude Code itself
+    /// recovers because the fresh refresh_token we wrote — if the write
+    /// actually landed — works.
     /// Note: passing the JSON via `-w` makes it briefly visible in `ps` to
     /// processes owned by the same user. The keychain itself is gated by
     /// the same trust boundary, so this is not a meaningful regression.
     @discardableResult
-    private static func writeClaudeCreds(account: String, oauth: [String: Any]) -> Bool {
-        let payload: [String: Any] = ["claudeAiOauth": oauth]
+    private static func writeClaudeCreds(account: String, payload: [String: Any]) -> Bool {
         guard let data = try? JSONSerialization.data(withJSONObject: payload, options: []),
               let json = String(data: data, encoding: .utf8) else {
             NSLog("CodexIsland: failed to serialize rotated Claude tokens for keychain write")

--- a/Sources/Usage/ClaudeCredentials.swift
+++ b/Sources/Usage/ClaudeCredentials.swift
@@ -310,25 +310,43 @@ enum ClaudeCredentials {
         }
     }
 
-    /// Updates the existing `Claude Code-credentials` keychain item in place
-    /// (`-U` flag) so the rotated OAuth tokens persist. `payload` MUST be the
-    /// complete top-level blob (build it with `rotatedPayload`) — `security`
-    /// replaces the whole secret, so a partial payload silently drops the
-    /// omitted keys. Best-effort: a failure here means the next CodexIsland
-    /// refresh pays the same rotation cost again, but Claude Code itself
-    /// recovers because the fresh refresh_token we wrote — if the write
-    /// actually landed — works.
-    /// Note: passing the JSON via `-w` makes it briefly visible in `ps` to
-    /// processes owned by the same user. The keychain itself is gated by
-    /// the same trust boundary, so this is not a meaningful regression.
+    /// Updates the existing `Claude Code-credentials` keychain item in place so
+    /// the rotated OAuth tokens persist. `payload` MUST be the complete
+    /// top-level blob (build it with `rotatedPayload`) — the secret is replaced
+    /// wholesale, so a partial payload silently drops the omitted keys.
+    ///
+    /// Primary path is `SecItemUpdate`, which carries the secret in-process via
+    /// `kSecValueData`, so the JSON never lands on the process list. Only if
+    /// SecItem can't update the item (e.g. its ACL doesn't trust this app) do we
+    /// fall back to the `security` CLI: dropping a rotated refresh_token would
+    /// 401 downstream consumers (Claude Code, Claude Desktop), so a write that
+    /// actually lands always wins over avoiding the brief argv exposure.
     @discardableResult
     private static func writeClaudeCreds(account: String, payload: [String: Any]) -> Bool {
-        guard let data = try? JSONSerialization.data(withJSONObject: payload, options: []),
-              let json = String(data: data, encoding: .utf8) else {
+        guard let data = try? JSONSerialization.data(withJSONObject: payload, options: []) else {
             NSLog("CodexIsland: failed to serialize rotated Claude tokens for keychain write")
             return false
         }
 
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: "Claude Code-credentials",
+            kSecAttrAccount as String: account,
+        ]
+        let status = SecItemUpdate(query as CFDictionary, [kSecValueData as String: data] as CFDictionary)
+        if status == errSecSuccess { return true }
+
+        NSLog("CodexIsland: SecItemUpdate for rotated Claude tokens failed (OSStatus %d), falling back to security CLI", status)
+        return writeClaudeCredsViaSecurityCLI(account: account, json: String(decoding: data, as: UTF8.self))
+    }
+
+    /// Fallback keychain write via the Apple-signed `security` tool, used only
+    /// when `SecItemUpdate` can't land the write. Briefly exposes the JSON on
+    /// the process list via `-w` to same-user processes — accepted here because
+    /// a same-user process can already read the item straight from the keychain,
+    /// and losing the rotated token is the worse failure.
+    @discardableResult
+    private static func writeClaudeCredsViaSecurityCLI(account: String, json: String) -> Bool {
         let task = Process()
         task.launchPath = "/usr/bin/security"
         task.arguments = [

--- a/Tests/ResolveUsageTests.swift
+++ b/Tests/ResolveUsageTests.swift
@@ -72,6 +72,36 @@ struct ResolveUsageTests {
         }
         expect(t2.calls == 1, "T2 probes exactly once (got \(t2.calls))")
 
+        // T3 — multi-item keychain selection. Claude Code writes several items
+        // under one service name; a stray acct="unknown" item holds only
+        // mcpOAuth. Selection must skip it (and any logged-out empty-token
+        // item) and pick the item that actually carries claudeAiOauth.
+        let candidates = [
+            ClaudeCredentials.KeychainCandidate(account: "unknown", blob: ["mcpOAuth": ["server": "x"]]),
+            ClaudeCredentials.KeychainCandidate(account: "loggedout", blob: ["claudeAiOauth": ["accessToken": "", "refreshToken": ""]]),
+            ClaudeCredentials.KeychainCandidate(account: "ericpark", blob: [
+                "mcpOAuth": ["server": "x"],
+                "claudeAiOauth": ["accessToken": "at", "refreshToken": "rt", "subscriptionType": "max"],
+            ]),
+        ]
+        let picked = ClaudeCredentials.selectClaudeCreds(from: candidates)
+        expect(picked?.account == "ericpark", "T3 selects the claudeAiOauth item, not the mcpOAuth/empty ones")
+        expect(picked?.subscriptionType == "max", "T3 carries subscriptionType from the picked item")
+        expect(picked?.outer["mcpOAuth"] != nil, "T3 keeps sibling top-level keys in outer")
+        expect(ClaudeCredentials.selectClaudeCreds(from: [
+            ClaudeCredentials.KeychainCandidate(account: "unknown", blob: ["mcpOAuth": [:]]),
+        ]) == nil, "T3 returns nil when no item carries claudeAiOauth")
+
+        // T4 — rotation writeback preserves every sibling key. Writing only
+        // {"claudeAiOauth": …} back to an item that also held mcpOAuth would
+        // clobber Claude Code's MCP auth.
+        let rotated = ClaudeCredentials.rotatedPayload(
+            outer: ["mcpOAuth": ["server": "x"], "claudeAiOauth": ["accessToken": "old"]],
+            oauth: ["accessToken": "new", "refreshToken": "rt2"]
+        )
+        expect(rotated["mcpOAuth"] != nil, "T4 rotation payload keeps mcpOAuth")
+        expect((rotated["claudeAiOauth"] as? [String: Any])?["accessToken"] as? String == "new", "T4 rotation payload updates claudeAiOauth")
+
         // The store and views match these exact strings; a reword is a
         // breaking change for them, not a copy edit.
         expect(ClaudeCredentials.rateLimitedMessage == "rate limited", "rateLimitedMessage literal is stable")

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -13,6 +13,7 @@ trap 'rm -rf "$OUT_DIR"' EXIT
 swiftc \
   -parse-as-library \
   -o "$OUT_DIR/resolve-usage-tests" \
+  Sources/Model/UsageDisplayModeStore.swift \
   Sources/Usage/AppUsage.swift \
   Sources/Usage/ClaudeCredentials.swift \
   Tests/ResolveUsageTests.swift


### PR DESCRIPTION
## What

The Claude panel shows "no Claude usage" / an `auth required`-style state for users who have more than one keychain item under the `Claude Code-credentials` service. Codex data is unaffected.

## Root cause

Claude Code stores several generic-password items under the **same** service name `Claude Code-credentials`:

| account | top-level keys |
|---|---|
| `unknown` | `mcpOAuth` (per-MCP-server tokens) |
| `<your login>` | `mcpOAuth`, `claudeAiOauth` (the subscription tokens) |

`readClaudeCreds()` called `security find-generic-password -s "Claude Code-credentials"` with **no account**, so `security` returned whichever item it found first. When that was the `mcpOAuth`-only `unknown` item, the lookup found no `claudeAiOauth`, returned `nil`, and `resolveUsage` fell through to an error. The existing `account != NSUserName()` branch surfaced "multiple keychain logins" but didn't recover the data.

## Fix

- Enumerate **every** account under the service with an attributes-only `SecItemCopyMatching` query (no `kSecReturnData`, so it doesn't trip the keychain ACL prompt), then pick the first item that actually carries a non-empty `claudeAiOauth`. The username-based lookup stays as a fallback when SecItem can't enumerate.
- Empty-token items (logged-out remnants) are skipped so a later account still gets a chance.

While here, one latent data-loss bug: the token-refresh writeback rewrote the item as `{"claudeAiOauth": …}` only. On the account that also holds `mcpOAuth`, that dropped the MCP tokens on the next rotation and broke Claude Code's MCP auth. The selected item's full blob is now carried through and `rotatedPayload` keeps every sibling key.

## Tests

`scripts/run-tests.sh` didn't compile `Sources/Model/UsageDisplayModeStore.swift`, so since `AppUsage` started referencing `UsageDisplayMode` the harness failed with `cannot find type 'UsageDisplayMode'` and never ran (it isn't wired into CI). First commit adds that file to the compile list, which also un-breaks the existing T1/T2 tests.

New cases in the same harness:
- **T3** — selection skips the `mcpOAuth`-only and empty-token items and picks the `claudeAiOauth` one; returns nil when none qualify.
- **T4** — `rotatedPayload` keeps `mcpOAuth` while updating `claudeAiOauth`.

## Verification

- `./scripts/run-tests.sh` — all green (T1–T4).
- `./scripts/verify.sh` — builds + smoke-launches.
- Verified live against `api.anthropic.com/api/oauth/usage`: with the fix the reader selects the right account and the 5-hour / 7-day windows populate.

No `VERSION` / Sparkle / appcast changes — left for a maintainer release.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed OAuth credential refresh to preserve other saved account data in the secure keychain.
  * Improved credential selection when multiple keychain entries exist, ensuring the correct credentials are used and only the intended token values are rotated.
* **Tests**
  * Added regression coverage for multi-entry credential selection and refresh payload behavior, including checks that sibling values remain intact.
* **Chores**
  * Updated the test harness build to include the usage display mode store source.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Related

Likely the cause of #46 (`auth required — run claude`). That exact string is `resolveUsage`'s `defaultError`, emitted only when no readable `claudeAiOauth` is found — which is what this multi-item keychain situation produces. Not marking it `Fixes` since the same message can also mean a genuinely-absent login; the reporter can confirm whether a second keychain item is present.
