### PR TITLE
feat(usage): show Codex reset credit status

### DIFF
--- a/Resources/en.lproj/Localizable.strings
+++ b/Resources/en.lproj/Localizable.strings
@@ -31,7 +31,6 @@
 "Auto" = "Auto";
 "Auto — currently on %@." = "Auto — currently on %@.";
 "Auto — picks a notched display when available." = "Auto — picks a notched display when available.";
-"Available" = "Available";
 "EXPIRES" = "EXPIRES";
 "Bar" = "Bar";
 "Both" = "Both";

--- a/Resources/en.lproj/Localizable.strings
+++ b/Resources/en.lproj/Localizable.strings
@@ -13,6 +13,10 @@
 "%@ in %@. %d active days. Claude %@, Codex %@." = "%@ in %@. %d active days. Claude %@, Codex %@.";
 "%@ TOKENS" = "%@ TOKENS";
 "%d Active Days" = "%d Active Days";
+"%d Codex resets available" = "%d Codex resets available";
+"%d resets available" = "%d resets available";
+"1 Codex reset available" = "1 Codex reset available";
+"1 reset available" = "1 reset available";
 "⚠ %d unpriced" = "⚠ %d unpriced";
 " · pricing data %dd old" = " · pricing data %dd old";
 "$%@ cumulative" = "$%@ cumulative";
@@ -27,6 +31,8 @@
 "Auto" = "Auto";
 "Auto — currently on %@." = "Auto — currently on %@.";
 "Auto — picks a notched display when available." = "Auto — picks a notched display when available.";
+"Available" = "Available";
+"EXPIRES" = "EXPIRES";
 "Bar" = "Bar";
 "Both" = "Both";
 "Both providers hidden" = "Both providers hidden";
@@ -139,6 +145,7 @@
 "Click to expand. Command-click to cycle visualization." = "Click to expand. Command-click to cycle visualization.";
 "Command-click to cycle visualization." = "Command-click to cycle visualization.";
 "Hover to peek usage. Click to expand. Command-click to cycle visualization." = "Hover to peek usage. Click to expand. Command-click to cycle visualization.";
+"Hover to show reset expiration details" = "Hover to show reset expiration details";
 "How often to refresh." = "How often to refresh.";
 "Percentages" = "Percentages";
 "Remaining" = "Remaining";

--- a/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Resources/zh-Hans.lproj/Localizable.strings
@@ -31,7 +31,6 @@
 "Auto" = "自动";
 "Auto — currently on %@." = "自动 — 当前在 %@。";
 "Auto — picks a notched display when available." = "自动 — 优先选择带刘海的屏幕。";
-"Available" = "可用";
 "EXPIRES" = "到期时间";
 "Bar" = "柱状";
 "Both" = "两者";

--- a/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Resources/zh-Hans.lproj/Localizable.strings
@@ -13,6 +13,10 @@
 "%@ in %@. %d active days. Claude %@, Codex %@." = "%@，%@ 年。%d 个活跃日。Claude %@，Codex %@。";
 "%@ TOKENS" = "%@ TOKEN";
 "%d Active Days" = "%d 个活跃日";
+"%d Codex resets available" = "%d 个 Codex 重置可用";
+"%d resets available" = "%d 个重置可用";
+"1 Codex reset available" = "1 个 Codex 重置可用";
+"1 reset available" = "1 个重置可用";
 "⚠ %d unpriced" = "⚠ %d 个模型缺价格";
 " · pricing data %dd old" = " · 价格数据已过 %d 天";
 "$%@ cumulative" = "$%@ 累计";
@@ -27,6 +31,8 @@
 "Auto" = "自动";
 "Auto — currently on %@." = "自动 — 当前在 %@。";
 "Auto — picks a notched display when available." = "自动 — 优先选择带刘海的屏幕。";
+"Available" = "可用";
+"EXPIRES" = "到期时间";
 "Bar" = "柱状";
 "Both" = "两者";
 "Both providers hidden" = "两个服务都已隐藏";
@@ -139,6 +145,7 @@
 "Click to expand. Command-click to cycle visualization." = "点击展开。Command 点击可切换可视化。";
 "Command-click to cycle visualization." = "Command 点击可切换可视化。";
 "Hover to peek usage. Click to expand. Command-click to cycle visualization." = "悬停预览用量。点击展开。Command 点击可切换可视化。";
+"Hover to show reset expiration details" = "悬停查看重置到期详情";
 "How often to refresh." = "刷新频率。";
 "Percentages" = "百分比";
 "Remaining" = "剩余";

--- a/Sources/Usage/CodexResetCredits.swift
+++ b/Sources/Usage/CodexResetCredits.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+struct CodexResetCredit: Identifiable, Equatable {
+    let id: String
+    let status: String
+    let expiresAt: Date
+    let title: String
+    let description: String
+
+    var isAvailable: Bool {
+        status.lowercased() == "available"
+    }
+}
+
+struct CodexResetCredits: Equatable {
+    var availableCount: Int
+    var credits: [CodexResetCredit]
+
+    static let empty = CodexResetCredits(availableCount: 0, credits: [])
+
+    var availableCredits: [CodexResetCredit] {
+        credits.filter(\.isAvailable)
+            .sorted { $0.expiresAt < $1.expiresAt }
+    }
+}

--- a/Sources/Usage/CodexResetCredits.swift
+++ b/Sources/Usage/CodexResetCredits.swift
@@ -18,8 +18,10 @@ struct CodexResetCredits: Equatable {
 
     static let empty = CodexResetCredits(availableCount: 0, credits: [])
 
+    /// Status alone isn't enough: with 30-minute polling a credit can lapse
+    /// mid-cycle while the last snapshot still reports it "available".
     var availableCredits: [CodexResetCredit] {
-        credits.filter(\.isAvailable)
+        credits.filter { $0.isAvailable && $0.expiresAt > Date() }
             .sorted { $0.expiresAt < $1.expiresAt }
     }
 }

--- a/Sources/Usage/UsageFetcher.swift
+++ b/Sources/Usage/UsageFetcher.swift
@@ -65,6 +65,50 @@ enum UsageFetcher {
         return WindowUsage(usedPercent: used / 100, resetAt: resetAt, error: nil)
     }
 
+    static func fetchCodexResetCredits() async -> CodexResetCredits? {
+        guard let token = readCodexAccessToken() else { return nil }
+
+        var req = URLRequest(url: URL(string: "https://chatgpt.com/backend-api/wham/rate-limit-reset-credits")!)
+        req.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        req.setValue("application/json", forHTTPHeaderField: "Accept")
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: req)
+            let status = (response as? HTTPURLResponse)?.statusCode ?? 0
+            guard status == 200,
+                  let obj = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+            else { return nil }
+
+            let availableCount = (obj["available_count"] as? Int) ?? 0
+            let formatter = ISO8601DateFormatter()
+            formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+            let fallbackFormatter = ISO8601DateFormatter()
+            fallbackFormatter.formatOptions = [.withInternetDateTime]
+
+            let rawCredits: [[String: Any]] = (obj["credits"] as? [[String: Any]]) ?? []
+            let credits: [CodexResetCredit] = rawCredits.compactMap { item -> CodexResetCredit? in
+                guard let id = item["id"] as? String,
+                      let status = item["status"] as? String,
+                      let expiresRaw = item["expires_at"] as? String,
+                      let expiresAt = formatter.date(from: expiresRaw)
+                        ?? fallbackFormatter.date(from: expiresRaw)
+                else { return nil }
+
+                return CodexResetCredit(
+                    id: id,
+                    status: status,
+                    expiresAt: expiresAt,
+                    title: item["title"] as? String ?? "",
+                    description: item["description"] as? String ?? ""
+                )
+            }
+
+            return CodexResetCredits(availableCount: availableCount, credits: credits)
+        } catch {
+            return nil
+        }
+    }
+
     // MARK: - Claude
 
     /// Anthropic doesn't ship a usage endpoint for end users — Claude Code

--- a/Sources/Usage/UsageStore.swift
+++ b/Sources/Usage/UsageStore.swift
@@ -9,6 +9,7 @@ final class UsageStore: ObservableObject {
 
     @Published var claude: AppUsage = .empty
     @Published var codex: AppUsage = .empty
+    @Published var codexResetCredits: CodexResetCredits = .empty
     @Published var lastUpdated: Date?
     @Published var loading = false
     /// Set while a `claude auth login` flow is in progress (spawned + still
@@ -75,6 +76,25 @@ final class UsageStore: ObservableObject {
                 ),
                 plan: "pro"
             )
+            self.codexResetCredits = CodexResetCredits(
+                availableCount: 2,
+                credits: [
+                    CodexResetCredit(
+                        id: "demo-reset-1",
+                        status: "available",
+                        expiresAt: now.addingTimeInterval(3 * 86400 + 4 * 3600),
+                        title: "One free rate limit reset",
+                        description: "Thanks for using Codex! You've been granted one free rate limit reset."
+                    ),
+                    CodexResetCredit(
+                        id: "demo-reset-2",
+                        status: "available",
+                        expiresAt: now.addingTimeInterval(9 * 86400 + 3600),
+                        title: "One free rate limit reset",
+                        description: "Thanks for using Codex! You've been granted one free rate limit reset."
+                    )
+                ]
+            )
             self.lastUpdated = now
             return
         }
@@ -83,12 +103,14 @@ final class UsageStore: ObservableObject {
         refreshTask?.cancel()
         refreshTask = Task {
             async let codexResult = UsageFetcher.fetchCodex()
+            async let codexResetCreditsResult = UsageFetcher.fetchCodexResetCredits()
             let coolingDown = claudeCooldownUntil.map { Date() < $0 } ?? false
             var cl: AppUsage?
             if !coolingDown {
                 cl = await UsageFetcher.fetchClaude()
             }
             let c = await codexResult
+            let codexResetCredits = await codexResetCreditsResult
 
             // Cancellation = network monitor saw the path come up while we
             // were mid-flight on a dead one. The fetched values are the
@@ -119,6 +141,9 @@ final class UsageStore: ObservableObject {
                 if !UsageStore.isErrorOnly(cl) || UsageStore.isErrorOnly(self.claude) {
                     self.claude = cl
                 }
+            }
+            if let codexResetCredits {
+                self.codexResetCredits = codexResetCredits
             }
 
             // Record this poll's readings so the SparkChart can plot real

--- a/Sources/Views/CodexResetStatus.swift
+++ b/Sources/Views/CodexResetStatus.swift
@@ -125,7 +125,7 @@ struct CodexResetStatus: View {
     /// app, but faster than `.strongEaseOut` (280ms) — a small hover
     /// reveal should settle in under 200ms. Exit is faster than enter.
     private static let popoverIn = Animation.timingCurve(0.23, 1, 0.32, 1, duration: 0.18)
-    private static let popoverOut = Animation.easeOut(duration: 0.13)
+    private static let popoverOut = Animation.easeOut(duration: 0.09)
 
     private func presentPopover() {
         cancelHide()
@@ -144,7 +144,9 @@ struct CodexResetStatus: View {
             }
         }
         hideWorkItem = workItem
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.12, execute: workItem)
+        // Just enough grace to cross the badge → popover gap; any longer
+        // and the card lingers after hover-out.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.08, execute: workItem)
     }
 
     private func cancelHide() {

--- a/Sources/Views/CodexResetStatus.swift
+++ b/Sources/Views/CodexResetStatus.swift
@@ -12,10 +12,13 @@ struct CodexResetStatus: View {
     var body: some View {
         if shouldShowBadge {
             badge
-                .overlay(alignment: .topTrailing) {
+                .overlay(alignment: .bottomTrailing) {
                     if showPopover {
                         popover
-                            .offset(x: 42, y: popoverYOffset)
+                            // Anchored to the badge bottom, lifted clear of
+                            // the badge so the card grows upward inside the
+                            // panel regardless of row count.
+                            .offset(y: -30)
                             .transition(.opacity.combined(with: .scale(scale: 0.97, anchor: .bottomTrailing)))
                     }
                 }
@@ -31,15 +34,19 @@ struct CodexResetStatus: View {
     private var badge: some View {
         HStack(spacing: 6) {
             Image(systemName: "arrow.counterclockwise")
-                .font(Typography.caption.weight(.semibold))
-                .foregroundStyle(.white.opacity(badgeHovered || showPopover ? 0.84 : 0.72))
+                .font(Typography.caption)
+                .foregroundStyle(IslandColor.codex.opacity(badgeHovered || showPopover ? 1 : 0.8))
             Text(resetAvailabilityText)
-                .font(Typography.caption.weight(.semibold))
-                .foregroundStyle(.white.opacity(badgeHovered || showPopover ? 0.96 : 0.86))
+                .font(Typography.caption)
+                .foregroundStyle(.white.opacity(badgeHovered || showPopover ? 0.85 : 0.55))
         }
-        .padding(.horizontal, 2)
-        .padding(.vertical, 2)
-        .contentShape(RoundedRectangle(cornerRadius: 8))
+        .padding(.horizontal, 6)
+        .padding(.vertical, 3)
+        .background(
+            RoundedRectangle(cornerRadius: 5)
+                .fill(.white.opacity(badgeHovered || showPopover ? 0.05 : 0))
+        )
+        .contentShape(RoundedRectangle(cornerRadius: 5))
         .onHover { hovered in
             badgeHovered = hovered
             hovered ? presentPopover() : scheduleHide()
@@ -48,7 +55,7 @@ struct CodexResetStatus: View {
         .accessibilityLabel(resetAvailabilityAccessibilityLabel)
         .accessibilityHint(L10n.tr("Hover to show reset expiration details"))
         .animation(.easeOut(duration: 0.12), value: badgeHovered)
-        .animation(.strongEaseOut, value: showPopover)
+        .animation(.easeOut(duration: 0.12), value: showPopover)
     }
 
     private var resetAvailabilityText: String {
@@ -61,40 +68,27 @@ struct CodexResetStatus: View {
         return count == 1 ? L10n.tr("1 Codex reset available") : L10n.tr("%d Codex resets available", count)
     }
 
-    private var popoverYOffset: CGFloat {
-        let extraRows = max(0, min(2, usageStore.codexResetCredits.availableCredits.count - 1))
-        return -56 - CGFloat(extraRows * 50)
-    }
-
     private var popover: some View {
-        VStack(spacing: 6) {
+        VStack(spacing: 4) {
             ForEach(Array(usageStore.codexResetCredits.availableCredits.prefix(3)), id: \.id) { credit in
                 resetRow(credit)
             }
         }
-        .padding(5)
-        .frame(width: 330, alignment: .leading)
-        .background(alignment: .top) {
-            ZStack(alignment: .topTrailing) {
-                RoundedRectangle(cornerRadius: 20)
-                    .fill(Color(red: 0.17, green: 0.20, blue: 0.28).opacity(0.92))
-                RoundedRectangle(cornerRadius: 16)
-                    .fill(
-                        LinearGradient(
-                            colors: [
-                                Color.white.opacity(0.08),
-                                Color.white.opacity(0.03)
-                            ],
-                            startPoint: .top,
-                            endPoint: .bottom
-                        )
-                    )
-                RoundedRectangle(cornerRadius: 20)
-                    .strokeBorder(.white.opacity(0.10), lineWidth: 0.75)
-            }
-        }
-        .shadow(color: .black.opacity(0.42), radius: 28, y: 14)
-        .shadow(color: Color.white.opacity(0.03), radius: 4)
+        .padding(6)
+        .frame(width: 210, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 10)
+                .fill(.black)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 10)
+                        .fill(.white.opacity(0.04))
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 10)
+                        .strokeBorder(.white.opacity(0.10), lineWidth: 0.5)
+                )
+        )
+        .shadow(color: .black.opacity(0.5), radius: 16, y: 8)
         .onHover { hovered in
             popoverHovered = hovered
             hovered ? cancelHide() : scheduleHide()
@@ -102,71 +96,40 @@ struct CodexResetStatus: View {
     }
 
     private func resetRow(_ credit: CodexResetCredit) -> some View {
-        HStack(alignment: .center, spacing: 7) {
-            Image(systemName: "checkmark.seal")
-                .font(.system(size: 14, weight: .semibold))
-                .foregroundStyle(Color(red: 0.43, green: 0.95, blue: 0.74))
-                .frame(width: 18, height: 18)
+        HStack(alignment: .center, spacing: 8) {
+            Image(systemName: "arrow.counterclockwise")
+                .font(Typography.caption)
+                .foregroundStyle(IslandColor.codex.opacity(0.9))
 
-            VStack(alignment: .leading, spacing: 2) {
-                Text(L10n.tr("EXPIRES"))
-                    .font(.system(size: 9, weight: .semibold))
-                    .tracking(0.9)
-                    .foregroundStyle(.white.opacity(0.52))
-                Text(absolute(credit.expiresAt))
-                    .font(.system(size: 13, weight: .semibold, design: .monospaced))
-                    .foregroundStyle(.white.opacity(0.95))
-                    .lineLimit(1)
-                    .minimumScaleFactor(0.5)
-                    .layoutPriority(1)
-                    .fixedSize(horizontal: false, vertical: true)
-            }
-            Spacer(minLength: 10)
+            Text(L10n.tr("EXPIRES"))
+                .font(Typography.sectionLabel)
+                .tracking(0.8)
+                .foregroundStyle(.white.opacity(0.40))
+            Spacer(minLength: 8)
 
-            Text(L10n.tr("Available"))
-                .font(.system(size: 10, weight: .semibold))
-                .foregroundStyle(Color(red: 0.52, green: 0.95, blue: 0.71))
-                .frame(width: 68, height: 26)
-                .padding(.horizontal, 2)
-                .padding(.vertical, 1)
-                .background(
-                    RoundedRectangle(cornerRadius: 8, style: .continuous)
-                        .fill(Color(red: 0.29, green: 0.55, blue: 0.42).opacity(0.26))
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 8, style: .continuous)
-                                .strokeBorder(Color(red: 0.37, green: 0.83, blue: 0.60).opacity(0.28), lineWidth: 0.75)
-                        )
-                )
+            Text(absolute(credit.expiresAt))
+                .font(Typography.bodyNumber)
+                .foregroundStyle(.white.opacity(0.95))
+                .lineLimit(1)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(.horizontal, 8)
-        .padding(.vertical, 7)
+        .padding(.vertical, 6)
         .background(
-            RoundedRectangle(cornerRadius: 14)
-                .fill(Color.white.opacity(0.055))
-                .overlay(
-                    RoundedRectangle(cornerRadius: 14)
-                        .fill(
-                            LinearGradient(
-                                colors: [
-                                    Color.white.opacity(0.04),
-                                    Color.clear
-                                ],
-                                startPoint: .top,
-                                endPoint: .bottom
-                            )
-                        )
-                )
-                .overlay(
-                    RoundedRectangle(cornerRadius: 14)
-                        .strokeBorder(Color(red: 0.25, green: 0.62, blue: 0.42).opacity(0.18), lineWidth: 0.75)
-                )
+            RoundedRectangle(cornerRadius: 6)
+                .fill(.white.opacity(0.05))
         )
     }
 
+    /// Popover-tier timing: same strong ease-out curve as the rest of the
+    /// app, but faster than `.strongEaseOut` (280ms) — a small hover
+    /// reveal should settle in under 200ms. Exit is faster than enter.
+    private static let popoverIn = Animation.timingCurve(0.23, 1, 0.32, 1, duration: 0.18)
+    private static let popoverOut = Animation.easeOut(duration: 0.13)
+
     private func presentPopover() {
         cancelHide()
-        withAnimation(.strongEaseOut) {
+        withAnimation(Self.popoverIn) {
             showPopover = true
         }
     }
@@ -175,7 +138,7 @@ struct CodexResetStatus: View {
         cancelHide()
         let workItem = DispatchWorkItem {
             if !badgeHovered && !popoverHovered {
-                withAnimation(.easeOut(duration: 0.14)) {
+                withAnimation(Self.popoverOut) {
                     showPopover = false
                 }
             }
@@ -192,7 +155,7 @@ struct CodexResetStatus: View {
     private static let absoluteFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.locale = L10n.locale
-        formatter.setLocalizedDateFormatFromTemplate("yMMMdahmm")
+        formatter.setLocalizedDateFormatFromTemplate("yMMMd")
         return formatter
     }()
 

--- a/Sources/Views/CodexResetStatus.swift
+++ b/Sources/Views/CodexResetStatus.swift
@@ -109,7 +109,7 @@ struct CodexResetStatus: View {
                 .frame(width: 18, height: 18)
 
             VStack(alignment: .leading, spacing: 2) {
-                Text("EXPIRES")
+                Text(L10n.tr("EXPIRES"))
                     .font(.system(size: 9, weight: .semibold))
                     .tracking(0.9)
                     .foregroundStyle(.white.opacity(0.52))

--- a/Sources/Views/CodexResetStatus.swift
+++ b/Sources/Views/CodexResetStatus.swift
@@ -62,7 +62,7 @@ struct CodexResetStatus: View {
     }
 
     private var popoverYOffset: CGFloat {
-        usageStore.codexResetCredits.availableCredits.count == 1 ? -92 : -118
+        usageStore.codexResetCredits.availableCredits.count == 1 ? -56 : -118
     }
 
     private var popover: some View {

--- a/Sources/Views/CodexResetStatus.swift
+++ b/Sources/Views/CodexResetStatus.swift
@@ -1,0 +1,213 @@
+import SwiftUI
+
+struct CodexResetStatus: View {
+    @ObservedObject private var usageStore = UsageStore.shared
+    @ObservedObject private var visibility = ProviderVisibilityStore.shared
+
+    @State private var showPopover = false
+    @State private var badgeHovered = false
+    @State private var popoverHovered = false
+    @State private var hideWorkItem: DispatchWorkItem?
+
+    var body: some View {
+        if shouldShowBadge {
+            badge
+                .overlay(alignment: .topTrailing) {
+                    if showPopover {
+                        popover
+                            .offset(x: 42, y: popoverYOffset)
+                            .transition(.opacity.combined(with: .scale(scale: 0.97, anchor: .bottomTrailing)))
+                    }
+                }
+                .zIndex(showPopover ? 10 : 0)
+        }
+    }
+
+    private var shouldShowBadge: Bool {
+        visibility.codexVisible && usageStore.codexResetCredits.availableCount > 0
+            && !usageStore.codexResetCredits.availableCredits.isEmpty
+    }
+
+    private var badge: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "arrow.counterclockwise")
+                .font(Typography.caption.weight(.semibold))
+                .foregroundStyle(.white.opacity(badgeHovered || showPopover ? 0.84 : 0.72))
+            Text(resetAvailabilityText)
+                .font(Typography.caption.weight(.semibold))
+                .foregroundStyle(.white.opacity(badgeHovered || showPopover ? 0.96 : 0.86))
+        }
+        .padding(.horizontal, 2)
+        .padding(.vertical, 2)
+        .contentShape(RoundedRectangle(cornerRadius: 8))
+        .onHover { hovered in
+            badgeHovered = hovered
+            hovered ? presentPopover() : scheduleHide()
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(resetAvailabilityAccessibilityLabel)
+        .accessibilityHint(L10n.tr("Hover to show reset expiration details"))
+        .animation(.easeOut(duration: 0.12), value: badgeHovered)
+        .animation(.strongEaseOut, value: showPopover)
+    }
+
+    private var resetAvailabilityText: String {
+        let count = usageStore.codexResetCredits.availableCount
+        return count == 1 ? L10n.tr("1 reset available") : L10n.tr("%d resets available", count)
+    }
+
+    private var resetAvailabilityAccessibilityLabel: String {
+        let count = usageStore.codexResetCredits.availableCount
+        return count == 1 ? L10n.tr("1 Codex reset available") : L10n.tr("%d Codex resets available", count)
+    }
+
+    private var popoverYOffset: CGFloat {
+        usageStore.codexResetCredits.availableCredits.count == 1 ? -92 : -118
+    }
+
+    private var popover: some View {
+        VStack(spacing: 6) {
+            ForEach(Array(usageStore.codexResetCredits.availableCredits.prefix(3)), id: \.id) { credit in
+                resetRow(credit)
+            }
+        }
+        .padding(5)
+        .frame(width: 330, alignment: .leading)
+        .background(alignment: .top) {
+            ZStack(alignment: .topTrailing) {
+                RoundedRectangle(cornerRadius: 20)
+                    .fill(Color(red: 0.17, green: 0.20, blue: 0.28).opacity(0.92))
+                RoundedRectangle(cornerRadius: 16)
+                    .fill(
+                        LinearGradient(
+                            colors: [
+                                Color.white.opacity(0.08),
+                                Color.white.opacity(0.03)
+                            ],
+                            startPoint: .top,
+                            endPoint: .bottom
+                        )
+                    )
+                RoundedRectangle(cornerRadius: 20)
+                    .strokeBorder(.white.opacity(0.10), lineWidth: 0.75)
+            }
+        }
+        .shadow(color: .black.opacity(0.42), radius: 28, y: 14)
+        .shadow(color: Color.white.opacity(0.03), radius: 4)
+        .onHover { hovered in
+            popoverHovered = hovered
+            hovered ? cancelHide() : scheduleHide()
+        }
+    }
+
+    private func resetRow(_ credit: CodexResetCredit) -> some View {
+        HStack(alignment: .center, spacing: 7) {
+            Image(systemName: "checkmark.seal")
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundStyle(Color(red: 0.43, green: 0.95, blue: 0.74))
+                .frame(width: 18, height: 18)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text("EXPIRES")
+                    .font(.system(size: 9, weight: .semibold))
+                    .tracking(0.9)
+                    .foregroundStyle(.white.opacity(0.52))
+                Text(absolute(credit.expiresAt))
+                    .font(.system(size: 13, weight: .semibold, design: .monospaced))
+                    .foregroundStyle(.white.opacity(0.95))
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.5)
+                    .layoutPriority(1)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            Spacer(minLength: 10)
+
+            Text(L10n.tr("Available"))
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundStyle(Color(red: 0.52, green: 0.95, blue: 0.71))
+                .frame(width: 68, height: 26)
+                .padding(.horizontal, 2)
+                .padding(.vertical, 1)
+                .background(
+                    RoundedRectangle(cornerRadius: 8, style: .continuous)
+                        .fill(Color(red: 0.29, green: 0.55, blue: 0.42).opacity(0.26))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                                .strokeBorder(Color(red: 0.37, green: 0.83, blue: 0.60).opacity(0.28), lineWidth: 0.75)
+                        )
+                )
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 8)
+        .padding(.vertical, 7)
+        .background(
+            RoundedRectangle(cornerRadius: 14)
+                .fill(Color.white.opacity(0.055))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 14)
+                        .fill(
+                            LinearGradient(
+                                colors: [
+                                    Color.white.opacity(0.04),
+                                    Color.clear
+                                ],
+                                startPoint: .top,
+                                endPoint: .bottom
+                            )
+                        )
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 14)
+                        .strokeBorder(Color(red: 0.25, green: 0.62, blue: 0.42).opacity(0.18), lineWidth: 0.75)
+                )
+        )
+    }
+
+    private func presentPopover() {
+        cancelHide()
+        withAnimation(.strongEaseOut) {
+            showPopover = true
+        }
+    }
+
+    private func scheduleHide() {
+        cancelHide()
+        let workItem = DispatchWorkItem {
+            if !badgeHovered && !popoverHovered {
+                withAnimation(.easeOut(duration: 0.14)) {
+                    showPopover = false
+                }
+            }
+        }
+        hideWorkItem = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.12, execute: workItem)
+    }
+
+    private func cancelHide() {
+        hideWorkItem?.cancel()
+        hideWorkItem = nil
+    }
+
+    private static let relativeFormatter: RelativeDateTimeFormatter = {
+        let formatter = RelativeDateTimeFormatter()
+        formatter.locale = L10n.locale
+        formatter.unitsStyle = .abbreviated
+        return formatter
+    }()
+
+    private static let absoluteFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = L10n.locale
+        formatter.setLocalizedDateFormatFromTemplate("yMMMdahmm")
+        return formatter
+    }()
+
+    private func relative(_ date: Date) -> String {
+        Self.relativeFormatter.localizedString(for: date, relativeTo: Date())
+    }
+
+    private func absolute(_ date: Date) -> String {
+        Self.absoluteFormatter.locale = L10n.locale
+        return Self.absoluteFormatter.string(from: date)
+    }
+}

--- a/Sources/Views/CodexResetStatus.swift
+++ b/Sources/Views/CodexResetStatus.swift
@@ -189,23 +189,12 @@ struct CodexResetStatus: View {
         hideWorkItem = nil
     }
 
-    private static let relativeFormatter: RelativeDateTimeFormatter = {
-        let formatter = RelativeDateTimeFormatter()
-        formatter.locale = L10n.locale
-        formatter.unitsStyle = .abbreviated
-        return formatter
-    }()
-
     private static let absoluteFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.locale = L10n.locale
         formatter.setLocalizedDateFormatFromTemplate("yMMMdahmm")
         return formatter
     }()
-
-    private func relative(_ date: Date) -> String {
-        Self.relativeFormatter.localizedString(for: date, relativeTo: Date())
-    }
 
     private func absolute(_ date: Date) -> String {
         Self.absoluteFormatter.locale = L10n.locale

--- a/Sources/Views/CodexResetStatus.swift
+++ b/Sources/Views/CodexResetStatus.swift
@@ -62,7 +62,8 @@ struct CodexResetStatus: View {
     }
 
     private var popoverYOffset: CGFloat {
-        usageStore.codexResetCredits.availableCredits.count == 1 ? -56 : -118
+        let extraRows = max(0, min(2, usageStore.codexResetCredits.availableCredits.count - 1))
+        return -56 - CGFloat(extraRows * 50)
     }
 
     private var popover: some View {

--- a/Sources/Views/PanelFooter.swift
+++ b/Sources/Views/PanelFooter.swift
@@ -51,6 +51,10 @@ struct PanelFooter: View {
 
                     Spacer()
 
+                    if screenPref.screen == .usage {
+                        CodexResetStatus()
+                    }
+
                     liveStatus
                 }
 


### PR DESCRIPTION
Adds a "Codex resets available" status surface: a new `CodexResetCredits` model, a `UsageFetcher.fetchCodexResetCredits()` network call, `UsageStore` wiring (+ demo data), the `CodexResetStatus` popover UI, and a `PanelFooter` badge.

Split out of #36 as its own reviewable feature (new network surface + UI). Rebased on latest `main` — the `UsageStore` refresh path is merged with the current claude-cooldown / usage-history logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Codex reset-credits badge in the Usage view.
  * Hovering the badge now shows a popover with upcoming reset details and expiration times.

* **Bug Fixes**
  * Improved loading of reset-credit data, with partial results still shown when some items can’t be parsed.
  * Reset credits now refresh alongside other usage data.

* **Style**
  * Added clearer visual formatting for reset status and expiration information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->