### PR TITLE
fix(window): keep island silhouette flush with menu bar bottom

### DIFF
--- a/Sources/Model/NotchInfo.swift
+++ b/Sources/Model/NotchInfo.swift
@@ -39,16 +39,39 @@ struct NotchInfo {
     }
 
     private static func visibleMenuBarHeight(of screen: NSScreen) -> CGFloat {
-        let fromVisibleFrame = screen.frame.maxY - screen.visibleFrame.maxY
-        if fromVisibleFrame > 0 { return fromVisibleFrame }
+        menuBarHeight(
+            safeTop: screen.safeAreaInsets.top,
+            visibleFrameDelta: screen.frame.maxY - screen.visibleFrame.maxY,
+            statusBarThickness: NSStatusBar.system.thickness
+        )
+    }
+
+    /// Pure height rule, separated from NSScreen so the test harness can
+    /// drive it (see Tests/NotchHeightTests.swift).
+    ///
+    /// `visibleFrame.maxY` sits 1pt BELOW the menu bar's bottom edge (AppKit
+    /// reserves that strip), so the raw frame/visibleFrame delta over-reports
+    /// the bar by 1pt — measured 39pt against a 38pt bar on a notched 14".
+    /// That extra point made the silhouette's bottom edge dip into app
+    /// content below the menu bar. Correct for the gap, and clamp to the
+    /// physical notch height so a stale visibleFrame reading (login, display
+    /// wake) can never push the silhouette below the real bar either.
+    static func menuBarHeight(
+        safeTop: CGFloat,
+        visibleFrameDelta: CGFloat,
+        statusBarThickness: CGFloat
+    ) -> CGFloat {
+        let fromVisibleFrame = visibleFrameDelta - 1
+        if fromVisibleFrame > 0 {
+            return safeTop > 0 ? min(fromVisibleFrame, safeTop) : fromVisibleFrame
+        }
         // Auto-hide menu bar — visibleFrame == frame, so derive from the
         // physical notch (if present) or the system status bar thickness.
-        if screen.safeAreaInsets.top > 0 { return screen.safeAreaInsets.top }
-        return menuBarFallback()
+        if safeTop > 0 { return safeTop }
+        return statusBarThickness > 0 ? statusBarThickness : 24
     }
 
     private static func menuBarFallback() -> CGFloat {
-        let t = NSStatusBar.system.thickness
-        return t > 0 ? t : 24
+        menuBarHeight(safeTop: 0, visibleFrameDelta: 0, statusBarThickness: NSStatusBar.system.thickness)
     }
 }

--- a/Tests/NotchHeightTests.swift
+++ b/Tests/NotchHeightTests.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+/// Regression tests for NotchInfo.menuBarHeight, run by scripts/run-tests.sh
+/// (bare swiftc, no XCTest — same harness pattern as ResolveUsageTests).
+///
+/// Locks down the menu-bar overhang fix: NSScreen.visibleFrame.maxY sits 1pt
+/// below the menu bar's bottom edge, so the raw frame/visibleFrame delta made
+/// the compact silhouette 1pt taller than the bar (and stale readings made it
+/// arbitrarily worse), dipping the pill's rounded bottom into app content —
+/// and, because the hit rect tracks the silhouette, stealing hover/clicks
+/// from the app underneath.
+@main
+struct NotchHeightTests {
+    static var failures = 0
+
+    static func expect(_ condition: Bool, _ label: String) {
+        if condition {
+            print("PASS \(label)")
+        } else {
+            print("FAIL \(label)")
+            failures += 1
+        }
+    }
+
+    static func main() {
+        // Values measured on a notched 14" MacBook Pro: menu bar occupies
+        // 38pt (safeAreaInsets.top == auxiliary area height == 38), while
+        // frame.maxY - visibleFrame.maxY reports 39.
+        expect(
+            NotchInfo.menuBarHeight(safeTop: 38, visibleFrameDelta: 39, statusBarThickness: 22) == 38,
+            "notched default: 1pt visibleFrame gap corrected"
+        )
+        expect(
+            NotchInfo.menuBarHeight(safeTop: 38, visibleFrameDelta: 46, statusBarThickness: 22) == 38,
+            "stale visibleFrame reading clamped to physical notch height"
+        )
+        expect(
+            NotchInfo.menuBarHeight(safeTop: 0, visibleFrameDelta: 25, statusBarThickness: 22) == 24,
+            "non-notched display: 1pt gap corrected"
+        )
+        expect(
+            NotchInfo.menuBarHeight(safeTop: 38, visibleFrameDelta: 0, statusBarThickness: 22) == 38,
+            "auto-hide menu bar on notched screen: physical notch height"
+        )
+        expect(
+            NotchInfo.menuBarHeight(safeTop: 0, visibleFrameDelta: 0, statusBarThickness: 22) == 22,
+            "auto-hide menu bar, non-notched: status bar thickness"
+        )
+        expect(
+            NotchInfo.menuBarHeight(safeTop: 0, visibleFrameDelta: 0, statusBarThickness: 0) == 24,
+            "nothing measurable: 24pt default"
+        )
+
+        if failures > 0 {
+            print("\(failures) failure(s)")
+            exit(1)
+        }
+        print("all NotchHeightTests passed")
+    }
+}

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -19,3 +19,13 @@ swiftc \
   Tests/ResolveUsageTests.swift
 
 CLAUDE_CODE_OAUTH_TOKEN="test-stub-token" "$OUT_DIR/resolve-usage-tests"
+
+swiftc \
+  -parse-as-library \
+  -o "$OUT_DIR/notch-height-tests" \
+  Sources/Model/NotchInfo.swift \
+  Sources/Model/IslandSpacingStore.swift \
+  Sources/Model/PreferenceStorage.swift \
+  Tests/NotchHeightTests.swift
+
+"$OUT_DIR/notch-height-tests"


### PR DESCRIPTION
## Problem

User report: the island's rounded bottom edge draws below the menu bar, overlapping app content underneath — and since the hit rect tracks the silhouette, hovering that strip steals focus/clicks from the app below.

## Root cause

`NSScreen.visibleFrame.maxY` sits 1pt **below** the menu bar's bottom edge (AppKit reserves that strip). `NotchInfo.visibleMenuBarHeight` derived the silhouette height from `frame.maxY - visibleFrame.maxY`, over-reporting the bar by 1pt on every config (measured 39pt vs a 38pt bar on a notched 14"). Stale `visibleFrame` readings at login/display wake over-report arbitrarily more, and nothing re-measures until the next screen-parameters notification.

## Fix

- Correct the 1pt gap in the visibleFrame-derived height.
- Clamp to `safeAreaInsets.top` on notched screens so no stale reading can push the silhouette below the real bar.
- Extract the height rule into pure `NotchInfo.menuBarHeight(safeTop:visibleFrameDelta:statusBarThickness:)` so the bare-swiftc test harness can drive it.

## Tests

New `Tests/NotchHeightTests.swift` wired into `scripts/run-tests.sh` — 6 cases covering notched default, stale-reading clamp, non-notched displays, auto-hide menu bar (notched + non-notched), and the nothing-measurable fallback. Full suite passes (15/15). Verified visually on a notched 14": pill bottom now ends exactly at the menu bar edge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)