### PR TITLE
fix(animation): eliminate black flash on island hover-out

### DIFF
--- a/Sources/Views/IslandRootView.swift
+++ b/Sources/Views/IslandRootView.swift
@@ -189,7 +189,13 @@ struct IslandRootView: View {
                         withAnimation(.easeOut(duration: 0.10)) {
                             contentVisible = false
                         }
-                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.10) {
+                        // Start the shape morph after only 20ms — overlapping
+                        // with the content fade — so the silhouette begins
+                        // shrinking while the content is still fading out.
+                        // The original 100ms wait caused a visible "flash black"
+                        // because the full-size black shape was exposed for the
+                        // entire fade before the closeMorph fired.
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.02) {
                             guard !hovering else { return }
                             // Re-read restState here — the user may have flipped
                             // the always-show toggle during the 100ms wait, and

--- a/Sources/Views/IslandRootView.swift
+++ b/Sources/Views/IslandRootView.swift
@@ -198,7 +198,7 @@ struct IslandRootView: View {
                         DispatchQueue.main.asyncAfter(deadline: .now() + 0.02) {
                             guard !hovering else { return }
                             // Re-read restState here — the user may have flipped
-                            // the always-show toggle during the 100ms wait, and
+                            // the always-show toggle during the 20ms wait, and
                             // a captured-at-creation-time `target` would settle
                             // at the wrong state for them.
                             let target = restState


### PR DESCRIPTION
Overlaps the closeMorph with the content fade (shape morph starts after 20ms instead of 100ms) so the silhouette begins shrinking while content is still fading out — no full-size black shape is exposed for the whole fade.

Split out of #36 as a standalone, on-topic change. Rebased on latest `main` (no conflicts). Also corrects a stale nearby comment that still referred to the "100ms wait".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the hover exit animation so the shape returns to its rest state more quickly and smoothly.
  * Reduced a brief visual glitch during hover transitions by shortening the delay before the closing animation starts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->