### PR TITLE
fix(usage): show multi-day resets as "6d 23h" instead of raw hours

### DIFF
--- a/Sources/Cost/CostBucketing.swift
+++ b/Sources/Cost/CostBucketing.swift
@@ -53,14 +53,21 @@ enum CostBucketing {
     }
 }
 
-/// Shared `TimeInterval` → "Ns/Nm/Nh/Nd" formatter. Used by the cost reset
-/// glyph and the usage screen's reset caption so both screens use the same
-/// vocabulary for "time remaining".
+/// Shared `TimeInterval` → compact remaining-time string. Used by the cost
+/// reset glyph, usage captions, and the notch peek pill so every surface
+/// speaks the same vocabulary.
+///
+/// Buckets: `Ns` / `Nm` / `Nh` under a day; at ≥1 day, `Nd` when the hour
+/// remainder is zero, otherwise `Nd Nh` (e.g. `6d 23h`). Plain `167h` is
+/// hard to parse once weekly Codex windows replaced the old 5h limit.
 enum Duration {
     static func compact(_ seconds: TimeInterval) -> String {
         if seconds < 60 { return "\(Int(seconds))s" }
         if seconds < 3600 { return "\(Int(seconds / 60))m" }
         if seconds < 86400 { return "\(Int(seconds / 3600))h" }
-        return "\(Int(seconds / 86400))d"
+        let days = Int(seconds / 86400)
+        let hours = Int(seconds.truncatingRemainder(dividingBy: 86400) / 3600)
+        if hours == 0 { return "\(days)d" }
+        return "\(days)d \(hours)h"
     }
 }

--- a/Sources/Model/IslandModel.swift
+++ b/Sources/Model/IslandModel.swift
@@ -17,12 +17,13 @@ final class IslandModel: ObservableObject {
     let tabWidth: CGFloat = 38
 
     /// Per-side outboard slot that houses the peek-state percentage pill.
-    /// Sized for "100% · Nh" worst case at the chosen pill typography.
-    /// Fixed (not text-measured) so percentage updates don't jitter the
-    /// silhouette width during refresh. Grown symmetrically on both sides
-    /// regardless of which provider is visible — keeps the silhouette
-    /// balanced over the physical notch.
-    let pillSlotWidth: CGFloat = 78
+    /// Sized for "100% · Nd Nh" worst case at the chosen pill typography
+    /// (weekly Codex windows can land at e.g. `6d 23h`). Fixed (not
+    /// text-measured) so percentage updates don't jitter the silhouette
+    /// width during refresh. Grown symmetrically on both sides regardless
+    /// of which provider is visible — keeps the silhouette balanced over
+    /// the physical notch.
+    let pillSlotWidth: CGFloat = 96
 
     /// Visible expanded panel width.
     private let expandedWidth: CGFloat = 800

--- a/Sources/Views/IslandRootView.swift
+++ b/Sources/Views/IslandRootView.swift
@@ -88,7 +88,7 @@ struct IslandRootView: View {
                     )
                 }
                 .overlay(alignment: .topLeading) {
-                    // Pill lives in the new outboard slot (the 78pt the
+                    // Pill lives in the new outboard slot (the width the
                     // silhouette grew on entering peek). 14pt inset from the
                     // silhouette's new leading edge keeps it visually
                     // breathing inside the rounded corner.

--- a/Sources/Views/NotchPeekPill.swift
+++ b/Sources/Views/NotchPeekPill.swift
@@ -5,8 +5,9 @@ import SwiftUI
 /// directly on the dark silhouette, like the logos.
 ///
 /// Renders one of three states:
-///   • value:    "32% · 2h"  (active countdown) or "0% · 5h" (window-length
-///               fallback at lower opacity when no active resetAt is known)
+///   • value:    "32% · 2h" / "0% · 6d 23h" (active countdown) or
+///               "0% · 5h" (window-length fallback at lower opacity when no
+///               active resetAt is known)
 ///   • loading:  small pulsing dot (only when `loading && usedPercent == 0`)
 ///   • errored:  "—%"         (when error is set and we have no value)
 ///
@@ -113,18 +114,14 @@ struct NotchPeekPill: View {
         "\(usage.displayedPercentInt(mode: usageDisplay.mode))%"
     }
 
-    /// `Nh` when ≥ 1h remaining, `Nm` under 1h. Returns nil if there's no
-    /// resetAt or the reset has already passed (happens transiently when a
-    /// window rolls over before the next fetch lands).
+    /// Shared compact countdown (`Nm` / `Nh` / `Nd Nh`). Returns nil if
+    /// there's no resetAt or the reset has already passed (happens
+    /// transiently when a window rolls over before the next fetch lands).
     private var resetText: String? {
         guard let resetAt = usage.resetAt else { return nil }
         let remaining = resetAt.timeIntervalSinceNow
         guard remaining > 0 else { return nil }
-        if remaining >= 3600 {
-            return "\(Int((remaining / 3600).rounded(.down)))h"
-        } else {
-            return "\(max(1, Int((remaining / 60).rounded(.down))))m"
-        }
+        return Duration.compact(remaining)
     }
 }
 


### PR DESCRIPTION
## Summary
- Format multi-day rate-limit countdowns as `6d 23h` (or plain `7d` when hours are zero) instead of hard-to-read values like `167h`, now that Codex uses weekly windows.
- Route the notch peek pill through the shared `Duration.compact` formatter so peek, usage, and cost surfaces stay consistent.
- Widen the peek pill slot so longer weekly countdowns still fit.

## Test plan
- [ ] Rebuild and open the island with a Codex weekly reset still days away
- [ ] Confirm peek pill shows e.g. `6d 23h` rather than `167h`
- [ ] Confirm Claude short windows still show `Nh` / `Nm` as before
- [ ] Expand the panel and check usage/cost reset captions use the same format
- [ ] Confirm peek silhouette still looks balanced with both pills visible

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Countdown displays now include remaining hours for durations of one day or more, such as “6d 23h.”
  * Reset countdowns use the improved compact time format.

* **Bug Fixes**
  * Improved peek-state sizing to better accommodate wider pill content.
  * Countdown formatting remains clean for exact whole-day durations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->