### PR TITLE
refactor(views): move Codex reset badge to the Codex header title

### DIFF
--- a/Sources/Views/CodexResetStatus.swift
+++ b/Sources/Views/CodexResetStatus.swift
@@ -12,14 +12,15 @@ struct CodexResetStatus: View {
     var body: some View {
         if shouldShowBadge {
             badge
-                .overlay(alignment: .bottomTrailing) {
+                .overlay(alignment: .topTrailing) {
                     if showPopover {
                         popover
-                            // Anchored to the badge bottom, lifted clear of
-                            // the badge so the card grows upward inside the
-                            // panel regardless of row count.
-                            .offset(y: -30)
-                            .transition(.opacity.combined(with: .scale(scale: 0.97, anchor: .bottomTrailing)))
+                            // Anchored to the badge top, dropped clear of the
+                            // badge so the card grows downward into the panel.
+                            // The badge now lives in the header (panel top), so
+                            // opening upward would spill off the top edge.
+                            .offset(y: 28)
+                            .transition(.opacity.combined(with: .scale(scale: 0.97, anchor: .topTrailing)))
                     }
                 }
                 .zIndex(showPopover ? 10 : 0)
@@ -59,8 +60,11 @@ struct CodexResetStatus: View {
     }
 
     private var resetAvailabilityText: String {
+        // Short form: the badge now sits next to the Codex title where
+        // "N resets available" truncates. The fuller phrasing lives on the
+        // accessibility label below.
         let count = usageStore.codexResetCredits.availableCount
-        return count == 1 ? L10n.tr("1 reset available") : L10n.tr("%d resets available", count)
+        return count == 1 ? L10n.tr("1 reset") : L10n.tr("%d resets", count)
     }
 
     private var resetAvailabilityAccessibilityLabel: String {

--- a/Sources/Views/ExpandedView.swift
+++ b/Sources/Views/ExpandedView.swift
@@ -10,6 +10,10 @@ struct ExpandedView: View {
     var body: some View {
         VStack(spacing: 0) {
             PanelHeader(notch: model.notch)
+                // The Codex reset badge's hover popover opens downward out of
+                // the header; without this it renders behind PagedContent
+                // (later VStack sibling → drawn on top).
+                .zIndex(1)
             PagedContent(model: model)
             PanelFooter(model: model)
         }

--- a/Sources/Views/PanelFooter.swift
+++ b/Sources/Views/PanelFooter.swift
@@ -51,10 +51,6 @@ struct PanelFooter: View {
 
                     Spacer()
 
-                    if screenPref.screen == .usage {
-                        CodexResetStatus()
-                    }
-
                     liveStatus
                 }
 

--- a/Sources/Views/PanelHeader.swift
+++ b/Sources/Views/PanelHeader.swift
@@ -17,13 +17,21 @@ struct PanelHeader: View {
             let claudeOn = visibility.claudeVisible
             let codexOn = visibility.codexVisible
             providerTitle(name: "Claude", tag: usageStore.claude.plan?.uppercased(),
-                          color: IslandColor.claude, alignment: .leading)
+                          color: IslandColor.claude, alignment: .leading) {
+                EmptyView()
+            }
                 .opacity(claudeOn ? 1 : 0)
                 .animation(.openMorph, value: claudeOn)
                 .accessibilityHidden(!claudeOn)
             Color.clear.frame(width: notch.width)
             providerTitle(name: "Codex", tag: usageStore.codex.plan?.uppercased(),
-                          color: IslandColor.codex, alignment: .trailing)
+                          color: IslandColor.codex, alignment: .trailing) {
+                // Codex-only rate-limit reset credits, pinned to the Codex
+                // title so the badge unambiguously belongs to Codex — its old
+                // footer-center spot read as panel-global. Account-level like
+                // the plan tag, so it rides along on every screen.
+                CodexResetStatus()
+            }
                 .opacity(codexOn ? 1 : 0)
                 .animation(.openMorph, value: codexOn)
                 .accessibilityHidden(!codexOn)
@@ -35,11 +43,12 @@ struct PanelHeader: View {
     }
 
     @ViewBuilder
-    private func providerTitle(
+    private func providerTitle<Accessory: View>(
         name: String,
         tag: String?,
         color: Color,
-        alignment: HorizontalAlignment
+        alignment: HorizontalAlignment,
+        @ViewBuilder accessory: () -> Accessory
     ) -> some View {
         // Push past where the overlay logo lands: 9 leading + 20 logo + 8 gap.
         let logoOffset: CGFloat = 9 + 20 + 8
@@ -73,8 +82,9 @@ struct PanelHeader: View {
             }
             .frame(maxWidth: .infinity)
         } else {
-            HStack {
+            HStack(spacing: 10) {
                 Spacer(minLength: 0)
+                accessory()
                 content.padding(.trailing, logoOffset)
             }
             .frame(maxWidth: .infinity)


### PR DESCRIPTION
## Problem

The **"N resets available"** badge is Codex-specific, but its footer-center placement read as panel-global — sitting in the shared bottom bar between the page dots and the sync status, it looked like it could apply to Claude too.

## Change

- **Pin the badge beside the Codex title** in the header (`PanelHeader` gains an accessory slot on the trailing/Codex side). It's account-level like the `MAX`/`PLUS` plan tag, so it shows on every screen and the header stays fixed across page swipes.
- **Flip the hover popover to open downward** — the header sits at the panel top, so the old upward growth would spill off the top edge. Raised the header's `zIndex` so the popover renders above `PagedContent` instead of behind it.
- **Shorten the visible label to "N resets"** — "N resets available" truncates in the tighter header slot. The fuller "N Codex resets available" stays on the accessibility label.
- **Removed** it from the footer.

## Test plan

- `SU_FEED_URL= ./build.sh` compiles clean.
- Verified in the running app: badge sits next to `Codex PLUS`, no longer in the footer; hover opens the reset-expiry popover downward without clipping; label no longer truncates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Codex reset status badge to the panel header.
  * The badge now displays concise reset availability text.

* **Bug Fixes**
  * Improved the reset status popover’s positioning and expansion direction.
  * Ensured the popover appears above panel content when hovered.
  * Prevented unnecessary status view updates in the usage panel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->