### PR TITLE
feat(usage): surface expired-token state with a dedicated re-auth panel

### DIFF
--- a/Sources/Usage/ClaudeCredentials.swift
+++ b/Sources/Usage/ClaudeCredentials.swift
@@ -41,6 +41,26 @@ enum ClaudeCredentials {
     /// refreshes and writes back the next time the user runs it.
     static let tokenExpiredMessage = "token expired — run claude"
 
+    /// True when a probe error is one the in-app re-auth flow can act on: a
+    /// terminal auth failure — an expired keychain token (401) or a token
+    /// missing a scope the usage endpoint now requires (403). Distinct from a
+    /// transient 429/network error, which self-heals and must NOT trigger the
+    /// re-auth prompt. Views key the "Re-authenticate" button and its caption
+    /// on this; `UsageStore` uses `isTerminalAuthFailure` to let these replace
+    /// a stale good value instead of retaining it.
+    static func isReauthActionable(_ error: String?) -> Bool {
+        error == tokenExpiredMessage || error == reauthRequiredMessage
+    }
+
+    /// True when BOTH windows carry a reauth-actionable error — the token
+    /// itself is unusable, not one window transiently failing. `UsageStore`'s
+    /// "don't clobber good values" retention makes an exception for this so the
+    /// panel surfaces the re-auth prompt instead of freezing on numbers it can
+    /// no longer refresh.
+    static func isTerminalAuthFailure(_ usage: AppUsage) -> Bool {
+        isReauthActionable(usage.fiveHour.error) && isReauthActionable(usage.weekly.error)
+    }
+
     /// Outcome of a single usage-endpoint probe against one token. The fetcher
     /// owns the HTTP + parsing and reports back through this; `ClaudeCredentials`
     /// interprets it to decide whether to advance to the next token source.

--- a/Sources/Usage/UsageStore.swift
+++ b/Sources/Usage/UsageStore.swift
@@ -138,7 +138,13 @@ final class UsageStore: ObservableObject {
                 } else {
                     self.claudeCooldownUntil = nil
                 }
-                if !UsageStore.isErrorOnly(cl) || UsageStore.isErrorOnly(self.claude) {
+                // A terminal auth failure (expired token / missing scope)
+                // REPLACES a stale good value — otherwise the panel freezes on
+                // numbers we can no longer refresh with no signal to the user.
+                // Transient errors (429/network) still fall through to the
+                // retention rule above.
+                if !UsageStore.isErrorOnly(cl) || UsageStore.isErrorOnly(self.claude)
+                    || ClaudeCredentials.isTerminalAuthFailure(cl) {
                     self.claude = cl
                 }
             }

--- a/Sources/Views/UsageView.swift
+++ b/Sources/Views/UsageView.swift
@@ -82,31 +82,67 @@ struct ChartsBlock: View {
     let seed: Int
     let provider: AlertEngine.Provider
 
-    /// Treat the block as needing re-auth when both windows are stuck on the
-    /// scope-insufficient sentinel. Either tile alone could be a transient
-    /// per-window failure, but matching pair = the underlying token genuinely
-    /// lacks the required scope.
+    /// Treat the block as needing re-auth when both windows are stuck on a
+    /// reauth-actionable sentinel — an expired token (401) or a missing scope
+    /// (403). Either tile alone could be a transient per-window failure, but a
+    /// matching pair = the underlying token is genuinely unusable.
     private var needsReauth: Bool {
-        usage.fiveHour.error == ClaudeCredentials.reauthRequiredMessage
-            && usage.weekly.error == ClaudeCredentials.reauthRequiredMessage
+        ClaudeCredentials.isTerminalAuthFailure(usage)
     }
 
     var body: some View {
-        VStack(spacing: 6) {
-            HStack(spacing: 18) {
-                ChartTile(style: style, color: color, labelKey: "5h",
-                          window: usage.fiveHour, seed: seed,
-                          provider: provider, windowKind: .fiveHour)
-                ChartTile(style: style, color: color, labelKey: "week",
-                          window: usage.weekly, seed: seed + 1,
-                          provider: provider, windowKind: .weekly)
-            }
-            if needsReauth && ClaudeCredentials.canPromptReauth() {
-                ReauthButton()
+        Group {
+            if needsReauth {
+                // Dead token: the sparkline tiles carry no live data, so
+                // replace them with a single centered prompt. Swapping (not
+                // appending a button row) keeps the panel within its fixed
+                // 188pt height instead of overflowing into the footer.
+                ReauthState(color: color, usage: usage)
+            } else {
+                HStack(spacing: 18) {
+                    ChartTile(style: style, color: color, labelKey: "5h",
+                              window: usage.fiveHour, seed: seed,
+                              provider: provider, windowKind: .fiveHour)
+                    ChartTile(style: style, color: color, labelKey: "week",
+                              window: usage.weekly, seed: seed + 1,
+                              provider: provider, windowKind: .weekly)
+                }
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
         .padding(.horizontal, 12)
+    }
+}
+
+/// Shown in place of the sparkline tiles when the Claude token can no longer
+/// be used — expired (401) or missing the scope the usage endpoint now
+/// requires (403). Both windows carry a reauth-actionable sentinel; the dead
+/// numbers would only mislead, so this centered prompt takes their place. When
+/// a `claude` binary is discoverable it offers one-click re-auth; otherwise it
+/// shows the exact manual command from the sentinel.
+struct ReauthState: View {
+    let color: Color
+    let usage: AppUsage
+
+    var body: some View {
+        VStack(spacing: 10) {
+            Image(systemName: "key.slash")
+                .font(.system(size: 20, weight: .regular))
+                .foregroundStyle(color.opacity(0.85))
+            if ClaudeCredentials.canPromptReauth() {
+                Text(L10n.tr("Claude session expired"))
+                    .font(Typography.label)
+                    .foregroundStyle(.white.opacity(0.55))
+                ReauthButton()
+            } else {
+                Text(usage.fiveHour.error ?? ClaudeCredentials.tokenExpiredMessage)
+                    .font(Typography.label)
+                    .foregroundStyle(.white.opacity(0.55))
+                    .multilineTextAlignment(.center)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+        .padding(.horizontal, 8)
     }
 }
 
@@ -202,16 +238,10 @@ struct ChartTile: View {
         // OAuth call lands. Hide it so the tile reads as a passive
         // window-context cue (the "5h"/"week" header label communicates the
         // window type) instead of looking broken. Real errors still surface.
+        // A terminal auth failure is handled by ReauthState (which replaces
+        // the tiles entirely), so any error reaching a tile here is a genuine
+        // per-window caption worth showing verbatim.
         if let err = window.error, err != "no data" {
-            // Suppress the scope-insufficient text when the inline re-auth
-            // button is going to appear below the tiles — otherwise the same
-            // remediation hint reads twice (caption + button label). Users
-            // without a discoverable `claude` binary still get the raw text
-            // so they know the manual fix.
-            if err == ClaudeCredentials.reauthRequiredMessage,
-               ClaudeCredentials.canPromptReauth() {
-                return ""
-            }
             return err
         }
         return ""
@@ -223,10 +253,6 @@ struct ChartTile: View {
             return "↻ " + Duration.compact(delta)
         }
         if let err = window.error, err != "no data" {
-            if err == ClaudeCredentials.reauthRequiredMessage,
-               ClaudeCredentials.canPromptReauth() {
-                return ""
-            }
             return err
         }
         return ""

--- a/Tests/ResolveUsageTests.swift
+++ b/Tests/ResolveUsageTests.swift
@@ -143,6 +143,40 @@ struct ResolveUsageTests {
         expect(ClaudeCredentials.readClaudeFileCandidates().isEmpty, "T5 missing file yields no candidates")
         unsetenv("CLAUDE_CONFIG_DIR")
 
+        // T6 — auth-failure classification. UsageStore lets a terminal auth
+        // error (expired token / missing scope) REPLACE a stale good value,
+        // while a transient 429/network error is retained. Both predicates
+        // must key only on the two actionable sentinels, and
+        // isTerminalAuthFailure must require BOTH windows to carry one — a
+        // single-window failure is a transient per-window glitch, not a dead
+        // token.
+        expect(ClaudeCredentials.isReauthActionable(ClaudeCredentials.tokenExpiredMessage),
+               "T6 expired token is reauth-actionable")
+        expect(ClaudeCredentials.isReauthActionable(ClaudeCredentials.reauthRequiredMessage),
+               "T6 scope-insufficient is reauth-actionable")
+        expect(!ClaudeCredentials.isReauthActionable(ClaudeCredentials.rateLimitedMessage),
+               "T6 rate-limited is NOT reauth-actionable")
+        expect(!ClaudeCredentials.isReauthActionable("no data"), "T6 no-data is NOT reauth-actionable")
+        expect(!ClaudeCredentials.isReauthActionable(nil), "T6 nil error is NOT reauth-actionable")
+
+        func pair(_ msg: String?) -> AppUsage {
+            AppUsage(
+                fiveHour: WindowUsage(usedPercent: 0, resetAt: nil, error: msg),
+                weekly: WindowUsage(usedPercent: 0, resetAt: nil, error: msg))
+        }
+        expect(ClaudeCredentials.isTerminalAuthFailure(pair(ClaudeCredentials.tokenExpiredMessage)),
+               "T6 both-window expired is a terminal auth failure")
+        expect(ClaudeCredentials.isTerminalAuthFailure(pair(ClaudeCredentials.reauthRequiredMessage)),
+               "T6 both-window scope is a terminal auth failure")
+        expect(!ClaudeCredentials.isTerminalAuthFailure(pair(ClaudeCredentials.rateLimitedMessage)),
+               "T6 rate-limited is NOT a terminal auth failure")
+        expect(!ClaudeCredentials.isTerminalAuthFailure(pair(nil)),
+               "T6 good usage is NOT a terminal auth failure")
+        expect(!ClaudeCredentials.isTerminalAuthFailure(AppUsage(
+            fiveHour: WindowUsage(usedPercent: 0.1, resetAt: nil, error: nil),
+            weekly: WindowUsage(usedPercent: 0, resetAt: nil, error: ClaudeCredentials.tokenExpiredMessage))),
+            "T6 single-window failure is NOT terminal (needs both)")
+
         // The store and views match these exact strings; a reword is a
         // breaking change for them, not a copy edit.
         expect(ClaudeCredentials.rateLimitedMessage == "rate limited", "rateLimitedMessage literal is stable")


### PR DESCRIPTION
## Problem

When the Claude keychain token expires (401) or is missing the `user:profile` scope (403), the panel kept showing the **last-good numbers frozen** with no signal. `UsageStore`'s "don't clobber good values" retention (which correctly shields a transient 429/network blip from blanking the panel to 0%) also swallowed the terminal auth-error result — so the re-auth prompt never reached the UI, and the numbers just silently stopped updating.

## Change

- **Classify** a terminal auth failure — both windows carrying an expired-token or scope-insufficient sentinel — as `ClaudeCredentials.isTerminalAuthFailure`, and let it **replace** a stale good value in the `UsageStore` gate. Transient 429/network errors still retain.
- **Dedicated re-auth state**: when the token is unusable the sparkline tiles carry no live data, so `ChartsBlock` swaps them for a centered `ReauthState` (key icon + reason + one-click **Re-authenticate**, or the manual `claude /login` command when no `claude` binary is discoverable). Swapping the tiles instead of appending a button row keeps the panel within its fixed 188pt height.

## Test plan

- `scripts/run-tests.sh` — new `ResolveUsageTests` T6 covers the classifier (401/403 → actionable; 429/nil/single-window → not).
- Verified in the running app: expired keychain token → panel shows the re-auth state; after `claude /login` the next poll recovers real numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated re-authentication state when both usage windows require authorization.
  * Added one-click re-authentication prompts when available.
  * Displays relevant authorization errors directly when automatic re-authentication is unavailable.

* **Bug Fixes**
  * Prevents stale usage data from remaining visible after terminal authentication failures.
  * Avoids treating temporary errors, such as rate limits, as re-authentication requirements.
  * Preserves inline error messaging for applicable usage failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->