### PR TITLE
feat(layout): adapt compact layout to macOS 27 menu bar spanning notch

### DIFF
--- a/Sources/Model/IslandModel.swift
+++ b/Sources/Model/IslandModel.swift
@@ -83,7 +83,8 @@ final class IslandModel: ObservableObject {
     func updateNotch(_ raw: NotchInfo) {
         guard raw.width != rawNotch.width
             || raw.height != rawNotch.height
-            || raw.hasNotch != rawNotch.hasNotch else { return }
+            || raw.hasNotch != rawNotch.hasNotch
+            || raw.sideSpace != rawNotch.sideSpace else { return }
         rawNotch = raw
         notch = Self.applyOverride(to: raw, width: IslandSpacingStore.shared.width)
         recomputeSize()

--- a/Sources/Model/IslandModel.swift
+++ b/Sources/Model/IslandModel.swift
@@ -13,16 +13,32 @@ final class IslandModel: ObservableObject {
     @Published var size: CGSize = .zero
     @Published var notch: NotchInfo
 
-    /// Side extension that houses each brand logo in compact state.
-    let tabWidth: CGFloat = 38
+    /// Maximum side extension for the brand logo tab in compact state.
+    private let maxTabWidth: CGFloat = 38
+    /// Maximum per-side outboard slot for the peek-state percentage pill.
+    private let maxPillSlotWidth: CGFloat = 78
+    /// Safety gap (pt) between our outermost edge and the nearest menu item.
+    private let sideMargin: CGFloat = 8
 
-    /// Per-side outboard slot that houses the peek-state percentage pill.
-    /// Sized for "100% · Nh" worst case at the chosen pill typography.
-    /// Fixed (not text-measured) so percentage updates don't jitter the
-    /// silhouette width during refresh. Grown symmetrically on both sides
-    /// regardless of which provider is visible — keeps the silhouette
-    /// balanced over the physical notch.
-    let pillSlotWidth: CGFloat = 78
+    /// Actual tab width, clamped to the space available beside the notch
+    /// before menu items begin (macOS 27+). Falls back to maxTabWidth when
+    /// there is no constraint (older macOS / non-notch screens).
+    var tabWidth: CGFloat {
+        let available = notch.sideSpace == .infinity ? maxTabWidth : max(0, notch.sideSpace - sideMargin)
+        return min(maxTabWidth, available)
+    }
+
+    /// Actual peek pill slot width, clamped to whatever space remains after
+    /// the tab and safety margin are accounted for.
+    var pillSlotWidth: CGFloat {
+        let available = notch.sideSpace == .infinity ? maxPillSlotWidth : max(0, notch.sideSpace - sideMargin - tabWidth)
+        return min(maxPillSlotWidth, available)
+    }
+
+    /// True when compact-state logo tabs are suppressed because menu items are
+    /// too close. Logos reappear as soon as the user hovers (peek state always
+    /// expands to full width regardless of this constraint).
+    var compactLogosHidden: Bool { tabWidth < maxTabWidth }
 
     /// Visible expanded panel width.
     private let expandedWidth: CGFloat = 800
@@ -118,7 +134,7 @@ final class IslandModel: ObservableObject {
     /// notch).
     private static func applyOverride(to raw: NotchInfo, width: CGFloat) -> NotchInfo {
         if raw.hasNotch { return raw }
-        return NotchInfo(width: width, height: raw.height, hasNotch: false)
+        return NotchInfo(width: width, height: raw.height, hasNotch: false, sideSpace: .infinity)
     }
 
     /// Re-applies the override and re-computes size whenever the user
@@ -170,8 +186,11 @@ final class IslandModel: ObservableObject {
                 height: notch.height
             )
         case .peek:
+            // Always expand to full peek width on hover even when compact is
+            // constrained — the user is actively interacting, brief menu
+            // overlap is acceptable and logos/pills must always be reachable.
             size = CGSize(
-                width: notch.width + tabWidth * 2 + pillSlotWidth * 2,
+                width: notch.width + maxTabWidth * 2 + maxPillSlotWidth * 2,
                 height: notch.height
             )
         case .expanded:

--- a/Sources/Model/NotchInfo.swift
+++ b/Sources/Model/NotchInfo.swift
@@ -4,6 +4,10 @@ struct NotchInfo {
     let width: CGFloat
     let height: CGFloat
     let hasNotch: Bool
+    /// Available points on each side of the notch before menu items begin.
+    /// Only meaningful on macOS 27+ notched screens where menu items flow
+    /// around the notch; set to .infinity on older systems (no constraint).
+    let sideSpace: CGFloat
 
     /// `screen.frame.maxY - screen.visibleFrame.maxY` reports the actual
     /// pixel distance between the top of the screen and the top of the app
@@ -22,7 +26,7 @@ struct NotchInfo {
     /// (screen width - left - right).
     static func detect(from screen: NSScreen?) -> NotchInfo {
         guard let screen else {
-            return NotchInfo(width: IslandSpacingStore.compactWidth, height: menuBarFallback(), hasNotch: false)
+            return NotchInfo(width: IslandSpacingStore.compactWidth, height: menuBarFallback(), hasNotch: false, sideSpace: .infinity)
         }
         let safeTop = screen.safeAreaInsets.top
         let visualHeight = visibleMenuBarHeight(of: screen)
@@ -33,9 +37,24 @@ struct NotchInfo {
             let width: CGFloat = (leftW > 0 && rightW > 0)
                 ? screen.frame.width - leftW - rightW
                 : 200
-            return NotchInfo(width: width, height: visualHeight, hasNotch: true)
+
+            // On macOS 27+ menu items flow into the aux areas beside the notch,
+            // so we calculate how much space remains on each side after they end.
+            // On older macOS the aux areas are dead zones — no constraint needed.
+            let sideSpace: CGFloat
+            if #available(macOS 27, *) {
+                let halfScreen = screen.frame.width / 2
+                let halfNotch  = width / 2
+                let leftFree   = halfScreen - halfNotch - leftW
+                let rightFree  = halfScreen - halfNotch - rightW
+                sideSpace = max(0, min(leftFree, rightFree))
+            } else {
+                sideSpace = .infinity
+            }
+
+            return NotchInfo(width: width, height: visualHeight, hasNotch: true, sideSpace: sideSpace)
         }
-        return NotchInfo(width: IslandSpacingStore.compactWidth, height: visualHeight, hasNotch: false)
+        return NotchInfo(width: IslandSpacingStore.compactWidth, height: visualHeight, hasNotch: false, sideSpace: .infinity)
     }
 
     private static func visibleMenuBarHeight(of screen: NSScreen) -> CGFloat {

--- a/Sources/Views/IslandRootView.swift
+++ b/Sources/Views/IslandRootView.swift
@@ -78,6 +78,7 @@ struct IslandRootView: View {
                         topPadding: max(0, (model.notch.height - 20) / 2)
                     )
                     .opacity(model.state == .compact && model.compactLogosHidden ? 0 : 1)
+                    .accessibilityHidden(model.state == .compact && model.compactLogosHidden)
                 }
                 .overlay(alignment: .topTrailing) {
                     LogoOverlay(
@@ -88,6 +89,7 @@ struct IslandRootView: View {
                         topPadding: max(0, (model.notch.height - 20) / 2)
                     )
                     .opacity(model.state == .compact && model.compactLogosHidden ? 0 : 1)
+                    .accessibilityHidden(model.state == .compact && model.compactLogosHidden)
                 }
                 .overlay(alignment: .topLeading) {
                     // Pill lives in the new outboard slot (the 78pt the

--- a/Sources/Views/IslandRootView.swift
+++ b/Sources/Views/IslandRootView.swift
@@ -77,6 +77,7 @@ struct IslandRootView: View {
                         edgePadding: logoEdgePadding,
                         topPadding: max(0, (model.notch.height - 20) / 2)
                     )
+                    .opacity(model.state == .compact && model.compactLogosHidden ? 0 : 1)
                 }
                 .overlay(alignment: .topTrailing) {
                     LogoOverlay(
@@ -86,6 +87,7 @@ struct IslandRootView: View {
                         edgePadding: logoEdgePadding,
                         topPadding: max(0, (model.notch.height - 20) / 2)
                     )
+                    .opacity(model.state == .compact && model.compactLogosHidden ? 0 : 1)
                 }
                 .overlay(alignment: .topLeading) {
                     // Pill lives in the new outboard slot (the 78pt the
@@ -350,7 +352,10 @@ struct IslandRootView: View {
     private var logoEdgePadding: CGFloat {
         switch model.state {
         case .compact, .expanded: return 9
-        case .peek:               return model.pillSlotWidth + 9
+        // Peek always expands to maxPillSlotWidth (78pt) regardless of the
+        // compact-state sideSpace constraint, so pin the logo to that fixed
+        // offset — model.pillSlotWidth may be 0 in constrained compact.
+        case .peek:               return 78 + 9
         }
     }
 }


### PR DESCRIPTION
Adds `NotchInfo.sideSpace`, dynamic `tabWidth`/`pillSlotWidth`, and `compactLogosHidden` so the compact layout adapts when the macOS 27 menu bar spans the notch. Also hides the constrained compact logos from VoiceOver and fixes the `updateNotch` sideSpace guard.

Gated on `#available(macOS 27, *)`, so it stays inactive until macOS 27 ships. Split out of #36 so it can land on its own once it can actually be exercised. Rebased on latest `main`.