### PR TITLE
feat(cost): fetch model prices from a published catalog instead of shipping them

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,11 @@ Native app behavior:
 - No crash reporting.
 - No proxy server.
 - No credentials are stored by CodexIsland.
+- Model prices are fetched once a day from a public, GitHub-hosted catalog
+  ([codex-island-model-catalog](https://github.com/ericjypark/codex-island-model-catalog)).
+  The request carries no identifier, no token, and no usage data — it is a
+  plain GET for a static JSON file, and the app works from a local cache when
+  it fails.
 - Codex tokens are read locally from `~/.codex/auth.json`.
 - Claude tokens are read from `CLAUDE_CODE_OAUTH_TOKEN`, Claude's credentials
   file, or the macOS Keychain. CodexIsland never refreshes or writes them.

--- a/Resources/en.lproj/Localizable.strings
+++ b/Resources/en.lproj/Localizable.strings
@@ -19,7 +19,6 @@
 "1 Codex reset available" = "1 Codex reset available";
 "1 reset available" = "1 reset available";
 "⚠ %d unpriced" = "⚠ %d unpriced";
-" · pricing data %dd old" = " · pricing data %dd old";
 "$%@ cumulative" = "$%@ cumulative";
 "5h" = "5h";
 "All tokens" = "All tokens";
@@ -65,7 +64,6 @@
 "Input + output only. Matches Anthropic's claude.ai stats." = "Input + output only. Matches Anthropic's claude.ai stats.";
 "Island width" = "Island width";
 "last scan %@" = "last scan %@";
-"last scan %@ · pricing data %dd old" = "last scan %@ · pricing data %dd old";
 "Launch at Login" = "Launch at Login";
 "Language" = "Language";
 "Later" = "Later";
@@ -102,14 +100,12 @@
 "Restart now" = "Restart now";
 "Ring" = "Ring";
 "scanning local logs…" = "scanning local logs…";
-"scanning local logs… · pricing data %dd old" = "scanning local logs… · pricing data %dd old";
 "Settings" = "Settings";
 "Show on" = "Show on";
 "Sparkline" = "Sparkline";
 "Spacing" = "Spacing";
 "Stepped" = "Stepped";
 "swipe panel to view" = "swipe panel to view";
-"swipe panel to view · pricing data %dd old" = "swipe panel to view · pricing data %dd old";
 "Synced" = "Synced";
 "Synced %@" = "Synced %@";
 "synced %@" = "synced %@";

--- a/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Resources/zh-Hans.lproj/Localizable.strings
@@ -19,7 +19,6 @@
 "1 Codex reset available" = "1 个 Codex 重置可用";
 "1 reset available" = "1 个重置可用";
 "⚠ %d unpriced" = "⚠ %d 个模型缺价格";
-" · pricing data %dd old" = " · 价格数据已过 %d 天";
 "$%@ cumulative" = "$%@ 累计";
 "5h" = "5小时";
 "All tokens" = "全部 token";
@@ -65,7 +64,6 @@
 "Input + output only. Matches Anthropic's claude.ai stats." = "只统计输入 + 输出；与 Anthropic 的 claude.ai 统计一致。";
 "Island width" = "岛宽度";
 "last scan %@" = "上次扫描 %@";
-"last scan %@ · pricing data %dd old" = "上次扫描 %@ · 价格数据已过 %d 天";
 "Launch at Login" = "登录时启动";
 "Language" = "语言";
 "Later" = "稍后";
@@ -102,14 +100,12 @@
 "Restart now" = "立即重启";
 "Ring" = "环形";
 "scanning local logs…" = "正在扫描本地日志…";
-"scanning local logs… · pricing data %dd old" = "正在扫描本地日志… · 价格数据已过 %d 天";
 "Settings" = "设置";
 "Show on" = "显示在";
 "Sparkline" = "折线";
 "Spacing" = "间距";
 "Stepped" = "阶梯";
 "swipe panel to view" = "滑动面板查看";
-"swipe panel to view · pricing data %dd old" = "滑动面板查看 · 价格数据已过 %d 天";
 "Synced" = "已同步";
 "Synced %@" = "已同步 %@";
 "synced %@" = "已同步 %@";

--- a/Sources/App.swift
+++ b/Sources/App.swift
@@ -19,6 +19,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var settingsShortcutMonitor: Any?
 
     func applicationDidFinishLaunching(_ notification: Notification) {
+        // Before any window or store exists: the first cost scan must price
+        // against the cached catalog, not fall back to the seed and then
+        // silently change its numbers a moment later.
+        PricingCatalog.loadFromDisk()
+
         NSApp.setActivationPolicy(.accessory)
         island = IslandWindowController()
         island?.show()
@@ -41,6 +46,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // of flashing "0%" while the first request lands.
         UsageStore.shared.startAutoRefresh()
         CostStore.shared.startAutoRefresh()
+        PricingCatalog.startAutoRefresh()
 
         // Wire the alert engine after the usage store so its initial
         // recompute sees whatever values the first refresh has produced.

--- a/Sources/Cost/Pricing.swift
+++ b/Sources/Cost/Pricing.swift
@@ -10,12 +10,10 @@ import Foundation
 /// LiteLLM has no entry.
 ///
 /// To refresh the seed: re-fetch the four rates per model from
-/// `https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json`
-/// and bump `seedSnapshotDate`. This is housekeeping, not a release
-/// requirement — the catalog covers new models without an app update.
+/// `https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json`.
+/// This is housekeeping, not a release requirement — the catalog covers new
+/// models without an app update.
 enum Pricing {
-    static let seedSnapshotDate = "2026-07-10"
-
     struct Rates {
         let inputPerMillion: Double
         let outputPerMillion: Double
@@ -217,30 +215,6 @@ enum Pricing {
         return seedTable[canonical]
     }
 
-    private static let snapshotFormatter: DateFormatter = {
-        let f = DateFormatter()
-        f.dateFormat = "yyyy-MM-dd"
-        f.timeZone = TimeZone(identifier: "UTC")
-        f.locale = Locale(identifier: "en_US_POSIX")
-        return f
-    }()
-
-    /// Days since the app last reached the catalog, falling back to the age of
-    /// the embedded seed when no fetch has ever succeeded.
-    ///
-    /// Deliberately not the catalog's own `generatedAt`: the sync bot commits
-    /// only when prices change, so a long-stable table would read as months
-    /// stale while the app was in fact checking daily and finding nothing new.
-    /// "How long since I reached the source" is what predicts whether these
-    /// numbers are wrong.
-    static func daysSincePricingRefresh(now: Date = Date()) -> Int {
-        let origin = PricingCatalog.lastFetched
-            ?? snapshotFormatter.date(from: seedSnapshotDate)
-        guard let origin else { return 0 }
-        var calendar = Calendar(identifier: .gregorian)
-        if let utc = TimeZone(identifier: "UTC") { calendar.timeZone = utc }
-        return max(0, calendar.dateComponents([.day], from: origin, to: now).day ?? 0)
-    }
 
     /// Strip Anthropic-style date suffixes (e.g. "claude-haiku-4-5-20251001"
     /// → "claude-haiku-4-5") so the snapshot table doesn't need an entry per

--- a/Sources/Cost/Pricing.swift
+++ b/Sources/Cost/Pricing.swift
@@ -1,16 +1,20 @@
 import Foundation
 
-/// Embedded snapshot of per-million-token API prices in USD. Mirrors LiteLLM's
-/// `model_prices_and_context_window.json` for the models we actually expect
-/// in Claude Code and Codex CLI sessions, so totals cross-check against
-/// `npx ccusage` and `npx @ccusage/codex` to within rounding.
+/// Model prices in USD per million tokens.
 ///
-/// To refresh: bump `snapshotDate` and re-fetch the four rates per model
-/// from `https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json`.
-/// Unknown models silently price to $0 — same behavior as ccusage when
+/// The live source is the published catalog (see `PricingCatalog`); the table
+/// below is the build-time seed, used until the first successful fetch and as
+/// the permanent fallback for anything the catalog omits. Totals cross-check
+/// against `npx ccusage` and `npx @ccusage/codex` to within rounding, and
+/// unknown models silently price to $0 — same behavior as ccusage when
 /// LiteLLM has no entry.
+///
+/// To refresh the seed: re-fetch the four rates per model from
+/// `https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json`
+/// and bump `seedSnapshotDate`. This is housekeeping, not a release
+/// requirement — the catalog covers new models without an app update.
 enum Pricing {
-    static let snapshotDate = "2026-07-10"
+    static let seedSnapshotDate = "2026-07-10"
 
     struct Rates {
         let inputPerMillion: Double
@@ -19,7 +23,7 @@ enum Pricing {
         let cacheReadPerMillion: Double
     }
 
-    private static let table: [String: Rates] = [
+    private static let seedTable: [String: Rates] = [
         // Anthropic — LiteLLM lists Opus 5 and 4-5/4-6/4-7/4-8 at the same
         // rates (cheaper than the original Opus 4 because Anthropic re-tiered
         // the Opus line in 2025). Opus 5's fast mode bills at $10/$50 but
@@ -182,8 +186,7 @@ enum Pricing {
     /// Claude Code workflows. ccusage's per-bucket threshold check would
     /// disagree with Anthropic's per-position-in-context billing anyway.
     static func cost(for event: TokenEvent) -> Double {
-        let lookup = canonicalModel(event.model)
-        guard let rates = table[lookup] else { return 0 }
+        guard let rates = resolvedRates(for: canonicalModel(event.model)) else { return 0 }
 
         let input = Double(event.inputTokens) / 1_000_000 * rates.inputPerMillion
         let output = Double(event.outputTokens) / 1_000_000 * rates.outputPerMillion
@@ -193,26 +196,50 @@ enum Pricing {
         return input + output + cacheCreate + cacheRead
     }
 
-    /// Whether the embedded snapshot has a price entry for this model.
-    /// Lets callers warn the user about unpriced spend without re-implementing
-    /// the canonical-name stripping logic.
+    /// Whether either source has a price entry for this model. Lets callers
+    /// warn the user about unpriced spend without re-implementing the
+    /// canonical-name stripping logic.
     static func isKnown(_ rawModel: String) -> Bool {
-        table[canonicalModel(rawModel)] != nil
+        resolvedRates(for: canonicalModel(rawModel)) != nil
     }
 
-    /// Calendar days between `snapshotDate` and now (UTC). Returns 0 if the
-    /// snapshot string fails to parse, so a malformed constant is treated as
-    /// fresh rather than triggering a permanent staleness warning.
-    static var daysSinceSnapshot: Int {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy-MM-dd"
-        formatter.timeZone = TimeZone(identifier: "UTC")
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        guard let snapshot = formatter.date(from: snapshotDate) else { return 0 }
+    /// Remote catalog first, embedded seed second. The seed is what keeps a
+    /// catalog that omits a model from silently pricing it at $0.
+    private static func resolvedRates(for canonical: String) -> Rates? {
+        if let remote = PricingCatalog.rates(for: canonical) {
+            return Rates(
+                inputPerMillion: remote.inputPerMillion,
+                outputPerMillion: remote.outputPerMillion,
+                cacheCreationPerMillion: remote.cacheCreationPerMillion,
+                cacheReadPerMillion: remote.cacheReadPerMillion
+            )
+        }
+        return seedTable[canonical]
+    }
+
+    private static let snapshotFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "yyyy-MM-dd"
+        f.timeZone = TimeZone(identifier: "UTC")
+        f.locale = Locale(identifier: "en_US_POSIX")
+        return f
+    }()
+
+    /// Days since the app last reached the catalog, falling back to the age of
+    /// the embedded seed when no fetch has ever succeeded.
+    ///
+    /// Deliberately not the catalog's own `generatedAt`: the sync bot commits
+    /// only when prices change, so a long-stable table would read as months
+    /// stale while the app was in fact checking daily and finding nothing new.
+    /// "How long since I reached the source" is what predicts whether these
+    /// numbers are wrong.
+    static func daysSincePricingRefresh(now: Date = Date()) -> Int {
+        let origin = PricingCatalog.lastFetched
+            ?? snapshotFormatter.date(from: seedSnapshotDate)
+        guard let origin else { return 0 }
         var calendar = Calendar(identifier: .gregorian)
         if let utc = TimeZone(identifier: "UTC") { calendar.timeZone = utc }
-        let components = calendar.dateComponents([.day], from: snapshot, to: Date())
-        return max(0, components.day ?? 0)
+        return max(0, calendar.dateComponents([.day], from: origin, to: now).day ?? 0)
     }
 
     /// Strip Anthropic-style date suffixes (e.g. "claude-haiku-4-5-20251001"
@@ -226,6 +253,9 @@ enum Pricing {
     /// Pretty-print the canonical model id for UI rows. Falls back to the
     /// raw id if no friendlier name is wired up yet — better than a blank.
     static func prettyModelName(_ canonical: String) -> String {
+        if let name = PricingCatalog.rates(for: canonical)?.displayName, !name.isEmpty {
+            return name
+        }
         // Anthropic: "claude-opus-4-7" → "Opus 4.7"
         if canonical.hasPrefix("claude-") {
             let trimmed = String(canonical.dropFirst("claude-".count))

--- a/Sources/Cost/PricingCatalog.swift
+++ b/Sources/Cost/PricingCatalog.swift
@@ -75,4 +75,109 @@ enum PricingCatalog {
         guard !payload.models.isEmpty else { return .rejected("empty catalog") }
         return .payload(payload)
     }
+
+    private static let refreshInterval: TimeInterval = 24 * 60 * 60
+
+    private static var etag: String?
+
+    private static var storedETag: String? {
+        get { lock.lock(); defer { lock.unlock() }; return etag }
+        set { lock.lock(); defer { lock.unlock() }; etag = newValue }
+    }
+
+    /// Records that the source was reached and confirmed unchanged, without
+    /// touching the price table.
+    static func markVerified(at stamp: Date) {
+        lock.lock()
+        defer { lock.unlock() }
+        fetchedAt = stamp
+    }
+
+    struct CachedCatalog: Codable {
+        let payload: CatalogPayload
+        let etag: String?
+        let fetchedAt: Date
+    }
+
+    /// `Caches` is purgeable by macOS. Losing this file costs one refetch and
+    /// drops to the embedded seed in the meantime, which is the intended
+    /// behavior — mirrors `LogParseCache.cacheURL`.
+    static func cacheURL() -> URL? {
+        let fm = FileManager.default
+        guard let caches = fm.urls(for: .cachesDirectory, in: .userDomainMask).first else {
+            return nil
+        }
+        let dir = caches.appendingPathComponent("dev.codexisland.CodexIsland", isDirectory: true)
+        try? fm.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir.appendingPathComponent("model-prices.json")
+    }
+
+    /// The URL parameter exists so tests can round-trip through a temp file
+    /// instead of the user's real cache.
+    static func loadFromDisk(from url: URL? = cacheURL()) {
+        guard let url,
+              let data = try? Data(contentsOf: url),
+              let cached = try? JSONDecoder().decode(CachedCatalog.self, from: data),
+              cached.payload.schemaVersion == supportedSchemaVersion,
+              !cached.payload.models.isEmpty
+        else { return }
+        storedETag = cached.etag
+        install(models: cached.payload.models, fetchedAt: cached.fetchedAt)
+    }
+
+    static func persist(
+        _ payload: CatalogPayload, etag newETag: String?, at stamp: Date,
+        to url: URL? = cacheURL()
+    ) {
+        storedETag = newETag
+        guard let url,
+              let data = try? JSONEncoder().encode(
+                CachedCatalog(payload: payload, etag: newETag, fetchedAt: stamp))
+        else { return }
+        try? data.write(to: url, options: .atomic)
+    }
+
+    static func refreshIfNeeded(
+        now: Date = Date(),
+        fetch: (URLRequest) async throws -> (Data, URLResponse) = {
+            try await URLSession.shared.data(for: $0)
+        }
+    ) async {
+        if let last = lastFetched, now.timeIntervalSince(last) < refreshInterval { return }
+
+        var request = URLRequest(url: endpoint)
+        request.timeoutInterval = 15
+        if let tag = storedETag { request.setValue(tag, forHTTPHeaderField: "If-None-Match") }
+
+        guard let (data, response) = try? await fetch(request),
+              let http = response as? HTTPURLResponse
+        else { return }
+
+        switch interpret(status: http.statusCode, data: data) {
+        case .payload(let payload):
+            install(models: payload.models, fetchedAt: now)
+            persist(payload, etag: http.value(forHTTPHeaderField: "ETag"), at: now)
+        case .unchanged:
+            markVerified(at: now)
+        case .rejected:
+            // Deliberately silent and deliberately inert: staleness already
+            // surfaces in Settings, and the previous catalog stays correct.
+            break
+        }
+    }
+
+    @MainActor
+    private static var refreshTimer: Timer?
+
+    /// Ticks every 6h against a 24h staleness threshold, so a laptop that
+    /// slept through its window catches up at the next wake rather than
+    /// waiting another full day.
+    @MainActor
+    static func startAutoRefresh() {
+        Task { await refreshIfNeeded() }
+        refreshTimer?.invalidate()
+        refreshTimer = Timer.scheduledTimer(withTimeInterval: 6 * 60 * 60, repeats: true) { _ in
+            Task { await refreshIfNeeded() }
+        }
+    }
 }

--- a/Sources/Cost/PricingCatalog.swift
+++ b/Sources/Cost/PricingCatalog.swift
@@ -139,11 +139,8 @@ enum PricingCatalog {
 
     /// A 304 means the source was reached and the payload is still current, so
     /// the timestamp has to reach disk too — `markVerified` only moves the
-    /// in-memory copy. Without this, every launch restores the older stamp, and
-    /// since a stable catalog answers almost every refresh with 304, the
-    /// staleness figure in Settings would climb past its threshold for a user
-    /// whose prices simply are not changing. That false alarm is the exact
-    /// thing `daysSincePricingRefresh` exists to avoid.
+    /// in-memory copy. Without this, every launch restores the older stamp and
+    /// the 24h refresh window is computed from the wrong instant.
     static func touchCache(at stamp: Date, to url: URL? = cacheURL()) {
         guard let url,
               let data = try? Data(contentsOf: url),

--- a/Sources/Cost/PricingCatalog.swift
+++ b/Sources/Cost/PricingCatalog.swift
@@ -137,8 +137,24 @@ enum PricingCatalog {
         try? data.write(to: url, options: .atomic)
     }
 
+    /// A 304 means the source was reached and the payload is still current, so
+    /// the timestamp has to reach disk too — `markVerified` only moves the
+    /// in-memory copy. Without this, every launch restores the older stamp, and
+    /// since a stable catalog answers almost every refresh with 304, the
+    /// staleness figure in Settings would climb past its threshold for a user
+    /// whose prices simply are not changing. That false alarm is the exact
+    /// thing `daysSincePricingRefresh` exists to avoid.
+    static func touchCache(at stamp: Date, to url: URL? = cacheURL()) {
+        guard let url,
+              let data = try? Data(contentsOf: url),
+              let cached = try? JSONDecoder().decode(CachedCatalog.self, from: data)
+        else { return }
+        persist(cached.payload, etag: cached.etag, at: stamp, to: url)
+    }
+
     static func refreshIfNeeded(
         now: Date = Date(),
+        cache: URL? = cacheURL(),
         fetch: (URLRequest) async throws -> (Data, URLResponse) = {
             try await URLSession.shared.data(for: $0)
         }
@@ -156,9 +172,10 @@ enum PricingCatalog {
         switch interpret(status: http.statusCode, data: data) {
         case .payload(let payload):
             install(models: payload.models, fetchedAt: now)
-            persist(payload, etag: http.value(forHTTPHeaderField: "ETag"), at: now)
+            persist(payload, etag: http.value(forHTTPHeaderField: "ETag"), at: now, to: cache)
         case .unchanged:
             markVerified(at: now)
+            touchCache(at: now, to: cache)
         case .rejected:
             // Deliberately silent and deliberately inert: staleness already
             // surfaces in Settings, and the previous catalog stays correct.

--- a/Sources/Cost/PricingCatalog.swift
+++ b/Sources/Cost/PricingCatalog.swift
@@ -1,0 +1,78 @@
+import Foundation
+
+struct CatalogRates: Codable, Equatable {
+    let displayName: String?
+    let inputPerMillion: Double
+    let outputPerMillion: Double
+    let cacheCreationPerMillion: Double
+    let cacheReadPerMillion: Double
+}
+
+struct CatalogPayload: Codable, Equatable {
+    let schemaVersion: Int
+    let generatedAt: String
+    let models: [String: CatalogRates]
+}
+
+enum CatalogFetchResult: Equatable {
+    case payload(CatalogPayload)
+    case unchanged
+    case rejected(String)
+}
+
+/// Remote model price table, refreshed daily from the published catalog.
+///
+/// `Pricing` reads this before its own embedded seed, so anything installed
+/// here decides what the user is charged on screen. Every path that fails to
+/// produce a complete, current payload therefore leaves the previous state
+/// untouched rather than installing something partial.
+enum PricingCatalog {
+    static let supportedSchemaVersion = 1
+
+    /// Literal, known-good URL — the same force-unwrap idiom `UsageFetcher`
+    /// uses for its endpoints.
+    static let endpoint = URL(
+        string: "https://ericjypark.github.io/codex-island-model-catalog/v1/models.json"
+    )!
+
+    /// `CostStore` summarizes on two concurrent detached tasks, so reads land
+    /// off the main actor while a refresh installs. The lock is what keeps
+    /// that from being a data race.
+    private static let lock = NSLock()
+    private static var models: [String: CatalogRates] = [:]
+    private static var fetchedAt: Date?
+
+    static func rates(for canonical: String) -> CatalogRates? {
+        lock.lock()
+        defer { lock.unlock() }
+        return models[canonical]
+    }
+
+    static var lastFetched: Date? {
+        lock.lock()
+        defer { lock.unlock() }
+        return fetchedAt
+    }
+
+    static func install(models newModels: [String: CatalogRates], fetchedAt stamp: Date) {
+        lock.lock()
+        defer { lock.unlock() }
+        models = newModels
+        fetchedAt = stamp
+    }
+
+    /// Decides what a response means. Pure, so the whole trust boundary is
+    /// testable without a network.
+    static func interpret(status: Int, data: Data) -> CatalogFetchResult {
+        if status == 304 { return .unchanged }
+        guard status == 200 else { return .rejected("HTTP \(status)") }
+        guard let payload = try? JSONDecoder().decode(CatalogPayload.self, from: data) else {
+            return .rejected("malformed JSON")
+        }
+        guard payload.schemaVersion == supportedSchemaVersion else {
+            return .rejected("unsupported schemaVersion \(payload.schemaVersion)")
+        }
+        guard !payload.models.isEmpty else { return .rejected("empty catalog") }
+        return .payload(payload)
+    }
+}

--- a/Sources/Views/SettingsView.swift
+++ b/Sources/Views/SettingsView.swift
@@ -603,7 +603,7 @@ struct SettingsView: View {
     }()
 
     private func costSubtitle() -> String {
-        let days = Pricing.daysSinceSnapshot
+        let days = Pricing.daysSincePricingRefresh()
         let isStale = days > Self.pricingFreshnessThreshold
 
         if cost.loading {

--- a/Sources/Views/SettingsView.swift
+++ b/Sources/Views/SettingsView.swift
@@ -589,12 +589,6 @@ struct SettingsView: View {
         .padding(.bottom, 14)
     }
 
-    /// Days past the embedded pricing snapshot before the Cost section
-    /// admits the data may be stale. Anthropic re-tiered Opus once already,
-    /// so two months without a refresh is the point where dollar totals
-    /// could meaningfully drift from reality.
-    private static let pricingFreshnessThreshold = 60
-
     private static let relativeFormatter: RelativeDateTimeFormatter = {
         let f = RelativeDateTimeFormatter()
         f.locale = L10n.locale
@@ -603,23 +597,14 @@ struct SettingsView: View {
     }()
 
     private func costSubtitle() -> String {
-        let days = Pricing.daysSincePricingRefresh()
-        let isStale = days > Self.pricingFreshnessThreshold
-
         if cost.loading {
-            return isStale
-                ? L10n.tr("scanning local logs… · pricing data %dd old", days)
-                : L10n.tr("scanning local logs…")
-        } else if let updated = cost.lastUpdated {
-            let relative = Self.relativeFormatter.localizedString(for: updated, relativeTo: Date())
-            return isStale
-                ? L10n.tr("last scan %@ · pricing data %dd old", relative, days)
-                : L10n.tr("last scan %@", relative)
+            return L10n.tr("scanning local logs…")
         }
-
-        return isStale
-            ? L10n.tr("swipe panel to view · pricing data %dd old", days)
-            : L10n.tr("swipe panel to view")
+        if let updated = cost.lastUpdated {
+            let relative = Self.relativeFormatter.localizedString(for: updated, relativeTo: Date())
+            return L10n.tr("last scan %@", relative)
+        }
+        return L10n.tr("swipe panel to view")
     }
 
     private var chartSection: some View {

--- a/Tests/PricingCatalogRaceTests.swift
+++ b/Tests/PricingCatalogRaceTests.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+/// Hammers the store from several threads while a writer swaps the whole
+/// table. Built with `-sanitize=thread`: if the lock in `PricingCatalog` is
+/// removed, TSan reports the race on the backing dictionary and aborts, so
+/// this fails loudly rather than flaking.
+@main
+struct PricingCatalogRaceTests {
+    static func rates(_ input: Double) -> [String: CatalogRates] {
+        ["m": CatalogRates(
+            displayName: "M", inputPerMillion: input, outputPerMillion: input * 2,
+            cacheCreationPerMillion: input, cacheReadPerMillion: 0
+        )]
+    }
+
+    static func main() {
+        let deadline = Date().addingTimeInterval(2)
+        let group = DispatchGroup()
+
+        DispatchQueue.global().async(group: group) {
+            var flip = false
+            while Date() < deadline {
+                PricingCatalog.install(models: rates(flip ? 1 : 9), fetchedAt: Date())
+                flip.toggle()
+            }
+        }
+        for _ in 0..<4 {
+            DispatchQueue.global().async(group: group) {
+                while Date() < deadline {
+                    _ = PricingCatalog.rates(for: "m")
+                    _ = PricingCatalog.lastFetched
+                }
+            }
+        }
+
+        group.wait()
+        print("PASS concurrent install/read is race-free")
+        exit(0)
+    }
+}

--- a/Tests/PricingCatalogRaceTests.swift
+++ b/Tests/PricingCatalogRaceTests.swift
@@ -5,16 +5,28 @@ import Foundation
 /// happens-before edges, TSan reports the race and aborts, so this fails
 /// loudly rather than flaking.
 ///
-/// One accessor per thread is load-bearing, not style. With a single thread
-/// calling several accessors in sequence, the locks on either side of an
-/// unlocked one cover it and the sanitizer stays silent.
+/// One accessor per writer thread is load-bearing, not style. With a single
+/// thread calling several accessors in sequence, the locks on either side of
+/// an unlocked one cover it and the sanitizer stays silent.
 ///
-/// Known gap: `markVerified(at:)` is NOT covered. Removing its lock is not
-/// detected, across two harness designs and ten runs. The likely cause is
-/// shadow-memory eviction — `install` also writes `fetchedAt`, at high
-/// frequency and under the lock, and TSan keeps only four shadow cells per
-/// eight-byte granule. `install`, `rates(for:)` and `storedETag` are all
-/// verified to fail when their locks are removed.
+/// **What this harness does and does not protect.** Verified by removing each
+/// lock in turn: `install`, `rates(for:)` and `storedETag` all abort with a
+/// TSan report. `markVerified(at:)` and `lastFetched` do not — removing their
+/// locks is not detected at all.
+///
+/// The boundary is the field's storage kind, not this harness's shape. On this
+/// toolchain TSan reports races on heap-backed refcounted storage — `models`
+/// (Dictionary) and `etag` (String) — and not on inline POD storage. A
+/// standalone probe racing a `static var Date?` with no lock anywhere in the
+/// program reports nothing; the same probe on `[String: Double]` or `String?`
+/// aborts. Both uncovered accessors are exactly the two whose only shared
+/// state is `fetchedAt: Date?`.
+///
+/// So this is not a gap a further redesign closes — it is undetectable by
+/// construction for that field type. The consequence for anyone extending
+/// `PricingCatalog`: a new lock-guarded `Int`, `Date`, or other POD field will
+/// NOT be covered here, and its lock has to be argued for by reading rather
+/// than proven by this test.
 @main
 struct PricingCatalogRaceTests {
     static func rates(_ input: Double) -> [String: CatalogRates] {
@@ -59,10 +71,16 @@ struct PricingCatalogRaceTests {
                     etag: "\"c\"", at: Date(), to: nil)
             }
         }
-        for _ in 0..<4 {
+        for _ in 0..<2 {
             DispatchQueue.global().async(group: group) {
                 while Date() < deadline {
                     _ = PricingCatalog.rates(for: "m")
+                }
+            }
+        }
+        for _ in 0..<2 {
+            DispatchQueue.global().async(group: group) {
+                while Date() < deadline {
                     _ = PricingCatalog.lastFetched
                 }
             }

--- a/Tests/PricingCatalogRaceTests.swift
+++ b/Tests/PricingCatalogRaceTests.swift
@@ -1,9 +1,20 @@
 import Foundation
 
-/// Hammers the store from several threads while a writer swaps the whole
-/// table. Built with `-sanitize=thread`: if the lock in `PricingCatalog` is
-/// removed, TSan reports the race on the backing dictionary and aborts, so
-/// this fails loudly rather than flaking.
+/// Hammers the store from several threads, one accessor per thread. Built
+/// with `-sanitize=thread`: removing a lock leaves that thread with no
+/// happens-before edges, TSan reports the race and aborts, so this fails
+/// loudly rather than flaking.
+///
+/// One accessor per thread is load-bearing, not style. With a single thread
+/// calling several accessors in sequence, the locks on either side of an
+/// unlocked one cover it and the sanitizer stays silent.
+///
+/// Known gap: `markVerified(at:)` is NOT covered. Removing its lock is not
+/// detected, across two harness designs and ten runs. The likely cause is
+/// shadow-memory eviction — `install` also writes `fetchedAt`, at high
+/// frequency and under the lock, and TSan keeps only four shadow cells per
+/// eight-byte granule. `install`, `rates(for:)` and `storedETag` are all
+/// verified to fail when their locks are removed.
 @main
 struct PricingCatalogRaceTests {
     static func rates(_ input: Double) -> [String: CatalogRates] {

--- a/Tests/PricingCatalogRaceTests.swift
+++ b/Tests/PricingCatalogRaceTests.swift
@@ -24,6 +24,30 @@ struct PricingCatalogRaceTests {
                 flip.toggle()
             }
         }
+        DispatchQueue.global().async(group: group) {
+            while Date() < deadline {
+                PricingCatalog.markVerified(at: Date())
+            }
+        }
+        DispatchQueue.global().async(group: group) {
+            var flip = false
+            while Date() < deadline {
+                // to: nil writes no file — this exists only to touch the ETag,
+                // which nothing public reads, so the race it must expose is
+                // write-against-write between this thread and the next.
+                PricingCatalog.persist(
+                    CatalogPayload(schemaVersion: 1, generatedAt: "x", models: rates(1)),
+                    etag: flip ? "\"a\"" : "\"b\"", at: Date(), to: nil)
+                flip.toggle()
+            }
+        }
+        DispatchQueue.global().async(group: group) {
+            while Date() < deadline {
+                PricingCatalog.persist(
+                    CatalogPayload(schemaVersion: 1, generatedAt: "y", models: rates(2)),
+                    etag: "\"c\"", at: Date(), to: nil)
+            }
+        }
         for _ in 0..<4 {
             DispatchQueue.global().async(group: group) {
                 while Date() < deadline {

--- a/Tests/PricingCatalogTests.swift
+++ b/Tests/PricingCatalogTests.swift
@@ -1,0 +1,88 @@
+import Foundation
+
+/// Locks down payload validation and the in-memory store: what the app is
+/// willing to believe from the network, and that a rejection never mutates
+/// what it already has.
+@main
+struct PricingCatalogTests {
+    static var failures = 0
+
+    static func expect(_ condition: Bool, _ label: String) {
+        if condition { print("PASS \(label)") } else { print("FAIL \(label)"); failures += 1 }
+    }
+
+    static func json(_ raw: String) -> Data { Data(raw.utf8) }
+
+    static let valid = """
+    {"schemaVersion":1,"generatedAt":"2026-07-26T01:00:00Z","models":{
+      "claude-opus-4-8":{"displayName":"Opus 4.8","inputPerMillion":5,
+        "outputPerMillion":25,"cacheCreationPerMillion":6.25,"cacheReadPerMillion":0.5}}}
+    """
+
+    static func main() {
+        // A well-formed v1 payload is accepted and decoded.
+        if case .payload(let p) = PricingCatalog.interpret(status: 200, data: json(valid)) {
+            expect(p.models.count == 1, "valid payload decodes one model")
+            expect(p.models["claude-opus-4-8"]?.inputPerMillion == 5, "rates decode")
+            expect(p.models["claude-opus-4-8"]?.displayName == "Opus 4.8", "displayName decodes")
+        } else {
+            expect(false, "valid payload accepted")
+        }
+
+        expect(PricingCatalog.interpret(status: 304, data: Data()) == .unchanged,
+               "304 reports unchanged")
+
+        // Everything below must be rejected — each one would otherwise zero
+        // out or corrupt the user's dollar totals.
+        let rejects: [(String, CatalogFetchResult)] = [
+            ("HTTP 500", PricingCatalog.interpret(status: 500, data: json(valid))),
+            ("HTTP 404", PricingCatalog.interpret(status: 404, data: Data())),
+            ("malformed JSON", PricingCatalog.interpret(status: 200, data: json("{nope"))),
+            ("wrong schema", PricingCatalog.interpret(
+                status: 200,
+                data: json(#"{"schemaVersion":2,"generatedAt":"x","models":{"a":{"inputPerMillion":1,"outputPerMillion":1,"cacheCreationPerMillion":1,"cacheReadPerMillion":1}}}"#))),
+            ("empty catalog", PricingCatalog.interpret(
+                status: 200,
+                data: json(#"{"schemaVersion":1,"generatedAt":"x","models":{}}"#))),
+        ]
+        for (label, result) in rejects {
+            if case .rejected = result { print("PASS rejects \(label)") }
+            else { print("FAIL rejects \(label)"); failures += 1 }
+        }
+
+        // displayName is optional — a payload without it still decodes.
+        if case .payload(let p) = PricingCatalog.interpret(
+            status: 200,
+            data: json(#"{"schemaVersion":1,"generatedAt":"x","models":{"gpt-9":{"inputPerMillion":1,"outputPerMillion":2,"cacheCreationPerMillion":1,"cacheReadPerMillion":0}}}"#)
+        ) {
+            expect(p.models["gpt-9"]?.displayName == nil, "absent displayName decodes as nil")
+        } else {
+            expect(false, "payload without displayName accepted")
+        }
+
+        // Store round trip.
+        expect(PricingCatalog.lastFetched == nil, "store starts empty")
+        expect(PricingCatalog.rates(for: "claude-opus-4-8") == nil, "empty store returns nil")
+
+        let stamp = Date(timeIntervalSince1970: 1_784_000_000)
+        PricingCatalog.install(
+            models: ["claude-opus-4-8": CatalogRates(
+                displayName: "Opus 4.8", inputPerMillion: 5, outputPerMillion: 25,
+                cacheCreationPerMillion: 6.25, cacheReadPerMillion: 0.5)],
+            fetchedAt: stamp
+        )
+        expect(PricingCatalog.rates(for: "claude-opus-4-8")?.outputPerMillion == 25,
+               "installed rates are readable")
+        expect(PricingCatalog.lastFetched == stamp, "install records the fetch time")
+        expect(PricingCatalog.rates(for: "not-a-model") == nil, "unknown id returns nil")
+
+        // Installing replaces wholesale rather than merging.
+        PricingCatalog.install(models: ["gpt-5.6": CatalogRates(
+            displayName: nil, inputPerMillion: 5, outputPerMillion: 30,
+            cacheCreationPerMillion: 6.25, cacheReadPerMillion: 0.5)], fetchedAt: stamp)
+        expect(PricingCatalog.rates(for: "claude-opus-4-8") == nil,
+               "install replaces the whole table")
+
+        exit(failures == 0 ? 0 : 1)
+    }
+}

--- a/Tests/PricingCatalogTests.swift
+++ b/Tests/PricingCatalogTests.swift
@@ -202,9 +202,6 @@ struct PricingCatalogTests {
         expect(PricingCatalog.rates(for: "claude-opus-4-8")?.inputPerMillion == 5,
                "corrupt cache file is ignored, previous state survives")
 
-        // Restore a good file for the assertions that follow.
-        PricingCatalog.persist(diskPayload, etag: "\"disk\"", at: base, to: tmp)
-
         // A cache written by a future schema is ignored rather than trusted.
         let futureSchema = CatalogPayload(
             schemaVersion: 2, generatedAt: "x",

--- a/Tests/PricingCatalogTests.swift
+++ b/Tests/PricingCatalogTests.swift
@@ -20,6 +20,13 @@ struct PricingCatalogTests {
     """
 
     static func main() async {
+        // Every disk write in this file goes to a temp path. Without the
+        // explicit `cache:`, refreshIfNeeded defaults to the real cache and
+        // the suite silently overwrites the user's installed catalog.
+        let tmp = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("codexisland-catalog-test.json")
+        try? FileManager.default.removeItem(at: tmp)
+
         // A well-formed v1 payload is accepted and decoded.
         if case .payload(let p) = PricingCatalog.interpret(status: 200, data: json(valid)) {
             expect(p.models.count == 1, "valid payload decodes one model")
@@ -71,7 +78,9 @@ struct PricingCatalogTests {
         // in this file would still pass. The transport throws, so the store
         // is left exactly as it was.
         var firstRunRequests = 0
-        await PricingCatalog.refreshIfNeeded(now: Date(timeIntervalSince1970: 1_000_000)) { _ in
+        await PricingCatalog.refreshIfNeeded(
+            now: Date(timeIntervalSince1970: 1_000_000), cache: tmp
+        ) { _ in
             firstRunRequests += 1
             throw URLError(.notConnectedToInternet)
         }
@@ -116,7 +125,7 @@ struct PricingCatalogTests {
 
         PricingCatalog.install(models: [:], fetchedAt: Date(timeIntervalSince1970: 0))
         await PricingCatalog.refreshIfNeeded(
-            now: base, fetch: transport(200, json(valid), "\"abc\""))
+            now: base, cache: tmp, fetch: transport(200, json(valid), "\"abc\""))
         expect(PricingCatalog.rates(for: "claude-opus-4-8")?.inputPerMillion == 5,
                "200 installs the payload")
         expect(PricingCatalog.lastFetched == base, "200 records the fetch time")
@@ -124,12 +133,12 @@ struct PricingCatalogTests {
         // Within 24h the refresh is a no-op — no request at all.
         let before = seenHeaders.count
         await PricingCatalog.refreshIfNeeded(
-            now: base.addingTimeInterval(3_600), fetch: transport(200, Data(), nil))
+            now: base.addingTimeInterval(3_600), cache: tmp, fetch: transport(200, Data(), nil))
         expect(seenHeaders.count == before, "refresh inside 24h makes no request")
 
         // Past 24h it fetches again, now carrying the stored ETag.
         let later = base.addingTimeInterval(25 * 3_600)
-        await PricingCatalog.refreshIfNeeded(now: later, fetch: transport(304, Data(), nil))
+        await PricingCatalog.refreshIfNeeded(now: later, cache: tmp, fetch: transport(304, Data(), nil))
         expect(seenHeaders.last == "\"abc\"", "stored ETag is sent as If-None-Match")
         expect(PricingCatalog.lastFetched == later, "304 advances the fetch time")
         expect(PricingCatalog.rates(for: "claude-opus-4-8")?.inputPerMillion == 5,
@@ -137,13 +146,13 @@ struct PricingCatalogTests {
 
         // A garbage response must not disturb what is already installed.
         let later2 = later.addingTimeInterval(25 * 3_600)
-        await PricingCatalog.refreshIfNeeded(now: later2, fetch: transport(200, json("{nope"), nil))
+        await PricingCatalog.refreshIfNeeded(now: later2, cache: tmp, fetch: transport(200, json("{nope"), nil))
         expect(PricingCatalog.rates(for: "claude-opus-4-8")?.inputPerMillion == 5,
                "malformed payload leaves the catalog intact")
         expect(PricingCatalog.lastFetched == later, "rejected payload does not advance the clock")
 
         // A transport that throws is equally harmless.
-        await PricingCatalog.refreshIfNeeded(now: later2, fetch: { _ in
+        await PricingCatalog.refreshIfNeeded(now: later2, cache: tmp, fetch: { _ in
             throw URLError(.notConnectedToInternet)
         })
         expect(PricingCatalog.rates(for: "claude-opus-4-8")?.inputPerMillion == 5,
@@ -151,9 +160,6 @@ struct PricingCatalogTests {
 
         // Disk cache: the middle tier of the fallback ladder. Round-trips
         // through a temp file so the user's real cache is never touched.
-        let tmp = URL(fileURLWithPath: NSTemporaryDirectory())
-            .appendingPathComponent("codexisland-catalog-test.json")
-        try? FileManager.default.removeItem(at: tmp)
 
         guard case .payload(let diskPayload) =
             PricingCatalog.interpret(status: 200, data: json(valid)) else {
@@ -181,7 +187,9 @@ struct PricingCatalogTests {
         // the app can hold an ETag for a cache it no longer has, receive 304
         // for data it does not hold, and sit on the embedded seed forever.
         var diskHeaders: [String?] = []
-        await PricingCatalog.refreshIfNeeded(now: base.addingTimeInterval(60 * 86_400)) { req in
+        await PricingCatalog.refreshIfNeeded(
+            now: base.addingTimeInterval(60 * 86_400), cache: tmp
+        ) { req in
             diskHeaders.append(req.value(forHTTPHeaderField: "If-None-Match"))
             throw URLError(.cancelled)
         }

--- a/Tests/PricingCatalogTests.swift
+++ b/Tests/PricingCatalogTests.swift
@@ -19,7 +19,7 @@ struct PricingCatalogTests {
         "outputPerMillion":25,"cacheCreationPerMillion":6.25,"cacheReadPerMillion":0.5}}}
     """
 
-    static func main() {
+    static func main() async {
         // A well-formed v1 payload is accepted and decoded.
         if case .payload(let p) = PricingCatalog.interpret(status: 200, data: json(valid)) {
             expect(p.models.count == 1, "valid payload decodes one model")
@@ -64,6 +64,19 @@ struct PricingCatalogTests {
         expect(PricingCatalog.lastFetched == nil, "store starts empty")
         expect(PricingCatalog.rates(for: "claude-opus-4-8") == nil, "empty store returns nil")
 
+        // Runs before anything installs, because `lastFetched` is nil only on
+        // a fresh process — and that is the branch a new install takes. A
+        // guard that bailed out when nothing had ever been fetched would mean
+        // the app never fetches a catalog at all, and every other assertion
+        // in this file would still pass. The transport throws, so the store
+        // is left exactly as it was.
+        var firstRunRequests = 0
+        await PricingCatalog.refreshIfNeeded(now: Date(timeIntervalSince1970: 1_000_000)) { _ in
+            firstRunRequests += 1
+            throw URLError(.notConnectedToInternet)
+        }
+        expect(firstRunRequests == 1, "a never-fetched catalog refreshes on first run")
+
         let stamp = Date(timeIntervalSince1970: 1_784_000_000)
         PricingCatalog.install(
             models: ["claude-opus-4-8": CatalogRates(
@@ -82,6 +95,132 @@ struct PricingCatalogTests {
             cacheCreationPerMillion: 6.25, cacheReadPerMillion: 0.5)], fetchedAt: stamp)
         expect(PricingCatalog.rates(for: "claude-opus-4-8") == nil,
                "install replaces the whole table")
+
+        // Refresh: a 200 installs, and the transport sees no If-None-Match
+        // until an ETag has been stored.
+        let base = Date(timeIntervalSince1970: 1_790_000_000)
+        var seenHeaders: [String?] = []
+
+        func transport(_ status: Int, _ body: Data, _ etag: String?)
+            -> (URLRequest) async throws -> (Data, URLResponse) {
+            { req in
+                seenHeaders.append(req.value(forHTTPHeaderField: "If-None-Match"))
+                var fields: [String: String] = [:]
+                if let etag { fields["ETag"] = etag }
+                let resp = HTTPURLResponse(
+                    url: PricingCatalog.endpoint, statusCode: status,
+                    httpVersion: nil, headerFields: fields)!
+                return (body, resp)
+            }
+        }
+
+        PricingCatalog.install(models: [:], fetchedAt: Date(timeIntervalSince1970: 0))
+        await PricingCatalog.refreshIfNeeded(
+            now: base, fetch: transport(200, json(valid), "\"abc\""))
+        expect(PricingCatalog.rates(for: "claude-opus-4-8")?.inputPerMillion == 5,
+               "200 installs the payload")
+        expect(PricingCatalog.lastFetched == base, "200 records the fetch time")
+
+        // Within 24h the refresh is a no-op — no request at all.
+        let before = seenHeaders.count
+        await PricingCatalog.refreshIfNeeded(
+            now: base.addingTimeInterval(3_600), fetch: transport(200, Data(), nil))
+        expect(seenHeaders.count == before, "refresh inside 24h makes no request")
+
+        // Past 24h it fetches again, now carrying the stored ETag.
+        let later = base.addingTimeInterval(25 * 3_600)
+        await PricingCatalog.refreshIfNeeded(now: later, fetch: transport(304, Data(), nil))
+        expect(seenHeaders.last == "\"abc\"", "stored ETag is sent as If-None-Match")
+        expect(PricingCatalog.lastFetched == later, "304 advances the fetch time")
+        expect(PricingCatalog.rates(for: "claude-opus-4-8")?.inputPerMillion == 5,
+               "304 preserves the payload")
+
+        // A garbage response must not disturb what is already installed.
+        let later2 = later.addingTimeInterval(25 * 3_600)
+        await PricingCatalog.refreshIfNeeded(now: later2, fetch: transport(200, json("{nope"), nil))
+        expect(PricingCatalog.rates(for: "claude-opus-4-8")?.inputPerMillion == 5,
+               "malformed payload leaves the catalog intact")
+        expect(PricingCatalog.lastFetched == later, "rejected payload does not advance the clock")
+
+        // A transport that throws is equally harmless.
+        await PricingCatalog.refreshIfNeeded(now: later2, fetch: { _ in
+            throw URLError(.notConnectedToInternet)
+        })
+        expect(PricingCatalog.rates(for: "claude-opus-4-8")?.inputPerMillion == 5,
+               "network failure leaves the catalog intact")
+
+        // Disk cache: the middle tier of the fallback ladder. Round-trips
+        // through a temp file so the user's real cache is never touched.
+        let tmp = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("codexisland-catalog-test.json")
+        try? FileManager.default.removeItem(at: tmp)
+
+        guard case .payload(let diskPayload) =
+            PricingCatalog.interpret(status: 200, data: json(valid)) else {
+            expect(false, "fixture payload parses")
+            exit(1)
+        }
+        PricingCatalog.persist(diskPayload, etag: "\"disk\"", at: base, to: tmp)
+
+        // Clobber the in-memory ETag without touching the file — `to: nil`
+        // writes nothing. Without this, `loadFromDisk` reassigning the same
+        // value it already holds is unobservable, and both halves of "the
+        // ETag lives with the payload on disk" could be deleted with a green
+        // suite.
+        PricingCatalog.persist(diskPayload, etag: "\"memory\"", at: base, to: nil)
+
+        PricingCatalog.install(models: [:], fetchedAt: Date(timeIntervalSince1970: 0))
+        expect(PricingCatalog.rates(for: "claude-opus-4-8") == nil, "store cleared before load")
+
+        PricingCatalog.loadFromDisk(from: tmp)
+        expect(PricingCatalog.rates(for: "claude-opus-4-8")?.inputPerMillion == 5,
+               "cached payload loads from disk")
+        expect(PricingCatalog.lastFetched == base, "cached fetch time is restored")
+
+        // The ETag has to come back off disk with its payload. If it does not,
+        // the app can hold an ETag for a cache it no longer has, receive 304
+        // for data it does not hold, and sit on the embedded seed forever.
+        var diskHeaders: [String?] = []
+        await PricingCatalog.refreshIfNeeded(now: base.addingTimeInterval(60 * 86_400)) { req in
+            diskHeaders.append(req.value(forHTTPHeaderField: "If-None-Match"))
+            throw URLError(.cancelled)
+        }
+        expect(diskHeaders.last == "\"disk\"", "ETag restored from disk is sent as If-None-Match")
+
+        // A cache whose model map is empty must be ignored, not adopted —
+        // adopting it would price every model at $0.
+        PricingCatalog.persist(
+            CatalogPayload(schemaVersion: 1, generatedAt: "x", models: [:]),
+            etag: nil, at: base, to: tmp)
+        PricingCatalog.loadFromDisk(from: tmp)
+        expect(PricingCatalog.rates(for: "claude-opus-4-8")?.inputPerMillion == 5,
+               "empty-model cache is ignored, previous state survives")
+
+        // Same for a file that is not JSON at all.
+        try? Data("not json".utf8).write(to: tmp)
+        PricingCatalog.loadFromDisk(from: tmp)
+        expect(PricingCatalog.rates(for: "claude-opus-4-8")?.inputPerMillion == 5,
+               "corrupt cache file is ignored, previous state survives")
+
+        // Restore a good file for the assertions that follow.
+        PricingCatalog.persist(diskPayload, etag: "\"disk\"", at: base, to: tmp)
+
+        // A cache written by a future schema is ignored rather than trusted.
+        let futureSchema = CatalogPayload(
+            schemaVersion: 2, generatedAt: "x",
+            models: ["claude-opus-4-8": CatalogRates(
+                displayName: nil, inputPerMillion: 999, outputPerMillion: 999,
+                cacheCreationPerMillion: 999, cacheReadPerMillion: 999)])
+        PricingCatalog.persist(futureSchema, etag: nil, at: base, to: tmp)
+        PricingCatalog.loadFromDisk(from: tmp)
+        expect(PricingCatalog.rates(for: "claude-opus-4-8")?.inputPerMillion == 5,
+               "future-schema cache is ignored, previous state survives")
+
+        // A missing file is a no-op, not a crash or a wipe.
+        try? FileManager.default.removeItem(at: tmp)
+        PricingCatalog.loadFromDisk(from: tmp)
+        expect(PricingCatalog.rates(for: "claude-opus-4-8")?.inputPerMillion == 5,
+               "missing cache file leaves the store alone")
 
         exit(failures == 0 ? 0 : 1)
     }

--- a/Tests/PricingCatalogTests.swift
+++ b/Tests/PricingCatalogTests.swift
@@ -202,6 +202,25 @@ struct PricingCatalogTests {
         expect(PricingCatalog.rates(for: "claude-opus-4-8")?.inputPerMillion == 5,
                "corrupt cache file is ignored, previous state survives")
 
+        // A 304 must carry its timestamp to disk, not just to memory. Without
+        // that, a restart restores the older stamp — and since a stable
+        // catalog answers almost every refresh with 304, the staleness figure
+        // would climb for a user whose prices are simply not changing.
+        PricingCatalog.persist(diskPayload, etag: "\"disk\"", at: base, to: tmp)
+        PricingCatalog.loadFromDisk(from: tmp)
+        let verified = base.addingTimeInterval(90 * 86_400)
+        await PricingCatalog.refreshIfNeeded(now: verified, cache: tmp) { _ in
+            (Data(), HTTPURLResponse(
+                url: PricingCatalog.endpoint, statusCode: 304,
+                httpVersion: nil, headerFields: [:])!)
+        }
+        PricingCatalog.install(models: [:], fetchedAt: Date(timeIntervalSince1970: 0))
+        PricingCatalog.loadFromDisk(from: tmp)
+        expect(PricingCatalog.lastFetched == verified,
+               "304 timestamp survives a reload from disk")
+        expect(PricingCatalog.rates(for: "claude-opus-4-8")?.inputPerMillion == 5,
+               "304 leaves the cached payload alone")
+
         // A cache written by a future schema is ignored rather than trusted.
         let futureSchema = CatalogPayload(
             schemaVersion: 2, generatedAt: "x",

--- a/Tests/PricingPrecedenceTests.swift
+++ b/Tests/PricingPrecedenceTests.swift
@@ -17,7 +17,7 @@ struct PricingPrecedenceTests {
         TokenEvent(
             provider: .claude, timestamp: now, model: model,
             inputTokens: input, outputTokens: 0,
-            cacheCreationTokens: 0, cacheReadTokens: 0, project: nil
+            cacheCreationTokens: 0, cacheReadTokens: 0
         )
     }
 

--- a/Tests/PricingPrecedenceTests.swift
+++ b/Tests/PricingPrecedenceTests.swift
@@ -1,0 +1,73 @@
+import Foundation
+
+/// Locks down catalog-over-seed lookup precedence: the remote catalog decides prices when it has
+/// an entry, the embedded seed covers everything else, and neither can knock
+/// out the other.
+@main
+struct PricingPrecedenceTests {
+    static var failures = 0
+
+    static func expect(_ condition: Bool, _ label: String) {
+        if condition { print("PASS \(label)") } else { print("FAIL \(label)"); failures += 1 }
+    }
+
+    static let now = Date(timeIntervalSince1970: 1_790_000_000)
+
+    static func ev(_ model: String, input: Int = 1_000_000) -> TokenEvent {
+        TokenEvent(
+            provider: .claude, timestamp: now, model: model,
+            inputTokens: input, outputTokens: 0,
+            cacheCreationTokens: 0, cacheReadTokens: 0, project: nil
+        )
+    }
+
+    static func main() {
+        // Runs first, before any install: with no successful fetch the
+        // freshness number falls back to the seed's build date.
+        expect(Pricing.daysSincePricingRefresh(now: now) > 0,
+               "seed date drives freshness before any fetch")
+
+        // Seed-only behavior, unchanged from before the catalog existed.
+        expect(Pricing.cost(for: ev("claude-opus-4-8")) == 5, "seed prices opus at $5/M input")
+        expect(Pricing.isKnown("claude-sonnet-4-5"), "seed model is known")
+        expect(!Pricing.isKnown("totally-made-up"), "unknown model stays unknown")
+
+        // A catalog that disagrees with the seed on one model and adds one the
+        // seed has never heard of.
+        PricingCatalog.install(
+            models: [
+                "claude-opus-4-8": CatalogRates(
+                    displayName: "Opus 4.8", inputPerMillion: 7, outputPerMillion: 25,
+                    cacheCreationPerMillion: 6.25, cacheReadPerMillion: 0.5),
+                "gpt-7-quasar": CatalogRates(
+                    displayName: "GPT-7 Quasar", inputPerMillion: 3, outputPerMillion: 12,
+                    cacheCreationPerMillion: 3, cacheReadPerMillion: 0.3),
+            ],
+            fetchedAt: now.addingTimeInterval(-3 * 86_400)
+        )
+
+        expect(Pricing.cost(for: ev("claude-opus-4-8")) == 7, "remote rate beats the seed")
+        expect(Pricing.cost(for: ev("gpt-7-quasar")) == 3, "remote-only model is priced")
+        expect(Pricing.isKnown("gpt-7-quasar"), "remote-only model is known")
+
+        // The fallback that stops a partial catalog from zeroing out costs.
+        expect(Pricing.cost(for: ev("claude-sonnet-4-5")) == 3, "seed still covers what remote omits")
+        expect(Pricing.isKnown("gpt-5-mini"), "seed-only model stays known")
+
+        // Date-pinned ids canonicalize before lookup, remote included.
+        expect(Pricing.cost(for: ev("claude-opus-4-8-20260101")) == 7,
+               "date-pinned id resolves to the remote entry")
+
+        // Display names: remote wins, the algorithm fills the gap.
+        expect(Pricing.prettyModelName("gpt-7-quasar") == "GPT-7 Quasar",
+               "remote displayName is used")
+        expect(Pricing.prettyModelName("claude-sonnet-4-5") == "Sonnet 4.5",
+               "algorithm covers models the catalog omits")
+
+        // Freshness now tracks the successful fetch, not the seed date.
+        expect(Pricing.daysSincePricingRefresh(now: now) == 3,
+               "freshness counts days since last successful fetch")
+
+        exit(failures == 0 ? 0 : 1)
+    }
+}

--- a/Tests/PricingPrecedenceTests.swift
+++ b/Tests/PricingPrecedenceTests.swift
@@ -22,11 +22,6 @@ struct PricingPrecedenceTests {
     }
 
     static func main() {
-        // Runs first, before any install: with no successful fetch the
-        // freshness number falls back to the seed's build date.
-        expect(Pricing.daysSincePricingRefresh(now: now) > 0,
-               "seed date drives freshness before any fetch")
-
         // Seed-only behavior, unchanged from before the catalog existed.
         expect(Pricing.cost(for: ev("claude-opus-4-8")) == 5, "seed prices opus at $5/M input")
         expect(Pricing.isKnown("claude-sonnet-4-5"), "seed model is known")
@@ -63,10 +58,6 @@ struct PricingPrecedenceTests {
                "remote displayName is used")
         expect(Pricing.prettyModelName("claude-sonnet-4-5") == "Sonnet 4.5",
                "algorithm covers models the catalog omits")
-
-        // Freshness now tracks the successful fetch, not the seed date.
-        expect(Pricing.daysSincePricingRefresh(now: now) == 3,
-               "freshness counts days since last successful fetch")
 
         exit(failures == 0 ? 0 : 1)
     }

--- a/docs/superpowers/plans/2026-07-26-model-catalog-app-client.md
+++ b/docs/superpowers/plans/2026-07-26-model-catalog-app-client.md
@@ -42,6 +42,11 @@
   - `enum CatalogFetchResult: Equatable` — `.payload(CatalogPayload)`, `.unchanged`, `.rejected(String)`
   - `enum PricingCatalog` with `static func interpret(status: Int, data: Data) -> CatalogFetchResult`, `static func install(models: [String: CatalogRates], fetchedAt: Date)`, `static func rates(for canonical: String) -> CatalogRates?`, `static var lastFetched: Date?`
 
+`etag` storage and `markVerified(at:)` belong to Task 2, which is what consumes
+them. Declaring them here would land untested dead code — and dead code inside
+the one file whose correctness argument is "every accessor takes the lock" is
+exactly where it should not sit.
+
 - [ ] **Step 1: Write the failing test**
 
 Create `Tests/PricingCatalogTests.swift`:
@@ -203,7 +208,6 @@ enum PricingCatalog {
     private static let lock = NSLock()
     private static var models: [String: CatalogRates] = [:]
     private static var fetchedAt: Date?
-    private static var etag: String?
 
     static func rates(for canonical: String) -> CatalogRates? {
         lock.lock()
@@ -224,14 +228,6 @@ enum PricingCatalog {
         fetchedAt = stamp
     }
 
-    /// Records that the source was reached and confirmed unchanged, without
-    /// touching the price table.
-    static func markVerified(at stamp: Date) {
-        lock.lock()
-        defer { lock.unlock() }
-        fetchedAt = stamp
-    }
-
     /// Decides what a response means. Pure, so the whole trust boundary is
     /// testable without a network.
     static func interpret(status: Int, data: Data) -> CatalogFetchResult {
@@ -249,16 +245,86 @@ enum PricingCatalog {
 }
 ```
 
-- [ ] **Step 4: Run the tests to verify they pass**
+- [ ] **Step 4: Write the race test**
+
+The lock is the whole reason this store exists rather than a bare `static var`,
+and nothing above would notice if it vanished — every assertion so far runs on
+one thread. A value assertion cannot catch a data race; a sanitizer can.
+
+Create `Tests/PricingCatalogRaceTests.swift`:
+
+```swift
+import Foundation
+
+/// Hammers the store from several threads while a writer swaps the whole
+/// table. Built with `-sanitize=thread`: if the lock in `PricingCatalog` is
+/// removed, TSan reports the race on the backing dictionary and aborts, so
+/// this fails loudly rather than flaking.
+@main
+struct PricingCatalogRaceTests {
+    static func rates(_ input: Double) -> [String: CatalogRates] {
+        ["m": CatalogRates(
+            displayName: "M", inputPerMillion: input, outputPerMillion: input * 2,
+            cacheCreationPerMillion: input, cacheReadPerMillion: 0
+        )]
+    }
+
+    static func main() {
+        let deadline = Date().addingTimeInterval(2)
+        let group = DispatchGroup()
+
+        DispatchQueue.global().async(group: group) {
+            var flip = false
+            while Date() < deadline {
+                PricingCatalog.install(models: rates(flip ? 1 : 9), fetchedAt: Date())
+                flip.toggle()
+            }
+        }
+        for _ in 0..<4 {
+            DispatchQueue.global().async(group: group) {
+                while Date() < deadline {
+                    _ = PricingCatalog.rates(for: "m")
+                    _ = PricingCatalog.lastFetched
+                }
+            }
+        }
+
+        group.wait()
+        print("PASS concurrent install/read is race-free")
+        exit(0)
+    }
+}
+```
+
+Add the target to `scripts/run-tests.sh`:
+
+```bash
+swiftc \
+  -parse-as-library \
+  -sanitize=thread \
+  -o "$OUT_DIR/pricing-catalog-race-tests" \
+  Sources/Cost/PricingCatalog.swift \
+  Tests/PricingCatalogRaceTests.swift
+
+"$OUT_DIR/pricing-catalog-race-tests"
+```
+
+- [ ] **Step 5: Run the tests and prove the race test is load-bearing**
 
 Run: `./scripts/run-tests.sh`
 
-Expected: all existing targets still pass, and `pricing-catalog-tests` prints only PASS lines.
+Expected: all existing targets still pass, `pricing-catalog-tests` prints only
+PASS lines, and `pricing-catalog-race-tests` prints its single PASS.
 
-- [ ] **Step 5: Commit**
+Then verify the new test actually guards the lock: temporarily delete the four
+`lock.lock()` / `defer { lock.unlock() }` pairs in `PricingCatalog.swift`,
+re-run, and confirm TSan reports a data race and the run exits non-zero.
+Restore the lock and confirm green again. Report both outputs.
+
+- [ ] **Step 6: Commit**
 
 ```bash
-git add Sources/Cost/PricingCatalog.swift Tests/PricingCatalogTests.swift scripts/run-tests.sh
+git add Sources/Cost/PricingCatalog.swift Tests/PricingCatalogTests.swift Tests/PricingCatalogRaceTests.swift scripts/run-tests.sh
 git commit -m "feat(cost): add remote pricing catalog store and payload validation"
 ```
 
@@ -396,9 +462,19 @@ Append to `Sources/Cost/PricingCatalog.swift`, inside the `PricingCatalog` enum:
 ```swift
     private static let refreshInterval: TimeInterval = 24 * 60 * 60
 
+    private static var etag: String?
+
     private static var storedETag: String? {
         get { lock.lock(); defer { lock.unlock() }; return etag }
         set { lock.lock(); defer { lock.unlock() }; etag = newValue }
+    }
+
+    /// Records that the source was reached and confirmed unchanged, without
+    /// touching the price table.
+    static func markVerified(at stamp: Date) {
+        lock.lock()
+        defer { lock.unlock() }
+        fetchedAt = stamp
     }
 
     struct CachedCatalog: Codable {

--- a/docs/superpowers/plans/2026-07-26-model-catalog-app-client.md
+++ b/docs/superpowers/plans/2026-07-26-model-catalog-app-client.md
@@ -351,6 +351,19 @@ git commit -m "feat(cost): add remote pricing catalog store and payload validati
 Insert into `Tests/PricingCatalogTests.swift`, immediately before the `exit(...)` line:
 
 ```swift
+        // Runs before anything installs, because `lastFetched` is nil only on
+        // a fresh process — and that is the branch a new install takes. A
+        // guard that bailed out when nothing had ever been fetched would mean
+        // the app never fetches a catalog at all, and every other assertion
+        // in this file would still pass. The transport throws, so the store
+        // is left exactly as it was.
+        var firstRunRequests = 0
+        await PricingCatalog.refreshIfNeeded(now: Date(timeIntervalSince1970: 1_000_000)) { _ in
+            firstRunRequests += 1
+            throw URLError(.notConnectedToInternet)
+        }
+        expect(firstRunRequests == 1, "a never-fetched catalog refreshes on first run")
+
         // Refresh: a 200 installs, and the transport sees no If-None-Match
         // until an ETag has been stored.
         let base = Date(timeIntervalSince1970: 1_790_000_000)
@@ -417,6 +430,13 @@ Insert into `Tests/PricingCatalogTests.swift`, immediately before the `exit(...)
         }
         PricingCatalog.persist(diskPayload, etag: "\"disk\"", at: base, to: tmp)
 
+        // Clobber the in-memory ETag without touching the file — `to: nil`
+        // writes nothing. Without this, `loadFromDisk` reassigning the same
+        // value it already holds is unobservable, and both halves of "the
+        // ETag lives with the payload on disk" could be deleted with a green
+        // suite.
+        PricingCatalog.persist(diskPayload, etag: "\"memory\"", at: base, to: nil)
+
         PricingCatalog.install(models: [:], fetchedAt: Date(timeIntervalSince1970: 0))
         expect(PricingCatalog.rates(for: "claude-opus-4-8") == nil, "store cleared before load")
 
@@ -424,6 +444,34 @@ Insert into `Tests/PricingCatalogTests.swift`, immediately before the `exit(...)
         expect(PricingCatalog.rates(for: "claude-opus-4-8")?.inputPerMillion == 5,
                "cached payload loads from disk")
         expect(PricingCatalog.lastFetched == base, "cached fetch time is restored")
+
+        // The ETag has to come back off disk with its payload. If it does not,
+        // the app can hold an ETag for a cache it no longer has, receive 304
+        // for data it does not hold, and sit on the embedded seed forever.
+        var diskHeaders: [String?] = []
+        await PricingCatalog.refreshIfNeeded(now: base.addingTimeInterval(60 * 86_400)) { req in
+            diskHeaders.append(req.value(forHTTPHeaderField: "If-None-Match"))
+            throw URLError(.cancelled)
+        }
+        expect(diskHeaders.last == "\"disk\"", "ETag restored from disk is sent as If-None-Match")
+
+        // A cache whose model map is empty must be ignored, not adopted —
+        // adopting it would price every model at $0.
+        PricingCatalog.persist(
+            CatalogPayload(schemaVersion: 1, generatedAt: "x", models: [:]),
+            etag: nil, at: base, to: tmp)
+        PricingCatalog.loadFromDisk(from: tmp)
+        expect(PricingCatalog.rates(for: "claude-opus-4-8")?.inputPerMillion == 5,
+               "empty-model cache is ignored, previous state survives")
+
+        // Same for a file that is not JSON at all.
+        try? Data("not json".utf8).write(to: tmp)
+        PricingCatalog.loadFromDisk(from: tmp)
+        expect(PricingCatalog.rates(for: "claude-opus-4-8")?.inputPerMillion == 5,
+               "corrupt cache file is ignored, previous state survives")
+
+        // Restore a good file for the assertions that follow.
+        PricingCatalog.persist(diskPayload, etag: "\"disk\"", at: base, to: tmp)
 
         // A cache written by a future schema is ignored rather than trusted.
         let futureSchema = CatalogPayload(
@@ -566,16 +614,64 @@ Append to `Sources/Cost/PricingCatalog.swift`, inside the `PricingCatalog` enum:
     }
 ```
 
-- [ ] **Step 4: Run the tests to verify they pass**
+- [ ] **Step 4: Extend the race harness to the accessors this task added**
+
+`Tests/PricingCatalogRaceTests.swift` was written in Task 1 and its threads
+touch only Task 1's accessors. `storedETag` and `markVerified(at:)` are new
+shared state, and stripping their locks leaves the sanitizer silent — the
+regression net stops at the task boundary unless it is widened here.
+
+In the writer closure, replace the single `install` call with all three
+mutations so every accessor is exercised:
+
+```swift
+        DispatchQueue.global().async(group: group) {
+            var flip = false
+            while Date() < deadline {
+                PricingCatalog.install(models: rates(flip ? 1 : 9), fetchedAt: Date())
+                PricingCatalog.markVerified(at: Date())
+                // to: nil writes no file — this exists to touch the ETag.
+                PricingCatalog.persist(
+                    CatalogPayload(schemaVersion: 1, generatedAt: "x", models: rates(1)),
+                    etag: flip ? "\"a\"" : "\"b\"", at: Date(), to: nil)
+                flip.toggle()
+            }
+        }
+```
+
+and add a second writer, so the ETag has a competing writer rather than only
+a single one (nothing public reads it):
+
+```swift
+        DispatchQueue.global().async(group: group) {
+            while Date() < deadline {
+                PricingCatalog.persist(
+                    CatalogPayload(schemaVersion: 1, generatedAt: "y", models: rates(2)),
+                    etag: "\"c\"", at: Date(), to: nil)
+            }
+        }
+```
+
+- [ ] **Step 5: Run the tests, and prove the new coverage is load-bearing**
 
 Run: `./scripts/run-tests.sh`
 
-Expected: `pricing-catalog-tests` prints only PASS lines.
+Expected: all targets pass.
 
-- [ ] **Step 5: Commit**
+Then mutate each new lock individually and confirm the sanitizer now catches
+what it previously missed. Remove the lock from `storedETag`'s getter and
+setter, re-run, confirm TSan reports a race and the run exits non-zero.
+Restore. Repeat for `markVerified(at:)`. Report both, and report the same for
+the three assertions added in Step 1 — delete `storedETag = cached.etag` from
+`loadFromDisk`, delete the `etag:` argument from `persist`'s encoded envelope,
+and rewrite the 24h guard so a nil `lastFetched` returns early. Each must fail
+a named assertion. If any mutation leaves the suite green, say so plainly —
+that means the assertion does not pin what it claims.
+
+- [ ] **Step 6: Commit**
 
 ```bash
-git add Sources/Cost/PricingCatalog.swift Tests/PricingCatalogTests.swift
+git add Sources/Cost/PricingCatalog.swift Tests/PricingCatalogTests.swift Tests/PricingCatalogRaceTests.swift
 git commit -m "feat(cost): add disk cache and daily conditional refresh for pricing catalog"
 ```
 

--- a/docs/superpowers/plans/2026-07-26-model-catalog-app-client.md
+++ b/docs/superpowers/plans/2026-07-26-model-catalog-app-client.md
@@ -621,28 +621,41 @@ touch only Task 1's accessors. `storedETag` and `markVerified(at:)` are new
 shared state, and stripping their locks leaves the sanitizer silent — the
 regression net stops at the task boundary unless it is widened here.
 
-In the writer closure, replace the single `install` call with all three
-mutations so every accessor is exercised:
+**One accessor per thread.** This is the load-bearing detail, not a style
+choice. If a single thread calls `install`, `markVerified`, and `persist` in
+sequence, the locks in the calls on either side of an unlocked one establish
+happens-before edges that cover it, and the sanitizer stays silent even though
+the write is genuinely unsynchronized. Give each accessor a thread whose only
+synchronization is its own lock, so removing that lock leaves the thread with
+no edges at all.
+
+Replace the single writer closure with three:
 
 ```swift
         DispatchQueue.global().async(group: group) {
             var flip = false
             while Date() < deadline {
                 PricingCatalog.install(models: rates(flip ? 1 : 9), fetchedAt: Date())
+                flip.toggle()
+            }
+        }
+        DispatchQueue.global().async(group: group) {
+            while Date() < deadline {
                 PricingCatalog.markVerified(at: Date())
-                // to: nil writes no file — this exists to touch the ETag.
+            }
+        }
+        DispatchQueue.global().async(group: group) {
+            var flip = false
+            while Date() < deadline {
+                // to: nil writes no file — this exists only to touch the ETag,
+                // which nothing public reads, so the race it must expose is
+                // write-against-write between this thread and the next.
                 PricingCatalog.persist(
                     CatalogPayload(schemaVersion: 1, generatedAt: "x", models: rates(1)),
                     etag: flip ? "\"a\"" : "\"b\"", at: Date(), to: nil)
                 flip.toggle()
             }
         }
-```
-
-and add a second writer, so the ETag has a competing writer rather than only
-a single one (nothing public reads it):
-
-```swift
         DispatchQueue.global().async(group: group) {
             while Date() < deadline {
                 PricingCatalog.persist(

--- a/docs/superpowers/plans/2026-07-26-model-catalog-app-client.md
+++ b/docs/superpowers/plans/2026-07-26-model-catalog-app-client.md
@@ -1,0 +1,833 @@
+# Model Catalog App Client Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make CodexIsland read model prices from the published catalog, falling back through a disk cache to the embedded table, so a new model no longer needs an app release.
+
+**Architecture:** A new `PricingCatalog` holds the remote price table behind a lock, loads a disk cache at launch, and refreshes over HTTP with `If-None-Match` once a day. `Pricing` keeps its synchronous static API — every call site is untouched — but now consults the catalog before its own table, which is demoted to a build-time seed.
+
+**Tech Stack:** Swift 5 (plain `swiftc`, no SPM/XCTest), Foundation, macOS 13+.
+
+**Spec:** `docs/superpowers/specs/2026-07-26-model-list-api-design.md`
+
+**Companion plan:** `2026-07-26-model-catalog-service.md` publishes the endpoint. This plan can be built and tested before that one ships — every test injects its payload, and at runtime the app just stays on its seed until the URL is live.
+
+## Global Constraints
+
+- **Working repo:** `codex-island`. This plan does **not** touch the catalog repo.
+- **Endpoint:** `https://ericjypark.github.io/codex-island-model-catalog/v1/models.json`
+- **Supported schema version is 1.** Any other value is rejected and the current state is kept.
+- **A failed refresh must never change prices.** Network error, non-200, malformed JSON, wrong schema, or an empty model map all leave the existing catalog in place.
+- **Call sites do not change.** `CostSummary`, `StatCardSummary`, and `CostBlock` must compile untouched.
+- **The catalog store is lock-guarded.** `CostStore` calls `CostSummary.summarize` from two concurrent `Task.detached` blocks (`Sources/Cost/CostStore.swift:67`, `:77`), so `Pricing.cost(for:)` is read off the main actor while the refresh installs a new catalog.
+- **Tests:** bare `swiftc` via `scripts/run-tests.sh`. No XCTest, no SPM. Harness idiom: `@main struct XTests` with `static var failures`, an `expect(_:_:)` helper, and `exit(failures == 0 ? 0 : 1)`.
+- **`build.sh` needs no edit** — it globs `find Sources -name '*.swift'` (`build.sh:49`).
+- **Commits:** Conventional Commits. Never add `Co-Authored-By` lines.
+- **Comments:** default to none. Only explain a WHY that is not obvious.
+
+---
+
+### Task 1: Catalog types, payload validation, and the lock-guarded store
+
+**Files:**
+- Create: `Sources/Cost/PricingCatalog.swift`
+- Create: `Tests/PricingCatalogTests.swift`
+- Modify: `scripts/run-tests.sh`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `struct CatalogRates: Codable, Equatable` — `displayName: String?`, `inputPerMillion`, `outputPerMillion`, `cacheCreationPerMillion`, `cacheReadPerMillion` (all `Double`)
+  - `struct CatalogPayload: Codable, Equatable` — `schemaVersion: Int`, `generatedAt: String`, `models: [String: CatalogRates]`
+  - `enum CatalogFetchResult: Equatable` — `.payload(CatalogPayload)`, `.unchanged`, `.rejected(String)`
+  - `enum PricingCatalog` with `static func interpret(status: Int, data: Data) -> CatalogFetchResult`, `static func install(models: [String: CatalogRates], fetchedAt: Date)`, `static func rates(for canonical: String) -> CatalogRates?`, `static var lastFetched: Date?`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `Tests/PricingCatalogTests.swift`:
+
+```swift
+import Foundation
+
+/// Locks down payload validation and the in-memory store: what the app is
+/// willing to believe from the network, and that a rejection never mutates
+/// what it already has.
+@main
+struct PricingCatalogTests {
+    static var failures = 0
+
+    static func expect(_ condition: Bool, _ label: String) {
+        if condition { print("PASS \(label)") } else { print("FAIL \(label)"); failures += 1 }
+    }
+
+    static func json(_ raw: String) -> Data { Data(raw.utf8) }
+
+    static let valid = """
+    {"schemaVersion":1,"generatedAt":"2026-07-26T01:00:00Z","models":{
+      "claude-opus-4-8":{"displayName":"Opus 4.8","inputPerMillion":5,
+        "outputPerMillion":25,"cacheCreationPerMillion":6.25,"cacheReadPerMillion":0.5}}}
+    """
+
+    static func main() {
+        // A well-formed v1 payload is accepted and decoded.
+        if case .payload(let p) = PricingCatalog.interpret(status: 200, data: json(valid)) {
+            expect(p.models.count == 1, "valid payload decodes one model")
+            expect(p.models["claude-opus-4-8"]?.inputPerMillion == 5, "rates decode")
+            expect(p.models["claude-opus-4-8"]?.displayName == "Opus 4.8", "displayName decodes")
+        } else {
+            expect(false, "valid payload accepted")
+        }
+
+        expect(PricingCatalog.interpret(status: 304, data: Data()) == .unchanged,
+               "304 reports unchanged")
+
+        // Everything below must be rejected — each one would otherwise zero
+        // out or corrupt the user's dollar totals.
+        let rejects: [(String, CatalogFetchResult)] = [
+            ("HTTP 500", PricingCatalog.interpret(status: 500, data: json(valid))),
+            ("HTTP 404", PricingCatalog.interpret(status: 404, data: Data())),
+            ("malformed JSON", PricingCatalog.interpret(status: 200, data: json("{nope"))),
+            ("wrong schema", PricingCatalog.interpret(
+                status: 200,
+                data: json(#"{"schemaVersion":2,"generatedAt":"x","models":{"a":{"inputPerMillion":1,"outputPerMillion":1,"cacheCreationPerMillion":1,"cacheReadPerMillion":1}}}"#))),
+            ("empty catalog", PricingCatalog.interpret(
+                status: 200,
+                data: json(#"{"schemaVersion":1,"generatedAt":"x","models":{}}"#))),
+        ]
+        for (label, result) in rejects {
+            if case .rejected = result { print("PASS rejects \(label)") }
+            else { print("FAIL rejects \(label)"); failures += 1 }
+        }
+
+        // displayName is optional — a payload without it still decodes.
+        if case .payload(let p) = PricingCatalog.interpret(
+            status: 200,
+            data: json(#"{"schemaVersion":1,"generatedAt":"x","models":{"gpt-9":{"inputPerMillion":1,"outputPerMillion":2,"cacheCreationPerMillion":1,"cacheReadPerMillion":0}}}"#)
+        ) {
+            expect(p.models["gpt-9"]?.displayName == nil, "absent displayName decodes as nil")
+        } else {
+            expect(false, "payload without displayName accepted")
+        }
+
+        // Store round trip.
+        expect(PricingCatalog.lastFetched == nil, "store starts empty")
+        expect(PricingCatalog.rates(for: "claude-opus-4-8") == nil, "empty store returns nil")
+
+        let stamp = Date(timeIntervalSince1970: 1_784_000_000)
+        PricingCatalog.install(
+            models: ["claude-opus-4-8": CatalogRates(
+                displayName: "Opus 4.8", inputPerMillion: 5, outputPerMillion: 25,
+                cacheCreationPerMillion: 6.25, cacheReadPerMillion: 0.5)],
+            fetchedAt: stamp
+        )
+        expect(PricingCatalog.rates(for: "claude-opus-4-8")?.outputPerMillion == 25,
+               "installed rates are readable")
+        expect(PricingCatalog.lastFetched == stamp, "install records the fetch time")
+        expect(PricingCatalog.rates(for: "not-a-model") == nil, "unknown id returns nil")
+
+        // Installing replaces wholesale rather than merging.
+        PricingCatalog.install(models: ["gpt-5.6": CatalogRates(
+            displayName: nil, inputPerMillion: 5, outputPerMillion: 30,
+            cacheCreationPerMillion: 6.25, cacheReadPerMillion: 0.5)], fetchedAt: stamp)
+        expect(PricingCatalog.rates(for: "claude-opus-4-8") == nil,
+               "install replaces the whole table")
+
+        exit(failures == 0 ? 0 : 1)
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Add the target to `scripts/run-tests.sh`, appending at the end of the file:
+
+```bash
+swiftc \
+  -parse-as-library \
+  -o "$OUT_DIR/pricing-catalog-tests" \
+  Sources/Cost/PricingCatalog.swift \
+  Tests/PricingCatalogTests.swift
+
+"$OUT_DIR/pricing-catalog-tests"
+```
+
+Run: `./scripts/run-tests.sh`
+
+Expected: FAIL at compilation — `cannot find 'PricingCatalog' in scope`.
+
+- [ ] **Step 3: Write the types and the store**
+
+Create `Sources/Cost/PricingCatalog.swift`:
+
+```swift
+import Foundation
+
+struct CatalogRates: Codable, Equatable {
+    let displayName: String?
+    let inputPerMillion: Double
+    let outputPerMillion: Double
+    let cacheCreationPerMillion: Double
+    let cacheReadPerMillion: Double
+}
+
+struct CatalogPayload: Codable, Equatable {
+    let schemaVersion: Int
+    let generatedAt: String
+    let models: [String: CatalogRates]
+}
+
+enum CatalogFetchResult: Equatable {
+    case payload(CatalogPayload)
+    case unchanged
+    case rejected(String)
+}
+
+/// Remote model price table, refreshed daily from the published catalog.
+///
+/// `Pricing` reads this before its own embedded seed, so anything installed
+/// here decides what the user is charged on screen. Every path that fails to
+/// produce a complete, current payload therefore leaves the previous state
+/// untouched rather than installing something partial.
+enum PricingCatalog {
+    static let supportedSchemaVersion = 1
+
+    /// Literal, known-good URL — the same force-unwrap idiom `UsageFetcher`
+    /// uses for its endpoints.
+    static let endpoint = URL(
+        string: "https://ericjypark.github.io/codex-island-model-catalog/v1/models.json"
+    )!
+
+    /// `CostStore` summarizes on two concurrent detached tasks, so reads land
+    /// off the main actor while a refresh installs. The lock is what keeps
+    /// that from being a data race.
+    private static let lock = NSLock()
+    private static var models: [String: CatalogRates] = [:]
+    private static var fetchedAt: Date?
+    private static var etag: String?
+
+    static func rates(for canonical: String) -> CatalogRates? {
+        lock.lock()
+        defer { lock.unlock() }
+        return models[canonical]
+    }
+
+    static var lastFetched: Date? {
+        lock.lock()
+        defer { lock.unlock() }
+        return fetchedAt
+    }
+
+    static func install(models newModels: [String: CatalogRates], fetchedAt stamp: Date) {
+        lock.lock()
+        defer { lock.unlock() }
+        models = newModels
+        fetchedAt = stamp
+    }
+
+    /// Records that the source was reached and confirmed unchanged, without
+    /// touching the price table.
+    static func markVerified(at stamp: Date) {
+        lock.lock()
+        defer { lock.unlock() }
+        fetchedAt = stamp
+    }
+
+    /// Decides what a response means. Pure, so the whole trust boundary is
+    /// testable without a network.
+    static func interpret(status: Int, data: Data) -> CatalogFetchResult {
+        if status == 304 { return .unchanged }
+        guard status == 200 else { return .rejected("HTTP \(status)") }
+        guard let payload = try? JSONDecoder().decode(CatalogPayload.self, from: data) else {
+            return .rejected("malformed JSON")
+        }
+        guard payload.schemaVersion == supportedSchemaVersion else {
+            return .rejected("unsupported schemaVersion \(payload.schemaVersion)")
+        }
+        guard !payload.models.isEmpty else { return .rejected("empty catalog") }
+        return .payload(payload)
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `./scripts/run-tests.sh`
+
+Expected: all existing targets still pass, and `pricing-catalog-tests` prints only PASS lines.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/Cost/PricingCatalog.swift Tests/PricingCatalogTests.swift scripts/run-tests.sh
+git commit -m "feat(cost): add remote pricing catalog store and payload validation"
+```
+
+---
+
+### Task 2: Disk cache and the network refresh
+
+**Files:**
+- Modify: `Sources/Cost/PricingCatalog.swift`
+- Modify: `Tests/PricingCatalogTests.swift`
+
+**Interfaces:**
+- Consumes: everything from Task 1.
+- Produces:
+  - `struct CachedCatalog: Codable` — `payload: CatalogPayload`, `etag: String?`, `fetchedAt: Date`
+  - `PricingCatalog.cacheURL() -> URL?`
+  - `PricingCatalog.loadFromDisk(from: URL?)` — parameter defaults to `cacheURL()`
+  - `PricingCatalog.persist(_:etag:at:to:)` — parameter defaults to `cacheURL()`
+  - `PricingCatalog.refreshIfNeeded(now:fetch:) async`
+  - `PricingCatalog.startAutoRefresh()` (`@MainActor`)
+
+- [ ] **Step 1: Write the failing test**
+
+Insert into `Tests/PricingCatalogTests.swift`, immediately before the `exit(...)` line:
+
+```swift
+        // Refresh: a 200 installs, and the transport sees no If-None-Match
+        // until an ETag has been stored.
+        let base = Date(timeIntervalSince1970: 1_790_000_000)
+        var seenHeaders: [String?] = []
+
+        func transport(_ status: Int, _ body: Data, _ etag: String?)
+            -> (URLRequest) async throws -> (Data, URLResponse) {
+            { req in
+                seenHeaders.append(req.value(forHTTPHeaderField: "If-None-Match"))
+                var fields: [String: String] = [:]
+                if let etag { fields["ETag"] = etag }
+                let resp = HTTPURLResponse(
+                    url: PricingCatalog.endpoint, statusCode: status,
+                    httpVersion: nil, headerFields: fields)!
+                return (body, resp)
+            }
+        }
+
+        PricingCatalog.install(models: [:], fetchedAt: Date(timeIntervalSince1970: 0))
+        await PricingCatalog.refreshIfNeeded(
+            now: base, fetch: transport(200, json(valid), "\"abc\""))
+        expect(PricingCatalog.rates(for: "claude-opus-4-8")?.inputPerMillion == 5,
+               "200 installs the payload")
+        expect(PricingCatalog.lastFetched == base, "200 records the fetch time")
+
+        // Within 24h the refresh is a no-op — no request at all.
+        let before = seenHeaders.count
+        await PricingCatalog.refreshIfNeeded(
+            now: base.addingTimeInterval(3_600), fetch: transport(200, Data(), nil))
+        expect(seenHeaders.count == before, "refresh inside 24h makes no request")
+
+        // Past 24h it fetches again, now carrying the stored ETag.
+        let later = base.addingTimeInterval(25 * 3_600)
+        await PricingCatalog.refreshIfNeeded(now: later, fetch: transport(304, Data(), nil))
+        expect(seenHeaders.last == "\"abc\"", "stored ETag is sent as If-None-Match")
+        expect(PricingCatalog.lastFetched == later, "304 advances the fetch time")
+        expect(PricingCatalog.rates(for: "claude-opus-4-8")?.inputPerMillion == 5,
+               "304 preserves the payload")
+
+        // A garbage response must not disturb what is already installed.
+        let later2 = later.addingTimeInterval(25 * 3_600)
+        await PricingCatalog.refreshIfNeeded(now: later2, fetch: transport(200, json("{nope"), nil))
+        expect(PricingCatalog.rates(for: "claude-opus-4-8")?.inputPerMillion == 5,
+               "malformed payload leaves the catalog intact")
+        expect(PricingCatalog.lastFetched == later, "rejected payload does not advance the clock")
+
+        // A transport that throws is equally harmless.
+        await PricingCatalog.refreshIfNeeded(now: later2, fetch: { _ in
+            throw URLError(.notConnectedToInternet)
+        })
+        expect(PricingCatalog.rates(for: "claude-opus-4-8")?.inputPerMillion == 5,
+               "network failure leaves the catalog intact")
+
+        // Disk cache: the middle tier of the fallback ladder. Round-trips
+        // through a temp file so the user's real cache is never touched.
+        let tmp = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("codexisland-catalog-test.json")
+        try? FileManager.default.removeItem(at: tmp)
+
+        guard case .payload(let diskPayload) =
+            PricingCatalog.interpret(status: 200, data: json(valid)) else {
+            expect(false, "fixture payload parses")
+            exit(1)
+        }
+        PricingCatalog.persist(diskPayload, etag: "\"disk\"", at: base, to: tmp)
+
+        PricingCatalog.install(models: [:], fetchedAt: Date(timeIntervalSince1970: 0))
+        expect(PricingCatalog.rates(for: "claude-opus-4-8") == nil, "store cleared before load")
+
+        PricingCatalog.loadFromDisk(from: tmp)
+        expect(PricingCatalog.rates(for: "claude-opus-4-8")?.inputPerMillion == 5,
+               "cached payload loads from disk")
+        expect(PricingCatalog.lastFetched == base, "cached fetch time is restored")
+
+        // A cache written by a future schema is ignored rather than trusted.
+        let futureSchema = CatalogPayload(
+            schemaVersion: 2, generatedAt: "x",
+            models: ["claude-opus-4-8": CatalogRates(
+                displayName: nil, inputPerMillion: 999, outputPerMillion: 999,
+                cacheCreationPerMillion: 999, cacheReadPerMillion: 999)])
+        PricingCatalog.persist(futureSchema, etag: nil, at: base, to: tmp)
+        PricingCatalog.loadFromDisk(from: tmp)
+        expect(PricingCatalog.rates(for: "claude-opus-4-8")?.inputPerMillion == 5,
+               "future-schema cache is ignored, previous state survives")
+
+        // A missing file is a no-op, not a crash or a wipe.
+        try? FileManager.default.removeItem(at: tmp)
+        PricingCatalog.loadFromDisk(from: tmp)
+        expect(PricingCatalog.rates(for: "claude-opus-4-8")?.inputPerMillion == 5,
+               "missing cache file leaves the store alone")
+```
+
+Change the harness signature so it can await — replace `static func main() {` with:
+
+```swift
+    static func main() async {
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `./scripts/run-tests.sh`
+
+Expected: FAIL at compilation — `type 'PricingCatalog' has no member 'refreshIfNeeded'`.
+
+- [ ] **Step 3: Write the disk cache and refresh**
+
+Append to `Sources/Cost/PricingCatalog.swift`, inside the `PricingCatalog` enum:
+
+```swift
+    private static let refreshInterval: TimeInterval = 24 * 60 * 60
+
+    private static var storedETag: String? {
+        get { lock.lock(); defer { lock.unlock() }; return etag }
+        set { lock.lock(); defer { lock.unlock() }; etag = newValue }
+    }
+
+    struct CachedCatalog: Codable {
+        let payload: CatalogPayload
+        let etag: String?
+        let fetchedAt: Date
+    }
+
+    /// `Caches` is purgeable by macOS. Losing this file costs one refetch and
+    /// drops to the embedded seed in the meantime, which is the intended
+    /// behavior — mirrors `LogParseCache.cacheURL`.
+    static func cacheURL() -> URL? {
+        let fm = FileManager.default
+        guard let caches = fm.urls(for: .cachesDirectory, in: .userDomainMask).first else {
+            return nil
+        }
+        let dir = caches.appendingPathComponent("dev.codexisland.CodexIsland", isDirectory: true)
+        try? fm.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir.appendingPathComponent("model-prices.json")
+    }
+
+    /// The URL parameter exists so tests can round-trip through a temp file
+    /// instead of the user's real cache.
+    static func loadFromDisk(from url: URL? = cacheURL()) {
+        guard let url,
+              let data = try? Data(contentsOf: url),
+              let cached = try? JSONDecoder().decode(CachedCatalog.self, from: data),
+              cached.payload.schemaVersion == supportedSchemaVersion,
+              !cached.payload.models.isEmpty
+        else { return }
+        storedETag = cached.etag
+        install(models: cached.payload.models, fetchedAt: cached.fetchedAt)
+    }
+
+    static func persist(
+        _ payload: CatalogPayload, etag newETag: String?, at stamp: Date,
+        to url: URL? = cacheURL()
+    ) {
+        storedETag = newETag
+        guard let url,
+              let data = try? JSONEncoder().encode(
+                CachedCatalog(payload: payload, etag: newETag, fetchedAt: stamp))
+        else { return }
+        try? data.write(to: url, options: .atomic)
+    }
+
+    static func refreshIfNeeded(
+        now: Date = Date(),
+        fetch: (URLRequest) async throws -> (Data, URLResponse) = {
+            try await URLSession.shared.data(for: $0)
+        }
+    ) async {
+        if let last = lastFetched, now.timeIntervalSince(last) < refreshInterval { return }
+
+        var request = URLRequest(url: endpoint)
+        request.timeoutInterval = 15
+        if let tag = storedETag { request.setValue(tag, forHTTPHeaderField: "If-None-Match") }
+
+        guard let (data, response) = try? await fetch(request),
+              let http = response as? HTTPURLResponse
+        else { return }
+
+        switch interpret(status: http.statusCode, data: data) {
+        case .payload(let payload):
+            install(models: payload.models, fetchedAt: now)
+            persist(payload, etag: http.value(forHTTPHeaderField: "ETag"), at: now)
+        case .unchanged:
+            markVerified(at: now)
+        case .rejected:
+            // Deliberately silent and deliberately inert: staleness already
+            // surfaces in Settings, and the previous catalog stays correct.
+            break
+        }
+    }
+
+    @MainActor
+    private static var refreshTimer: Timer?
+
+    /// Ticks every 6h against a 24h staleness threshold, so a laptop that
+    /// slept through its window catches up at the next wake rather than
+    /// waiting another full day.
+    @MainActor
+    static func startAutoRefresh() {
+        Task { await refreshIfNeeded() }
+        refreshTimer?.invalidate()
+        refreshTimer = Timer.scheduledTimer(withTimeInterval: 6 * 60 * 60, repeats: true) { _ in
+            Task { await refreshIfNeeded() }
+        }
+    }
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `./scripts/run-tests.sh`
+
+Expected: `pricing-catalog-tests` prints only PASS lines.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/Cost/PricingCatalog.swift Tests/PricingCatalogTests.swift
+git commit -m "feat(cost): add disk cache and daily conditional refresh for pricing catalog"
+```
+
+---
+
+### Task 3: Demote the embedded table to a seed
+
+**Files:**
+- Modify: `Sources/Cost/Pricing.swift`
+- Create: `Tests/PricingTests.swift`
+- Modify: `scripts/run-tests.sh`
+
+**Interfaces:**
+- Consumes: `PricingCatalog.rates(for:)`, `PricingCatalog.lastFetched` from Tasks 1–2.
+- Produces:
+  - `Pricing.seedSnapshotDate` (renamed from `snapshotDate`)
+  - `Pricing.daysSincePricingRefresh(now:) -> Int` (replaces `daysSinceSnapshot`)
+  - `Pricing.cost(for:)`, `isKnown(_:)`, `prettyModelName(_:)` — same signatures, catalog-first behavior
+
+- [ ] **Step 1: Write the failing test**
+
+Create `Tests/PricingTests.swift`:
+
+```swift
+import Foundation
+
+/// Locks down lookup precedence: the remote catalog decides prices when it
+/// has an entry, the embedded seed covers everything else, and neither can
+/// be knocked out by the other.
+@main
+struct PricingTests {
+    static var failures = 0
+
+    static func expect(_ condition: Bool, _ label: String) {
+        if condition { print("PASS \(label)") } else { print("FAIL \(label)"); failures += 1 }
+    }
+
+    static let now = Date(timeIntervalSince1970: 1_790_000_000)
+
+    static func ev(_ model: String, input: Int = 1_000_000) -> TokenEvent {
+        TokenEvent(
+            provider: .claude, timestamp: now, model: model,
+            inputTokens: input, outputTokens: 0,
+            cacheCreationTokens: 0, cacheReadTokens: 0, project: nil
+        )
+    }
+
+    static func main() {
+        // Runs first, before any install: with no successful fetch the
+        // freshness number falls back to the seed's build date.
+        expect(Pricing.daysSincePricingRefresh(now: now) > 0,
+               "seed date drives freshness before any fetch")
+
+        // Seed-only behavior still works untouched.
+        expect(Pricing.cost(for: ev("claude-opus-4-8")) == 5, "seed prices opus at $5/M input")
+        expect(Pricing.isKnown("claude-sonnet-4-5"), "seed model is known")
+        expect(!Pricing.isKnown("totally-made-up"), "unknown model stays unknown")
+
+        // Install a catalog that disagrees with the seed on one model and
+        // adds one the seed has never heard of.
+        PricingCatalog.install(
+            models: [
+                "claude-opus-4-8": CatalogRates(
+                    displayName: "Opus 4.8", inputPerMillion: 7, outputPerMillion: 25,
+                    cacheCreationPerMillion: 6.25, cacheReadPerMillion: 0.5),
+                "gpt-7-quasar": CatalogRates(
+                    displayName: "GPT-7 Quasar", inputPerMillion: 3, outputPerMillion: 12,
+                    cacheCreationPerMillion: 3, cacheReadPerMillion: 0.3),
+            ],
+            fetchedAt: now.addingTimeInterval(-3 * 86_400)
+        )
+
+        expect(Pricing.cost(for: ev("claude-opus-4-8")) == 7, "remote rate beats the seed")
+        expect(Pricing.cost(for: ev("gpt-7-quasar")) == 3, "remote-only model is priced")
+        expect(Pricing.isKnown("gpt-7-quasar"), "remote-only model is known")
+
+        // Seed models absent from the catalog keep working — this is the
+        // fallback that stops a partial payload from zeroing out costs.
+        expect(Pricing.cost(for: ev("claude-sonnet-4-5")) == 3, "seed still covers what remote omits")
+        expect(Pricing.isKnown("gpt-5-mini"), "seed-only model stays known")
+
+        // Date-pinned ids canonicalize before lookup, remote included.
+        expect(Pricing.cost(for: ev("claude-opus-4-8-20260101")) == 7,
+               "date-pinned id resolves to the remote entry")
+
+        // Display names: remote wins, algorithm fills the gap.
+        expect(Pricing.prettyModelName("gpt-7-quasar") == "GPT-7 Quasar",
+               "remote displayName is used")
+        expect(Pricing.prettyModelName("claude-sonnet-4-5") == "Sonnet 4.5",
+               "algorithm covers models the catalog omits")
+
+        // Freshness now tracks the successful fetch, not the seed date.
+        expect(Pricing.daysSincePricingRefresh(now: now) == 3,
+               "freshness counts days since last successful fetch")
+
+        exit(failures == 0 ? 0 : 1)
+    }
+}
+```
+
+- [ ] **Step 2: Add the test target and run it to verify it fails**
+
+Append to `scripts/run-tests.sh`:
+
+```bash
+swiftc \
+  -parse-as-library \
+  -o "$OUT_DIR/pricing-tests" \
+  Sources/Cost/TokenEvent.swift \
+  Sources/Cost/PricingCatalog.swift \
+  Sources/Cost/Pricing.swift \
+  Tests/PricingTests.swift
+
+"$OUT_DIR/pricing-tests"
+```
+
+Run: `./scripts/run-tests.sh`
+
+Expected: FAIL at compilation — `type 'Pricing' has no member 'daysSincePricingRefresh'`.
+
+- [ ] **Step 3: Rename the table and snapshot constant**
+
+In `Sources/Cost/Pricing.swift`:
+
+- Change `static let snapshotDate = "2026-07-10"` to `static let seedSnapshotDate = "2026-07-10"`.
+- Change `private static let table: [String: Rates] = [` to `private static let seedTable: [String: Rates] = [`. Leave every entry in it exactly as-is.
+- Replace the doc comment above `enum Pricing` with:
+
+```swift
+/// Model prices in USD per million tokens.
+///
+/// The live source is the published catalog (see `PricingCatalog`); the
+/// table below is the build-time seed used until the first successful fetch,
+/// and as the permanent fallback for anything the catalog omits. Unknown
+/// models silently price to $0 — same behavior as ccusage when LiteLLM has
+/// no entry.
+///
+/// To refresh the seed: re-fetch the four rates per model from
+/// `https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json`
+/// and bump `seedSnapshotDate`. This is housekeeping, not a release
+/// requirement — the catalog covers new models without an app update.
+```
+
+- [ ] **Step 4: Route lookups through the catalog**
+
+Replace the bodies of `cost(for:)` and `isKnown(_:)`, and add the resolver. In `Sources/Cost/Pricing.swift`:
+
+```swift
+    /// Remote catalog first, embedded seed second. The seed is what keeps a
+    /// catalog that omits a model from silently pricing it at $0.
+    private static func resolvedRates(for canonical: String) -> Rates? {
+        if let remote = PricingCatalog.rates(for: canonical) {
+            return Rates(
+                inputPerMillion: remote.inputPerMillion,
+                outputPerMillion: remote.outputPerMillion,
+                cacheCreationPerMillion: remote.cacheCreationPerMillion,
+                cacheReadPerMillion: remote.cacheReadPerMillion
+            )
+        }
+        return seedTable[canonical]
+    }
+
+    static func cost(for event: TokenEvent) -> Double {
+        guard let rates = resolvedRates(for: canonicalModel(event.model)) else { return 0 }
+
+        let input = Double(event.inputTokens) / 1_000_000 * rates.inputPerMillion
+        let output = Double(event.outputTokens) / 1_000_000 * rates.outputPerMillion
+        let cacheCreate = Double(event.cacheCreationTokens) / 1_000_000 * rates.cacheCreationPerMillion
+        let cacheRead = Double(event.cacheReadTokens) / 1_000_000 * rates.cacheReadPerMillion
+
+        return input + output + cacheCreate + cacheRead
+    }
+
+    static func isKnown(_ rawModel: String) -> Bool {
+        resolvedRates(for: canonicalModel(rawModel)) != nil
+    }
+```
+
+- [ ] **Step 5: Replace the freshness computation**
+
+Delete the whole `static var daysSinceSnapshot: Int { ... }` block and put this in its place:
+
+```swift
+    private static let snapshotFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "yyyy-MM-dd"
+        f.timeZone = TimeZone(identifier: "UTC")
+        f.locale = Locale(identifier: "en_US_POSIX")
+        return f
+    }()
+
+    /// Days since the app last reached the catalog, falling back to the age
+    /// of the embedded seed when no fetch has ever succeeded.
+    ///
+    /// Deliberately not the catalog's own `generatedAt`: the sync bot commits
+    /// only when prices change, so a long-stable table would read as months
+    /// stale while the app was in fact checking daily and finding nothing new.
+    /// "How long since I reached the source" is what actually predicts whether
+    /// these numbers are wrong.
+    static func daysSincePricingRefresh(now: Date = Date()) -> Int {
+        let origin = PricingCatalog.lastFetched
+            ?? snapshotFormatter.date(from: seedSnapshotDate)
+        guard let origin else { return 0 }
+        var calendar = Calendar(identifier: .gregorian)
+        if let utc = TimeZone(identifier: "UTC") { calendar.timeZone = utc }
+        return max(0, calendar.dateComponents([.day], from: origin, to: now).day ?? 0)
+    }
+```
+
+- [ ] **Step 6: Let the catalog supply display names**
+
+Insert at the very top of `prettyModelName(_:)`, before the `claude-` branch:
+
+```swift
+        if let name = PricingCatalog.rates(for: canonical)?.displayName, !name.isEmpty {
+            return name
+        }
+```
+
+- [ ] **Step 7: Add `PricingCatalog.swift` to the two existing targets that compile `Pricing.swift`**
+
+In `scripts/run-tests.sh`, add the line `  Sources/Cost/PricingCatalog.swift \` immediately above `  Sources/Cost/Pricing.swift \` in **both** the `stat-card-summary-tests` and `stat-card-render-tests` invocations.
+
+- [ ] **Step 8: Run the full suite**
+
+Run: `./scripts/run-tests.sh`
+
+Expected: every target passes, including the pre-existing `stat-card-summary-tests` and `stat-card-render-tests` — they exercise `Pricing.cost(for:)` with no catalog installed, which proves the seed fallback still works.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add Sources/Cost/Pricing.swift Tests/PricingTests.swift scripts/run-tests.sh
+git commit -m "feat(cost): resolve prices from remote catalog before embedded seed"
+```
+
+---
+
+### Task 4: Wire into launch, update Settings, disclose in README
+
+**Files:**
+- Modify: `Sources/App.swift:21-51`
+- Modify: `Sources/Views/SettingsView.swift:607`
+- Modify: `README.md:273-286`
+
+**Interfaces:**
+- Consumes: `PricingCatalog.loadFromDisk()`, `PricingCatalog.startAutoRefresh()`, `Pricing.daysSincePricingRefresh(now:)`.
+- Produces: nothing downstream.
+
+- [ ] **Step 1: Load the cache before anything summarizes**
+
+In `Sources/App.swift`, insert as the **first** statement of `applicationDidFinishLaunching`, above `NSApp.setActivationPolicy(.accessory)`:
+
+```swift
+        // Before any window or store exists: the first cost scan must price
+        // against the cached catalog, not fall back to the seed and then
+        // silently change its numbers a moment later.
+        PricingCatalog.loadFromDisk()
+```
+
+- [ ] **Step 2: Start the refresh alongside the other stores**
+
+In the same function, add immediately after `CostStore.shared.startAutoRefresh()`:
+
+```swift
+        PricingCatalog.startAutoRefresh()
+```
+
+- [ ] **Step 3: Point the Settings subtitle at the new freshness number**
+
+In `Sources/Views/SettingsView.swift:607`, change:
+
+```swift
+        let days = Pricing.daysSinceSnapshot
+```
+
+to:
+
+```swift
+        let days = Pricing.daysSincePricingRefresh()
+```
+
+Leave `pricingFreshnessThreshold` and all three `L10n.tr` strings exactly as they are — the wording still reads correctly, and no localization keys change.
+
+- [ ] **Step 4: Build the app**
+
+Run: `./build.sh`
+
+Expected: builds clean with no warnings about `PricingCatalog`. `build.sh` globs `Sources/**/*.swift`, so the new file needs no registration.
+
+- [ ] **Step 5: Verify against a real fetch**
+
+```bash
+curl -sS https://ericjypark.github.io/codex-island-model-catalog/v1/models.json | python3 -c "import json,sys; d=json.load(sys.stdin); print(d['schemaVersion'], len(d['models']))"
+```
+
+Expected: `1` and a model count. If the companion service plan has not shipped yet, this 404s — that is fine, and the app correctly stays on its seed. Skip to Step 6 and revisit after the service is live.
+
+Then launch the built app, open Settings, and confirm the Cost row reads `last scan … ` with no `pricing data Nd old` suffix (a fresh fetch means 0 days).
+
+- [ ] **Step 6: Disclose the new network destination in the README**
+
+The Privacy section currently implies the app talks only to `chatgpt.com` and `api.anthropic.com`. In `README.md`, inside the `## Privacy` list, add after the line `- No credentials are stored by CodexIsland.`:
+
+```markdown
+- Model prices are fetched once a day from a public GitHub-hosted catalog
+  ([codex-island-model-catalog](https://github.com/ericjypark/codex-island-model-catalog)).
+  The request carries no identifier, no token, and no usage data — it is a
+  plain GET for a static JSON file, and the app works from a local cache
+  when it fails.
+```
+
+Leave `- No app telemetry.` and `- No app analytics.` untouched. Both remain true.
+
+- [ ] **Step 7: Run the full suite one more time and commit**
+
+```bash
+./scripts/run-tests.sh
+git add Sources/App.swift Sources/Views/SettingsView.swift README.md
+git commit -m "feat(cost): load pricing catalog at launch and disclose the fetch"
+```
+
+---
+
+## Done when
+
+- `./scripts/run-tests.sh` passes every target, including the two pre-existing stat-card targets.
+- `./build.sh` succeeds and the app launches.
+- With the endpoint live: Settings shows no staleness suffix, and per-model rows use catalog display names.
+- With the network unplugged and the cache deleted (`rm ~/Library/Caches/dev.codexisland.CodexIsland/model-prices.json`): the app still shows non-zero costs, priced from the seed.
+- `grep -n "No app telemetry" README.md` still matches.

--- a/docs/superpowers/plans/2026-07-26-model-catalog-service.md
+++ b/docs/superpowers/plans/2026-07-26-model-catalog-service.md
@@ -1,0 +1,1717 @@
+# Model Catalog Service Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Publish a bot-maintained, publicly auditable model price catalog at `https://ericjypark.github.io/codex-island-model-catalog/v1/models.json` so the macOS app stops needing a release per new model.
+
+**Architecture:** A Go binary runs as a k3s CronJob every 6 hours on the maintainer's Raspberry Pi. It clones the catalog repo, fetches LiteLLM's price table, selects and converts the models we track, applies hand-maintained overrides, runs a sanity gate, and commits `v1/models.json` only when the price data actually changed. GitHub Pages serves the file. Nothing on the Pi is reachable from the internet.
+
+**Tech Stack:** Go 1.26 (standard library only), Docker, k3s, GitHub Actions, GitHub Pages.
+
+**Spec:** `docs/superpowers/specs/2026-07-26-model-list-api-design.md` (in the `codex-island` repo).
+
+**Companion plan:** `2026-07-26-model-catalog-app-client.md` implements the macOS consumer. It can be built in parallel — the app falls back to its embedded seed until this service is live.
+
+## Global Constraints
+
+- **Working repo:** `ericjypark/codex-island-model-catalog`. This plan does **not** touch the `codex-island` app repo.
+- **Go standard library only.** No third-party modules. `go.mod` must have an empty `require` block.
+- **Schema version is 1.** Any breaking payload change ships at `/v2/models.json`; `/v1/` keeps its shape forever.
+- **The bot never removes a model.** If LiteLLM drops an entry, the published value stays.
+- **`CanonicalID` and `DisplayName` must match `Pricing.swift` exactly.** The macOS app canonicalizes before lookup; a disagreement means silent lookup misses and $0 costs.
+- **Container image:** `ghcr.io/ericjypark/codex-island-model-catalog:<git-sha>`, matching the `ghcr.io/ericjypark/<name>:<sha>` convention already used on this cluster.
+- **Kubernetes namespace:** `codexisland`.
+- **Commits:** Conventional Commits (`feat:`, `fix:`, `chore:`, `test:`, `docs:`). Never add `Co-Authored-By` lines.
+- **Comments:** default to none. Only explain a WHY that is not obvious from the code.
+
+---
+
+### Task 1: Repo scaffold, canonical ids, and display names
+
+The two pure functions that must byte-for-byte agree with the macOS app. Everything else depends on them, so they come first.
+
+**Files:**
+- Create: `go.mod`
+- Create: `internal/catalog/catalog.go`
+- Create: `internal/catalog/naming.go`
+- Test: `internal/catalog/naming_test.go`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `catalog.Rates` struct — `DisplayName string`, `InputPerMillion`, `OutputPerMillion`, `CacheCreationPerMillion`, `CacheReadPerMillion` all `float64`
+  - `catalog.Catalog` struct — `SchemaVersion int`, `GeneratedAt string`, `Source string`, `Models map[string]Rates`
+  - `catalog.CanonicalID(raw string) string`
+  - `catalog.DisplayName(canonical string) string`
+  - `catalog.DateSuffix(raw string) string` — the stripped suffix, or `""` when there is none
+
+- [ ] **Step 1: Clone the repo and create the module**
+
+```bash
+cd ~/Desktop/Projects
+git clone https://github.com/ericjypark/codex-island-model-catalog.git
+cd codex-island-model-catalog
+go mod init github.com/ericjypark/codex-island-model-catalog
+```
+
+Edit `go.mod` so it reads exactly:
+
+```
+module github.com/ericjypark/codex-island-model-catalog
+
+go 1.26
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Create `internal/catalog/naming_test.go`:
+
+```go
+package catalog
+
+import "testing"
+
+func TestCanonicalID(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"claude-haiku-4-5-20251001", "claude-haiku-4-5"},
+		{"claude-opus-4-8", "claude-opus-4-8"},
+		{"gpt-5.6", "gpt-5.6"},
+		{"gpt-5.1-codex-max", "gpt-5.1-codex-max"},
+		// Too short to carry a 9-char suffix.
+		{"gpt-5", "gpt-5"},
+		// Nine trailing chars, but not "-" + 8 digits.
+		{"claude-opus-4-5-2025100x", "claude-opus-4-5-2025100x"},
+		{"model-1234567", "model-1234567"},
+	}
+	for _, c := range cases {
+		if got := CanonicalID(c.in); got != c.want {
+			t.Errorf("CanonicalID(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestDateSuffix(t *testing.T) {
+	if got := DateSuffix("claude-haiku-4-5-20251001"); got != "20251001" {
+		t.Errorf("DateSuffix = %q, want 20251001", got)
+	}
+	if got := DateSuffix("claude-opus-4-8"); got != "" {
+		t.Errorf("DateSuffix = %q, want empty", got)
+	}
+}
+
+func TestDisplayName(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"claude-opus-4-7", "Opus 4.7"},
+		{"claude-fable-5", "Fable 5"},
+		{"claude-sonnet-4-5", "Sonnet 4.5"},
+		{"gpt-5.6", "GPT-5.6"},
+		{"gpt-5.1-codex-max", "GPT-5.1-codex-max"},
+		{"o3-pro", "O3-pro"},
+		{"o4-mini-high", "O4-mini-high"},
+		{"something-else", "something-else"},
+	}
+	for _, c := range cases {
+		if got := DisplayName(c.in); got != c.want {
+			t.Errorf("DisplayName(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `go test ./internal/catalog/ -run 'TestCanonicalID|TestDateSuffix|TestDisplayName' -v`
+
+Expected: FAIL — `undefined: CanonicalID`, `undefined: DateSuffix`, `undefined: DisplayName`.
+
+- [ ] **Step 4: Write the types**
+
+Create `internal/catalog/catalog.go`:
+
+```go
+package catalog
+
+// Rates is the published per-million-token price set for one model.
+type Rates struct {
+	DisplayName             string  `json:"displayName"`
+	InputPerMillion         float64 `json:"inputPerMillion"`
+	OutputPerMillion        float64 `json:"outputPerMillion"`
+	CacheCreationPerMillion float64 `json:"cacheCreationPerMillion"`
+	CacheReadPerMillion     float64 `json:"cacheReadPerMillion"`
+}
+
+// Catalog is the exact shape of v1/models.json.
+type Catalog struct {
+	SchemaVersion int              `json:"schemaVersion"`
+	GeneratedAt   string           `json:"generatedAt"`
+	Source        string           `json:"source"`
+	Models        map[string]Rates `json:"models"`
+}
+
+const SchemaVersion = 1
+```
+
+- [ ] **Step 5: Write the naming rules**
+
+Create `internal/catalog/naming.go`:
+
+```go
+package catalog
+
+import "strings"
+
+// CanonicalID strips an Anthropic-style date suffix ("-20251001") so
+// date-pinned releases collapse onto their base model.
+//
+// This mirrors Pricing.canonicalModel in the macOS app character for
+// character. If the two ever disagree, the app looks up ids this file
+// never publishes and silently prices them at $0.
+func CanonicalID(raw string) string {
+	if DateSuffix(raw) == "" {
+		return raw
+	}
+	return raw[:len(raw)-9]
+}
+
+// DateSuffix returns the 8-digit date at the end of raw, or "" if the id
+// does not end in "-" followed by exactly 8 digits.
+func DateSuffix(raw string) string {
+	if len(raw) <= 9 {
+		return ""
+	}
+	tail := raw[len(raw)-9:]
+	if tail[0] != '-' {
+		return ""
+	}
+	for i := 1; i < len(tail); i++ {
+		if tail[i] < '0' || tail[i] > '9' {
+			return ""
+		}
+	}
+	return tail[1:]
+}
+
+// DisplayName renders a canonical id for the app's per-model rows.
+// Mirrors Pricing.prettyModelName.
+func DisplayName(canonical string) string {
+	if rest, ok := strings.CutPrefix(canonical, "claude-"); ok {
+		family, version, found := strings.Cut(rest, "-")
+		if !found {
+			return capitalizeFirst(rest)
+		}
+		return capitalizeFirst(family) + " " + strings.ReplaceAll(version, "-", ".")
+	}
+	if rest, ok := strings.CutPrefix(canonical, "gpt-"); ok {
+		return "GPT-" + rest
+	}
+	if len(canonical) > 1 && canonical[0] == 'o' && canonical[1] >= '0' && canonical[1] <= '9' {
+		return "O" + canonical[1:]
+	}
+	return canonical
+}
+
+func capitalizeFirst(s string) string {
+	if s == "" {
+		return s
+	}
+	return strings.ToUpper(s[:1]) + s[1:]
+}
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `go test ./internal/catalog/ -v`
+
+Expected: PASS for all three tests.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add go.mod internal/catalog/catalog.go internal/catalog/naming.go internal/catalog/naming_test.go
+git commit -m "feat: add catalog types and canonical id/display name rules"
+```
+
+---
+
+### Task 2: Fetch and convert LiteLLM's price table
+
+**Files:**
+- Create: `internal/litellm/litellm.go`
+- Create: `config.json`
+- Create: `internal/catalog/build.go`
+- Test: `internal/catalog/build_test.go`
+
+**Interfaces:**
+- Consumes: `catalog.Rates`, `catalog.CanonicalID`, `catalog.DateSuffix`, `catalog.DisplayName` from Task 1.
+- Produces:
+  - `litellm.Entry` struct with `Mode string` and four `*float64` cost fields
+  - `litellm.DefaultURL` constant
+  - `litellm.Fetch(ctx context.Context, url string) (map[string]litellm.Entry, error)`
+  - `catalog.Config` struct — `Patterns []string`
+  - `catalog.Build(entries map[string]litellm.Entry, cfg Config) (map[string]Rates, []string)` — returns the converted models and a slice of human-readable conflict notes
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/catalog/build_test.go`:
+
+```go
+package catalog
+
+import (
+	"testing"
+
+	"github.com/ericjypark/codex-island-model-catalog/internal/litellm"
+)
+
+func f(v float64) *float64 { return &v }
+
+var testCfg = Config{Patterns: []string{"claude-*", "gpt-5*", "o[0-9]*"}}
+
+func TestBuildConvertsPerTokenToPerMillion(t *testing.T) {
+	got, _ := Build(map[string]litellm.Entry{
+		"claude-opus-4-8": {
+			Mode:                        "chat",
+			InputCostPerToken:           f(0.000005),
+			OutputCostPerToken:          f(0.000025),
+			CacheCreationInputTokenCost: f(0.00000625),
+			CacheReadInputTokenCost:     f(0.0000005),
+		},
+	}, testCfg)
+
+	r, ok := got["claude-opus-4-8"]
+	if !ok {
+		t.Fatal("claude-opus-4-8 missing")
+	}
+	if r.InputPerMillion != 5 || r.OutputPerMillion != 25 {
+		t.Errorf("input/output = %v/%v, want 5/25", r.InputPerMillion, r.OutputPerMillion)
+	}
+	if r.CacheCreationPerMillion != 6.25 || r.CacheReadPerMillion != 0.5 {
+		t.Errorf("cache write/read = %v/%v, want 6.25/0.5",
+			r.CacheCreationPerMillion, r.CacheReadPerMillion)
+	}
+	if r.DisplayName != "Opus 4.8" {
+		t.Errorf("displayName = %q, want %q", r.DisplayName, "Opus 4.8")
+	}
+}
+
+func TestBuildCacheFallbacks(t *testing.T) {
+	got, _ := Build(map[string]litellm.Entry{
+		"gpt-5.4": {
+			Mode:               "chat",
+			InputCostPerToken:  f(0.0000025),
+			OutputCostPerToken: f(0.000015),
+		},
+	}, testCfg)
+
+	r := got["gpt-5.4"]
+	// Cache writes bill at the input rate when upstream lists none.
+	if r.CacheCreationPerMillion != 2.5 {
+		t.Errorf("cacheCreation = %v, want 2.5 (input rate)", r.CacheCreationPerMillion)
+	}
+	if r.CacheReadPerMillion != 0 {
+		t.Errorf("cacheRead = %v, want 0", r.CacheReadPerMillion)
+	}
+}
+
+func TestBuildFilters(t *testing.T) {
+	got, _ := Build(map[string]litellm.Entry{
+		// Wrong mode.
+		"claude-embed-1": {Mode: "embedding", InputCostPerToken: f(0.000001), OutputCostPerToken: f(0.000001)},
+		// Provider-prefixed re-listing.
+		"bedrock/claude-opus-4-8": {Mode: "chat", InputCostPerToken: f(0.000005), OutputCostPerToken: f(0.000025)},
+		// Not a tracked pattern.
+		"gemini-3-pro": {Mode: "chat", InputCostPerToken: f(0.000001), OutputCostPerToken: f(0.000001)},
+		// LiteLLM's non-model documentation key.
+		"sample_spec": {Mode: "chat", InputCostPerToken: f(0.000001), OutputCostPerToken: f(0.000001)},
+		// Keeper.
+		"gpt-5.6": {Mode: "chat", InputCostPerToken: f(0.000005), OutputCostPerToken: f(0.00003)},
+	}, testCfg)
+
+	if len(got) != 1 {
+		t.Fatalf("got %d models, want 1: %v", len(got), got)
+	}
+	if _, ok := got["gpt-5.6"]; !ok {
+		t.Errorf("gpt-5.6 missing, got %v", got)
+	}
+}
+
+func TestBuildRequiresBothBaseRates(t *testing.T) {
+	got, _ := Build(map[string]litellm.Entry{
+		"gpt-5.9": {Mode: "chat", InputCostPerToken: f(0.000005)},
+	}, testCfg)
+	if len(got) != 0 {
+		t.Errorf("entry without an output rate should be skipped, got %v", got)
+	}
+}
+
+func TestBuildDedupesDatedVariants(t *testing.T) {
+	got, notes := Build(map[string]litellm.Entry{
+		"claude-haiku-4-5": {
+			Mode: "chat", InputCostPerToken: f(0.000001), OutputCostPerToken: f(0.000005),
+		},
+		"claude-haiku-4-5-20251001": {
+			Mode: "chat", InputCostPerToken: f(0.000009), OutputCostPerToken: f(0.000005),
+		},
+	}, testCfg)
+
+	if len(got) != 1 {
+		t.Fatalf("dated variant should collapse onto the base id, got %v", got)
+	}
+	// The bare id is the alias that tracks latest, so it wins.
+	if got["claude-haiku-4-5"].InputPerMillion != 1 {
+		t.Errorf("input = %v, want 1 (bare id wins)", got["claude-haiku-4-5"].InputPerMillion)
+	}
+	if len(notes) == 0 {
+		t.Error("disagreeing variants should produce a conflict note")
+	}
+}
+
+func TestBuildPrefersNewestDateWhenNoBareID(t *testing.T) {
+	got, _ := Build(map[string]litellm.Entry{
+		"claude-opus-9-1-20250101": {
+			Mode: "chat", InputCostPerToken: f(0.000001), OutputCostPerToken: f(0.000001),
+		},
+		"claude-opus-9-1-20260101": {
+			Mode: "chat", InputCostPerToken: f(0.000007), OutputCostPerToken: f(0.000001),
+		},
+	}, testCfg)
+
+	if got["claude-opus-9-1"].InputPerMillion != 7 {
+		t.Errorf("input = %v, want 7 (newest date wins)", got["claude-opus-9-1"].InputPerMillion)
+	}
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `go test ./internal/catalog/ -run TestBuild -v`
+
+Expected: FAIL — the `internal/litellm` package does not exist yet.
+
+- [ ] **Step 3: Write the LiteLLM client**
+
+Create `internal/litellm/litellm.go`:
+
+```go
+package litellm
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+const DefaultURL = "https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json"
+
+// Entry is the subset of LiteLLM's per-model record this catalog reads.
+// Costs are pointers so an absent key is distinguishable from a real zero.
+type Entry struct {
+	Mode                        string   `json:"mode"`
+	InputCostPerToken           *float64 `json:"input_cost_per_token"`
+	OutputCostPerToken          *float64 `json:"output_cost_per_token"`
+	CacheCreationInputTokenCost *float64 `json:"cache_creation_input_token_cost"`
+	CacheReadInputTokenCost     *float64 `json:"cache_read_input_token_cost"`
+}
+
+func Fetch(ctx context.Context, url string) (map[string]Entry, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("litellm: HTTP %d", resp.StatusCode)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 32<<20))
+	if err != nil {
+		return nil, err
+	}
+	var out map[string]Entry
+	if err := json.Unmarshal(body, &out); err != nil {
+		return nil, fmt.Errorf("litellm: decode: %w", err)
+	}
+	return out, nil
+}
+```
+
+- [ ] **Step 4: Write the builder**
+
+Create `internal/catalog/build.go`:
+
+```go
+package catalog
+
+import (
+	"fmt"
+	"path"
+	"strings"
+
+	"github.com/ericjypark/codex-island-model-catalog/internal/litellm"
+)
+
+// Config is the shape of config.json.
+type Config struct {
+	Patterns []string `json:"patterns"`
+}
+
+// Build converts upstream entries into published rates. The second return
+// value carries notes about date-pinned variants that disagreed on price.
+func Build(entries map[string]litellm.Entry, cfg Config) (map[string]Rates, []string) {
+	type candidate struct {
+		rates Rates
+		date  string
+	}
+	best := map[string]candidate{}
+	var notes []string
+
+	for id, e := range entries {
+		if !tracked(id, e, cfg) {
+			continue
+		}
+		canonical := CanonicalID(id)
+		date := DateSuffix(id)
+		next := candidate{rates: convert(canonical, e), date: date}
+
+		prev, seen := best[canonical]
+		if !seen {
+			best[canonical] = next
+			continue
+		}
+		if prev.rates != next.rates {
+			notes = append(notes, fmt.Sprintf(
+				"%s: variants disagree (%s=%v vs %s=%v)",
+				canonical, variantLabel(prev.date), prev.rates.InputPerMillion,
+				variantLabel(next.date), next.rates.InputPerMillion))
+		}
+		if wins(next.date, prev.date) {
+			best[canonical] = next
+		}
+	}
+
+	out := make(map[string]Rates, len(best))
+	for id, c := range best {
+		out[id] = c.rates
+	}
+	return out, notes
+}
+
+// wins reports whether date a beats date b. The bare id (empty date) is the
+// alias upstream keeps pointed at the current release, so it outranks every
+// pinned variant; otherwise the later date wins.
+func wins(a, b string) bool {
+	if a == "" {
+		return true
+	}
+	if b == "" {
+		return false
+	}
+	return a > b
+}
+
+func variantLabel(date string) string {
+	if date == "" {
+		return "bare"
+	}
+	return date
+}
+
+func tracked(id string, e litellm.Entry, cfg Config) bool {
+	if id == "sample_spec" || strings.Contains(id, "/") {
+		return false
+	}
+	if e.Mode != "chat" && e.Mode != "responses" {
+		return false
+	}
+	if e.InputCostPerToken == nil || e.OutputCostPerToken == nil {
+		return false
+	}
+	for _, p := range cfg.Patterns {
+		if ok, _ := path.Match(p, id); ok {
+			return true
+		}
+	}
+	return false
+}
+
+func convert(canonical string, e litellm.Entry) Rates {
+	input := *e.InputCostPerToken * 1e6
+	r := Rates{
+		DisplayName:             DisplayName(canonical),
+		InputPerMillion:         input,
+		OutputPerMillion:        *e.OutputCostPerToken * 1e6,
+		CacheCreationPerMillion: input,
+	}
+	if e.CacheCreationInputTokenCost != nil {
+		r.CacheCreationPerMillion = *e.CacheCreationInputTokenCost * 1e6
+	}
+	if e.CacheReadInputTokenCost != nil {
+		r.CacheReadPerMillion = *e.CacheReadInputTokenCost * 1e6
+	}
+	return r
+}
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `go test ./... -v`
+
+Expected: PASS for every test in `internal/catalog`.
+
+- [ ] **Step 6: Create the pattern config**
+
+Create `config.json`:
+
+```json
+{
+  "patterns": [
+    "claude-*",
+    "gpt-5*",
+    "o[0-9]*"
+  ]
+}
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add config.json internal/litellm/litellm.go internal/catalog/build.go internal/catalog/build_test.go
+git commit -m "feat: convert litellm price table into catalog rates"
+```
+
+---
+
+### Task 3: Hand-maintained overrides
+
+**Files:**
+- Create: `internal/catalog/overrides.go`
+- Create: `overrides.json`
+- Test: `internal/catalog/overrides_test.go`
+
+**Interfaces:**
+- Consumes: `catalog.Rates` from Task 1.
+- Produces:
+  - `catalog.Override` struct — `DisplayName *string`, and `*float64` for each of the four rates
+  - `catalog.ApplyOverrides(base map[string]Rates, ov map[string]Override) map[string]Rates`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/catalog/overrides_test.go`:
+
+```go
+package catalog
+
+import "testing"
+
+func s(v string) *string { return &v }
+
+func TestApplyOverridesPerField(t *testing.T) {
+	base := map[string]Rates{
+		"gpt-5.6": {
+			DisplayName: "GPT-5.6", InputPerMillion: 5, OutputPerMillion: 30,
+			CacheCreationPerMillion: 5, CacheReadPerMillion: 0.5,
+		},
+	}
+	got := ApplyOverrides(base, map[string]Override{
+		"gpt-5.6": {CacheCreationPerMillion: f(6.25)},
+	})
+
+	r := got["gpt-5.6"]
+	if r.CacheCreationPerMillion != 6.25 {
+		t.Errorf("cacheCreation = %v, want 6.25", r.CacheCreationPerMillion)
+	}
+	if r.InputPerMillion != 5 || r.OutputPerMillion != 30 || r.CacheReadPerMillion != 0.5 {
+		t.Errorf("untouched fields changed: %+v", r)
+	}
+}
+
+func TestApplyOverridesZeroIsRespected(t *testing.T) {
+	base := map[string]Rates{"gpt-5-pro": {InputPerMillion: 15, CacheReadPerMillion: 1.5}}
+	got := ApplyOverrides(base, map[string]Override{
+		"gpt-5-pro": {CacheReadPerMillion: f(0)},
+	})
+	if got["gpt-5-pro"].CacheReadPerMillion != 0 {
+		t.Errorf("explicit zero override was dropped: %+v", got["gpt-5-pro"])
+	}
+}
+
+func TestApplyOverridesDisplayName(t *testing.T) {
+	base := map[string]Rates{"gpt-5.6-sol": {DisplayName: "GPT-5.6-sol", InputPerMillion: 5}}
+	got := ApplyOverrides(base, map[string]Override{
+		"gpt-5.6-sol": {DisplayName: s("GPT-5.6 Sol")},
+	})
+	if got["gpt-5.6-sol"].DisplayName != "GPT-5.6 Sol" {
+		t.Errorf("displayName = %q", got["gpt-5.6-sol"].DisplayName)
+	}
+}
+
+func TestApplyOverridesAddsModelAbsentUpstream(t *testing.T) {
+	got := ApplyOverrides(map[string]Rates{}, map[string]Override{
+		"gpt-5.6-luna": {
+			DisplayName: s("GPT-5.6 Luna"), InputPerMillion: f(1), OutputPerMillion: f(6),
+			CacheCreationPerMillion: f(1.25), CacheReadPerMillion: f(0.1),
+		},
+	})
+	r, ok := got["gpt-5.6-luna"]
+	if !ok {
+		t.Fatal("override-only model missing")
+	}
+	if r.InputPerMillion != 1 || r.OutputPerMillion != 6 {
+		t.Errorf("override-only rates wrong: %+v", r)
+	}
+}
+
+func TestApplyOverridesFillsMissingDisplayName(t *testing.T) {
+	got := ApplyOverrides(map[string]Rates{}, map[string]Override{
+		"claude-opus-9-9": {InputPerMillion: f(1), OutputPerMillion: f(2)},
+	})
+	if got["claude-opus-9-9"].DisplayName != "Opus 9.9" {
+		t.Errorf("displayName = %q, want generated %q",
+			got["claude-opus-9-9"].DisplayName, "Opus 9.9")
+	}
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `go test ./internal/catalog/ -run TestApplyOverrides -v`
+
+Expected: FAIL — `undefined: ApplyOverrides`, `undefined: Override`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `internal/catalog/overrides.go`:
+
+```go
+package catalog
+
+// Override is a partial Rates. Every field is a pointer so that an absent
+// key and an explicit zero stay distinguishable — "cacheReadPerMillion": 0
+// is a real statement about a model that has no prompt caching.
+type Override struct {
+	DisplayName             *string  `json:"displayName,omitempty"`
+	InputPerMillion         *float64 `json:"inputPerMillion,omitempty"`
+	OutputPerMillion        *float64 `json:"outputPerMillion,omitempty"`
+	CacheCreationPerMillion *float64 `json:"cacheCreationPerMillion,omitempty"`
+	CacheReadPerMillion     *float64 `json:"cacheReadPerMillion,omitempty"`
+}
+
+// ApplyOverrides layers hand-maintained values over the upstream-derived
+// ones. An override always wins, and may introduce a model upstream has
+// never listed.
+func ApplyOverrides(base map[string]Rates, ov map[string]Override) map[string]Rates {
+	out := make(map[string]Rates, len(base)+len(ov))
+	for id, r := range base {
+		out[id] = r
+	}
+	for id, o := range ov {
+		r := out[id]
+		if o.DisplayName != nil {
+			r.DisplayName = *o.DisplayName
+		}
+		if o.InputPerMillion != nil {
+			r.InputPerMillion = *o.InputPerMillion
+		}
+		if o.OutputPerMillion != nil {
+			r.OutputPerMillion = *o.OutputPerMillion
+		}
+		if o.CacheCreationPerMillion != nil {
+			r.CacheCreationPerMillion = *o.CacheCreationPerMillion
+		}
+		if o.CacheReadPerMillion != nil {
+			r.CacheReadPerMillion = *o.CacheReadPerMillion
+		}
+		if r.DisplayName == "" {
+			r.DisplayName = DisplayName(id)
+		}
+		out[id] = r
+	}
+	return out
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `go test ./... -v`
+
+Expected: PASS.
+
+- [ ] **Step 5: Seed overrides.json with the app's existing deviations**
+
+These are the values `Sources/Cost/Pricing.swift` carries today that LiteLLM either does not list or lists differently. Create `overrides.json`:
+
+```json
+{
+  "gpt-5.6": { "cacheCreationPerMillion": 6.25 },
+  "gpt-5.6-sol": {
+    "displayName": "GPT-5.6 Sol",
+    "inputPerMillion": 5,
+    "outputPerMillion": 30,
+    "cacheCreationPerMillion": 6.25,
+    "cacheReadPerMillion": 0.5
+  },
+  "gpt-5.6-terra": {
+    "displayName": "GPT-5.6 Terra",
+    "inputPerMillion": 2.5,
+    "outputPerMillion": 15,
+    "cacheCreationPerMillion": 3.125,
+    "cacheReadPerMillion": 0.25
+  },
+  "gpt-5.6-luna": {
+    "displayName": "GPT-5.6 Luna",
+    "inputPerMillion": 1,
+    "outputPerMillion": 6,
+    "cacheCreationPerMillion": 1.25,
+    "cacheReadPerMillion": 0.1
+  },
+  "gpt-5.2-pro": { "cacheReadPerMillion": 0 },
+  "gpt-5-pro": { "cacheReadPerMillion": 0 }
+}
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add overrides.json internal/catalog/overrides.go internal/catalog/overrides_test.go
+git commit -m "feat: layer hand-maintained overrides over upstream rates"
+```
+
+---
+
+### Task 4: Sanity gate
+
+The app release cycle used to be an implicit review gate on every price change. This replaces it, so it gets the densest test coverage in the plan.
+
+**Files:**
+- Create: `internal/catalog/gate.go`
+- Test: `internal/catalog/gate_test.go`
+
+**Interfaces:**
+- Consumes: `catalog.Rates` from Task 1.
+- Produces:
+  - `catalog.GateResult` struct — `Models map[string]Rates`, `Rejections []string`, `Aborted bool`, `AbortReason string`
+  - `catalog.Gate(candidate, published map[string]Rates) GateResult`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/catalog/gate_test.go`:
+
+```go
+package catalog
+
+import "testing"
+
+func rate(in, out float64) Rates {
+	return Rates{
+		DisplayName: "X", InputPerMillion: in, OutputPerMillion: out,
+		CacheCreationPerMillion: in, CacheReadPerMillion: in / 10,
+	}
+}
+
+func TestGateAbortsOnCountCollapse(t *testing.T) {
+	published := map[string]Rates{
+		"a": rate(1, 2), "b": rate(1, 2), "c": rate(1, 2), "d": rate(1, 2),
+	}
+	got := Gate(map[string]Rates{"a": rate(1, 2)}, published)
+	if !got.Aborted {
+		t.Fatal("1 of 4 models should abort the run")
+	}
+	if got.AbortReason == "" {
+		t.Error("abort should carry a reason")
+	}
+}
+
+func TestGateAllowsHalfExactly(t *testing.T) {
+	published := map[string]Rates{"a": rate(1, 2), "b": rate(1, 2)}
+	got := Gate(map[string]Rates{"a": rate(1, 2)}, published)
+	if got.Aborted {
+		t.Error("exactly half should not abort")
+	}
+}
+
+func TestGateFirstRunNeverAborts(t *testing.T) {
+	got := Gate(map[string]Rates{"a": rate(1, 2)}, map[string]Rates{})
+	if got.Aborted {
+		t.Error("bootstrapping against an empty catalog must not abort")
+	}
+}
+
+func TestGateRejectsNegativeRate(t *testing.T) {
+	published := map[string]Rates{"a": rate(1, 2)}
+	got := Gate(map[string]Rates{"a": rate(-1, 2)}, published)
+	if got.Models["a"].InputPerMillion != 1 {
+		t.Errorf("negative rate should keep the published value, got %v", got.Models["a"])
+	}
+	if len(got.Rejections) == 0 {
+		t.Error("rejection should be recorded")
+	}
+}
+
+func TestGateRejectsAbsurdInputRate(t *testing.T) {
+	published := map[string]Rates{"a": rate(5, 10)}
+	got := Gate(map[string]Rates{"a": rate(1001, 10)}, published)
+	if got.Models["a"].InputPerMillion != 5 {
+		t.Errorf("absurd rate should keep published value, got %v", got.Models["a"])
+	}
+}
+
+func TestGateRejectsTenfoldJump(t *testing.T) {
+	published := map[string]Rates{"a": rate(5, 10)}
+	got := Gate(map[string]Rates{"a": rate(50, 10)}, published)
+	if got.Models["a"].InputPerMillion != 5 {
+		t.Errorf("10x jump should keep published value, got %v", got.Models["a"])
+	}
+}
+
+func TestGateRejectsTenfoldDrop(t *testing.T) {
+	published := map[string]Rates{"a": rate(50, 10)}
+	got := Gate(map[string]Rates{"a": rate(5, 10)}, published)
+	if got.Models["a"].InputPerMillion != 50 {
+		t.Errorf("10x drop should keep published value, got %v", got.Models["a"])
+	}
+}
+
+func TestGateAllowsOrdinaryPriceChange(t *testing.T) {
+	published := map[string]Rates{"a": rate(3, 15)}
+	got := Gate(map[string]Rates{"a": rate(2, 10)}, published)
+	if got.Models["a"].InputPerMillion != 2 {
+		t.Errorf("a 33%% cut should pass, got %v", got.Models["a"])
+	}
+	if len(got.Rejections) != 0 {
+		t.Errorf("no rejection expected, got %v", got.Rejections)
+	}
+}
+
+func TestGateSkipsRatioRuleWhenPublishedIsZero(t *testing.T) {
+	published := map[string]Rates{"a": {InputPerMillion: 5, OutputPerMillion: 10, CacheReadPerMillion: 0}}
+	candidate := map[string]Rates{"a": {InputPerMillion: 5, OutputPerMillion: 10, CacheReadPerMillion: 0.5}}
+	got := Gate(candidate, published)
+	if got.Models["a"].CacheReadPerMillion != 0.5 {
+		t.Errorf("a rate moving off zero must be allowed, got %v", got.Models["a"])
+	}
+}
+
+func TestGateOmitsBadBrandNewModel(t *testing.T) {
+	got := Gate(map[string]Rates{"a": rate(1, 2), "b": rate(-3, 2)}, map[string]Rates{"a": rate(1, 2)})
+	if _, ok := got.Models["b"]; ok {
+		t.Error("a new model with a bad rate should be omitted, not published")
+	}
+}
+
+func TestGateCarriesForwardModelsDroppedUpstream(t *testing.T) {
+	published := map[string]Rates{"a": rate(1, 2), "gone": rate(9, 9)}
+	got := Gate(map[string]Rates{"a": rate(1, 2)}, published)
+	if _, ok := got.Models["gone"]; !ok {
+		t.Error("a model dropped upstream must survive in the output")
+	}
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `go test ./internal/catalog/ -run TestGate -v`
+
+Expected: FAIL — `undefined: Gate`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `internal/catalog/gate.go`:
+
+```go
+package catalog
+
+import "fmt"
+
+const (
+	maxInputPerMillion = 1000.0
+	maxRatioChange     = 10.0
+)
+
+type GateResult struct {
+	Models      map[string]Rates
+	Rejections  []string
+	Aborted     bool
+	AbortReason string
+}
+
+// Gate is the review step that the app release cycle used to provide. It
+// decides what is safe to publish given what is already published.
+//
+// A rejected model keeps its published values rather than disappearing:
+// dropping it would price it at $0, which is the exact failure this whole
+// design exists to prevent.
+func Gate(candidate, published map[string]Rates) GateResult {
+	res := GateResult{Models: make(map[string]Rates, len(candidate)+len(published))}
+
+	if n := len(published); n > 0 && len(candidate)*2 < n {
+		res.Aborted = true
+		res.AbortReason = fmt.Sprintf(
+			"model count collapsed: %d candidates against %d published", len(candidate), n)
+		return res
+	}
+
+	for id, r := range candidate {
+		prev, hadPrev := published[id]
+		if reason := check(r, prev, hadPrev); reason != "" {
+			res.Rejections = append(res.Rejections, fmt.Sprintf("%s: %s", id, reason))
+			if hadPrev {
+				res.Models[id] = prev
+			}
+			continue
+		}
+		res.Models[id] = r
+	}
+
+	// Upstream removals never propagate.
+	for id, r := range published {
+		if _, ok := res.Models[id]; !ok {
+			res.Models[id] = r
+		}
+	}
+	return res
+}
+
+func check(next, prev Rates, hadPrev bool) string {
+	fields := []struct {
+		name       string
+		next, prev float64
+	}{
+		{"inputPerMillion", next.InputPerMillion, prev.InputPerMillion},
+		{"outputPerMillion", next.OutputPerMillion, prev.OutputPerMillion},
+		{"cacheCreationPerMillion", next.CacheCreationPerMillion, prev.CacheCreationPerMillion},
+		{"cacheReadPerMillion", next.CacheReadPerMillion, prev.CacheReadPerMillion},
+	}
+	for _, f := range fields {
+		if f.next < 0 {
+			return fmt.Sprintf("%s is negative (%v)", f.name, f.next)
+		}
+		if !hadPrev || f.prev <= 0 {
+			// No baseline, or a rate legitimately moving off zero — the
+			// ratio test has nothing meaningful to say.
+			continue
+		}
+		if f.next >= f.prev*maxRatioChange || f.next*maxRatioChange <= f.prev {
+			return fmt.Sprintf("%s moved %v -> %v", f.name, f.prev, f.next)
+		}
+	}
+	if next.InputPerMillion > maxInputPerMillion {
+		return fmt.Sprintf("inputPerMillion %v exceeds %v", next.InputPerMillion, maxInputPerMillion)
+	}
+	return ""
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `go test ./... -v`
+
+Expected: PASS for all gate tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/catalog/gate.go internal/catalog/gate_test.go
+git commit -m "feat: add sanity gate guarding published price changes"
+```
+
+---
+
+### Task 5: Sync command and change detection
+
+**Files:**
+- Create: `internal/catalog/encode.go`
+- Create: `cmd/sync/main.go`
+- Create: `v1/models.json`
+- Create: `.nojekyll`
+- Test: `internal/catalog/encode_test.go`
+
+**Interfaces:**
+- Consumes: everything from Tasks 1–4. The test below reuses the `rate(in, out float64) Rates` helper defined in `gate_test.go` (Task 4) — same package, so Task 4 must land first.
+- Produces:
+  - `catalog.Encode(c Catalog) ([]byte, error)` — deterministic, indented, newline-terminated
+  - `catalog.Decode(b []byte) (Catalog, error)`
+  - `catalog.ModelsEqual(a, b map[string]Rates) bool`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/catalog/encode_test.go`:
+
+```go
+package catalog
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestEncodeIsDeterministic(t *testing.T) {
+	c := Catalog{
+		SchemaVersion: SchemaVersion,
+		GeneratedAt:   "2026-07-26T01:00:00Z",
+		Source:        "test",
+		Models: map[string]Rates{
+			"zeta": rate(1, 2), "alpha": rate(3, 4), "mid": rate(5, 6),
+		},
+	}
+	first, err := Encode(c)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 20; i++ {
+		again, err := Encode(c)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(first, again) {
+			t.Fatal("Encode is not deterministic across runs")
+		}
+	}
+	if !bytes.HasSuffix(first, []byte("\n")) {
+		t.Error("encoded catalog should end with a newline")
+	}
+}
+
+func TestEncodeDecodeRoundTrip(t *testing.T) {
+	c := Catalog{
+		SchemaVersion: SchemaVersion,
+		GeneratedAt:   "2026-07-26T01:00:00Z",
+		Source:        "test",
+		Models:        map[string]Rates{"claude-opus-4-8": rate(5, 25)},
+	}
+	b, err := Encode(c)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := Decode(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.SchemaVersion != SchemaVersion || !ModelsEqual(got.Models, c.Models) {
+		t.Errorf("round trip lost data: %+v", got)
+	}
+}
+
+func TestDecodeMissingFileShapeIsAnError(t *testing.T) {
+	if _, err := Decode([]byte("not json")); err == nil {
+		t.Error("garbage input should error")
+	}
+}
+
+func TestModelsEqualIgnoresTimestamp(t *testing.T) {
+	a := map[string]Rates{"x": rate(1, 2)}
+	b := map[string]Rates{"x": rate(1, 2)}
+	if !ModelsEqual(a, b) {
+		t.Error("identical model maps should compare equal")
+	}
+	b["x"] = rate(1, 3)
+	if ModelsEqual(a, b) {
+		t.Error("differing rates should compare unequal")
+	}
+	if ModelsEqual(a, map[string]Rates{}) {
+		t.Error("different sizes should compare unequal")
+	}
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `go test ./internal/catalog/ -run 'TestEncode|TestDecode|TestModelsEqual' -v`
+
+Expected: FAIL — `undefined: Encode`, `undefined: Decode`, `undefined: ModelsEqual`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `internal/catalog/encode.go`:
+
+```go
+package catalog
+
+import (
+	"encoding/json"
+	"maps"
+)
+
+// Encode renders a catalog for commit. encoding/json sorts map keys, so
+// byte-identical input yields byte-identical output and the change check
+// in cmd/sync stays honest.
+func Encode(c Catalog) ([]byte, error) {
+	b, err := json.MarshalIndent(c, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return append(b, '\n'), nil
+}
+
+func Decode(b []byte) (Catalog, error) {
+	var c Catalog
+	if err := json.Unmarshal(b, &c); err != nil {
+		return Catalog{}, err
+	}
+	return c, nil
+}
+
+// ModelsEqual compares only the price data. GeneratedAt is deliberately
+// excluded: including it would make every run differ and produce a commit
+// every six hours forever.
+func ModelsEqual(a, b map[string]Rates) bool {
+	return maps.Equal(a, b)
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `go test ./... -v`
+
+Expected: PASS.
+
+- [ ] **Step 5: Write the sync command**
+
+Create `cmd/sync/main.go`:
+
+```go
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+
+	"github.com/ericjypark/codex-island-model-catalog/internal/catalog"
+	"github.com/ericjypark/codex-island-model-catalog/internal/litellm"
+)
+
+const catalogPath = "v1/models.json"
+
+func main() {
+	if err := run(); err != nil {
+		log.Fatalf("sync: %v", err)
+	}
+}
+
+func run() error {
+	repo := os.Getenv("REPO_DIR")
+	if repo == "" {
+		repo = "."
+	}
+
+	cfg, err := readJSON[catalog.Config](filepath.Join(repo, "config.json"))
+	if err != nil {
+		return fmt.Errorf("config.json: %w", err)
+	}
+	overrides, err := readJSON[map[string]catalog.Override](filepath.Join(repo, "overrides.json"))
+	if err != nil {
+		return fmt.Errorf("overrides.json: %w", err)
+	}
+
+	published := map[string]catalog.Rates{}
+	if raw, err := os.ReadFile(filepath.Join(repo, catalogPath)); err == nil {
+		prev, err := catalog.Decode(raw)
+		if err != nil {
+			return fmt.Errorf("%s: %w", catalogPath, err)
+		}
+		published = prev.Models
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	url := litellm.DefaultURL
+	if v := os.Getenv("LITELLM_URL"); v != "" {
+		url = v
+	}
+	entries, err := litellm.Fetch(ctx, url)
+	if err != nil {
+		return err
+	}
+
+	built, notes := catalog.Build(entries, cfg)
+	for _, n := range notes {
+		log.Printf("conflict: %s", n)
+	}
+
+	gated := catalog.Gate(catalog.ApplyOverrides(built, overrides), published)
+	for _, r := range gated.Rejections {
+		log.Printf("rejected: %s", r)
+	}
+	if gated.Aborted {
+		return fmt.Errorf("aborted: %s", gated.AbortReason)
+	}
+
+	if catalog.ModelsEqual(gated.Models, published) {
+		log.Printf("no change (%d models)", len(gated.Models))
+		return nil
+	}
+
+	out, err := catalog.Encode(catalog.Catalog{
+		SchemaVersion: catalog.SchemaVersion,
+		GeneratedAt:   time.Now().UTC().Format(time.RFC3339),
+		Source:        "litellm + overrides",
+		Models:        gated.Models,
+	})
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(filepath.Join(repo, catalogPath), out, 0o644); err != nil {
+		return err
+	}
+	log.Printf("updated: %d models (was %d)", len(gated.Models), len(published))
+
+	if os.Getenv("SKIP_COMMIT") != "" {
+		return nil
+	}
+	return commit(repo, len(gated.Models))
+}
+
+func readJSON[T any](path string) (T, error) {
+	var v T
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return v, err
+	}
+	err = json.Unmarshal(b, &v)
+	return v, err
+}
+
+func commit(repo string, count int) error {
+	steps := [][]string{
+		{"config", "user.email", "bot@codexisland.dev"},
+		{"config", "user.name", "codexisland-catalog-bot"},
+		{"add", catalogPath},
+		{"commit", "-m", fmt.Sprintf("chore: refresh model catalog (%d models)", count)},
+		{"push"},
+	}
+	for _, args := range steps {
+		cmd := exec.Command("git", append([]string{"-C", repo}, args...)...)
+		cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr
+		if err := cmd.Run(); err != nil {
+			return fmt.Errorf("git %s: %w", args[0], err)
+		}
+	}
+	return nil
+}
+```
+
+- [ ] **Step 6: Bootstrap the catalog file against real upstream data**
+
+`v1/models.json` does not exist yet, so this first run bootstraps it. `SKIP_COMMIT` keeps it a local write.
+
+```bash
+touch .nojekyll
+SKIP_COMMIT=1 go run ./cmd/sync
+```
+
+Expected: a log line like `updated: NN models (was 0)`, and `v1/models.json` now exists.
+
+- [ ] **Step 7: Verify the bootstrapped catalog against the app's current table**
+
+Every model in `Sources/Cost/Pricing.swift` should appear, with matching rates. Check a representative sample:
+
+```bash
+python3 -c "
+import json
+d = json.load(open('v1/models.json'))
+print('models:', len(d['models']))
+for m in ['claude-opus-4-8','claude-sonnet-5','gpt-5.6','gpt-5-pro','gpt-5.6-luna']:
+    print(m, d['models'].get(m))
+"
+```
+
+Expected: `claude-opus-4-8` at 5/25/6.25/0.5, `gpt-5.6` with `cacheCreationPerMillion` 6.25 (the override), `gpt-5-pro` with `cacheReadPerMillion` 0, and `gpt-5.6-luna` present from overrides alone. If a model from `Pricing.swift` is missing, add it to `overrides.json` and re-run.
+
+- [ ] **Step 8: Verify the no-change path**
+
+```bash
+SKIP_COMMIT=1 go run ./cmd/sync
+```
+
+Expected: `no change (NN models)` and `v1/models.json` untouched (`git status --short` shows nothing for it).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add .nojekyll v1/models.json internal/catalog/encode.go internal/catalog/encode_test.go cmd/sync/main.go
+git commit -m "feat: add sync command and bootstrap the published catalog"
+```
+
+---
+
+### Task 6: Container image, CI, and k3s manifests
+
+**Files:**
+- Create: `Dockerfile`
+- Create: `.dockerignore`
+- Create: `.github/workflows/build.yml`
+- Create: `k8s/namespace.yaml`
+- Create: `k8s/cronjob.yaml`
+- Create: `k8s/secret.example.yaml`
+- Create: `README.md`
+
+**Interfaces:**
+- Consumes: `cmd/sync` from Task 5.
+- Produces: image `ghcr.io/ericjypark/codex-island-model-catalog:<sha>`; CronJob `model-catalog-sync` in namespace `codexisland`.
+
+- [ ] **Step 1: Write the Dockerfile**
+
+Create `Dockerfile`:
+
+```dockerfile
+FROM golang:1.26-alpine AS build
+WORKDIR /src
+COPY . .
+RUN CGO_ENABLED=0 go build -trimpath -o /out/sync ./cmd/sync
+
+FROM alpine:3.22
+RUN apk add --no-cache git ca-certificates
+COPY --from=build /out/sync /usr/local/bin/sync
+ENTRYPOINT ["/usr/local/bin/sync"]
+```
+
+`git` is in the runtime image because the sync command shells out to it to clone, commit, and push.
+
+Create `.dockerignore`:
+
+```
+.git
+README.md
+```
+
+`k8s/` stays copyable — Step 3 adds an entrypoint script that lives there.
+
+- [ ] **Step 2: Build the image locally to verify it compiles**
+
+Run: `docker build -t codex-island-model-catalog:dev .`
+
+Expected: build succeeds, final image under ~30MB (`docker images codex-island-model-catalog:dev`).
+
+- [ ] **Step 3: Write the entrypoint wrapper that clones before syncing**
+
+The CronJob starts from an empty filesystem, so it must clone first. Create `k8s/entrypoint.sh` and add it to the image.
+
+Append to `Dockerfile` before the `ENTRYPOINT` line:
+
+```dockerfile
+COPY k8s/entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+```
+
+and change the last line to:
+
+```dockerfile
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+```
+
+Create `k8s/entrypoint.sh`:
+
+```sh
+#!/bin/sh
+# Clone with the token in the remote URL, sync, then let the sync binary
+# commit and push. set -u is deliberate: an unset token must fail loudly
+# rather than produce an anonymous clone that cannot push.
+set -eu
+
+: "${GITHUB_TOKEN:?GITHUB_TOKEN is required}"
+REPO_DIR=/tmp/repo
+rm -rf "$REPO_DIR"
+
+git clone --depth 1 \
+  "https://x-access-token:${GITHUB_TOKEN}@github.com/ericjypark/codex-island-model-catalog.git" \
+  "$REPO_DIR"
+
+REPO_DIR="$REPO_DIR" exec /usr/local/bin/sync
+```
+
+- [ ] **Step 4: Rebuild and smoke-test the image without a token**
+
+Run: `docker build -t codex-island-model-catalog:dev . && docker run --rm codex-island-model-catalog:dev`
+
+Expected: exits non-zero with `GITHUB_TOKEN is required`. That is the correct failure — it proves the guard works.
+
+- [ ] **Step 5: Write the CI workflow**
+
+Create `.github/workflows/build.yml`:
+
+```yaml
+name: build
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.26"
+      - run: go vet ./...
+      - run: go test ./... -v
+
+  image:
+    needs: test
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/arm64
+          push: true
+          tags: ghcr.io/ericjypark/codex-island-model-catalog:${{ github.sha }}
+```
+
+Only `linux/arm64` is built — the Pi is the sole consumer.
+
+- [ ] **Step 6: Write the k3s manifests**
+
+Create `k8s/namespace.yaml`:
+
+```yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: codexisland
+```
+
+Create `k8s/secret.example.yaml`:
+
+```yaml
+# Copy to secret.yaml, fill in the token, apply, and do NOT commit it.
+# The token is a fine-grained PAT with contents:write scoped to
+# ericjypark/codex-island-model-catalog only.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: codexisland-git
+  namespace: codexisland
+type: Opaque
+stringData:
+  GITHUB_TOKEN: github_pat_REPLACE_ME
+```
+
+Create `k8s/cronjob.yaml`:
+
+```yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: model-catalog-sync
+  namespace: codexisland
+spec:
+  schedule: "17 */6 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: sync
+              image: ghcr.io/ericjypark/codex-island-model-catalog:REPLACE_WITH_SHA
+              envFrom:
+                - secretRef:
+                    name: codexisland-git
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 32Mi
+                limits:
+                  cpu: 500m
+                  memory: 128Mi
+```
+
+`17 */6 * * *` rather than `0 */6 * * *` — an off-the-hour minute avoids piling onto the same upstream-fetch spike as every other cron on the internet.
+
+- [ ] **Step 7: Add `secret.yaml` to gitignore**
+
+Create `.gitignore`:
+
+```
+k8s/secret.yaml
+```
+
+- [ ] **Step 8: Write the README**
+
+Create `README.md`:
+
+```markdown
+# codex-island-model-catalog
+
+Model prices for [CodexIsland](https://github.com/ericjypark/codex-island),
+published as a plain JSON file so new models do not require an app release.
+
+**Endpoint:** https://ericjypark.github.io/codex-island-model-catalog/v1/models.json
+
+## How it works
+
+A bot polls [LiteLLM's price table][litellm] every six hours, keeps the
+models CodexIsland tracks, converts per-token prices to per-million,
+applies `overrides.json`, and runs a sanity gate before committing
+`v1/models.json`. It commits only when prices actually change.
+
+[litellm]: https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json
+
+## Correcting a price
+
+Prices are public and reviewable. If a value here is wrong, open a PR
+against `overrides.json` — an override beats whatever upstream says:
+
+```json
+{ "gpt-5.6": { "cacheCreationPerMillion": 6.25 } }
+```
+
+Only the fields you list are replaced.
+
+## Sanity gate
+
+The bot refuses to publish data that looks broken:
+
+- the run aborts if the model count drops below half of what is published
+- a negative rate, or an input rate above $1000/M, is rejected
+- a rate that moves by 10x or more is rejected
+- a rejected model keeps its previously published value rather than
+  vanishing, because a missing model prices to $0 in the app
+- models are never removed, even if upstream drops them
+
+## Development
+
+```sh
+go test ./...
+SKIP_COMMIT=1 go run ./cmd/sync   # dry run against the local checkout
+```
+```
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add Dockerfile .dockerignore .gitignore README.md .github/workflows/build.yml k8s/
+git commit -m "chore: add container build, CI, and k3s manifests"
+```
+
+---
+
+### Task 7: Publish and deploy
+
+The manual, out-of-band steps. Everything before this was local.
+
+**Files:**
+- Modify: `k8s/cronjob.yaml` (pin the real image SHA)
+
+**Interfaces:**
+- Consumes: everything from Tasks 1–6.
+- Produces: a live URL the companion app plan consumes.
+
+- [ ] **Step 1: Push and make the repo public**
+
+```bash
+git push -u origin main
+gh repo edit ericjypark/codex-island-model-catalog --visibility public --accept-visibility-change-consequences
+```
+
+- [ ] **Step 2: Verify CI built and pushed the image**
+
+```bash
+gh run watch --exit-status -R ericjypark/codex-island-model-catalog
+gh api /users/ericjypark/packages/container/codex-island-model-catalog/versions --jq '.[0].metadata.container.tags'
+```
+
+Expected: the workflow succeeds and the package lists the head commit SHA as a tag.
+
+- [ ] **Step 3: Enable GitHub Pages**
+
+```bash
+gh api -X POST repos/ericjypark/codex-island-model-catalog/pages \
+  -f 'source[branch]=main' -f 'source[path]=/'
+```
+
+Wait ~1 minute for the first Pages build, then verify:
+
+```bash
+curl -sS -D- -o /dev/null https://ericjypark.github.io/codex-island-model-catalog/v1/models.json
+```
+
+Expected: `HTTP/2 200` and an `etag:` header.
+
+- [ ] **Step 4: Verify conditional GET returns 304**
+
+```bash
+ETAG=$(curl -sSI https://ericjypark.github.io/codex-island-model-catalog/v1/models.json | awk '/^etag:/{print $2}' | tr -d '\r')
+curl -sS -o /dev/null -w '%{http_code}\n' -H "If-None-Match: $ETAG" https://ericjypark.github.io/codex-island-model-catalog/v1/models.json
+```
+
+Expected: `304`. The app's daily refresh depends on this.
+
+- [ ] **Step 5: Mint the PAT and create the secret**
+
+Create a fine-grained PAT at https://github.com/settings/personal-access-tokens/new with **Repository access:** only `ericjypark/codex-island-model-catalog`, **Permissions:** Contents → Read and write. Then:
+
+```bash
+cp k8s/secret.example.yaml k8s/secret.yaml
+# edit k8s/secret.yaml, paste the token
+scp k8s/namespace.yaml k8s/secret.yaml ericpark@ericpark:/tmp/
+ssh ericpark@ericpark 'sudo k3s kubectl apply -f /tmp/namespace.yaml -f /tmp/secret.yaml && rm /tmp/secret.yaml'
+```
+
+- [ ] **Step 6: Pin the image SHA and deploy the CronJob**
+
+```bash
+SHA=$(git rev-parse HEAD)
+sed -i '' "s|REPLACE_WITH_SHA|$SHA|" k8s/cronjob.yaml
+scp k8s/cronjob.yaml ericpark@ericpark:/tmp/
+ssh ericpark@ericpark 'sudo k3s kubectl apply -f /tmp/cronjob.yaml'
+```
+
+- [ ] **Step 7: Trigger a manual run and verify it succeeds**
+
+```bash
+ssh ericpark@ericpark 'sudo k3s kubectl -n codexisland create job --from=cronjob/model-catalog-sync manual-1'
+sleep 45
+ssh ericpark@ericpark 'sudo k3s kubectl -n codexisland logs job/manual-1'
+```
+
+Expected: `no change (NN models)` — the catalog was already bootstrapped in Task 5, so a healthy run finds nothing to do. Any other outcome means the clone, the token, or the gate is misconfigured. Clean up: `ssh ericpark@ericpark 'sudo k3s kubectl -n codexisland delete job manual-1'`
+
+- [ ] **Step 8: Commit the pinned manifest**
+
+```bash
+git add k8s/cronjob.yaml
+git commit -m "chore: pin sync image to released sha"
+git push
+```
+
+---
+
+## Done when
+
+- `https://ericjypark.github.io/codex-island-model-catalog/v1/models.json` returns 200 with an ETag, and 304 on conditional GET.
+- Every model in `Sources/Cost/Pricing.swift` appears in the payload with matching rates.
+- `go test ./...` passes.
+- A manual CronJob run completes and reports `no change`.
+- `k8s/secret.yaml` is untracked; no token appears anywhere in git history.

--- a/docs/superpowers/plans/2026-07-26-model-catalog-service.md
+++ b/docs/superpowers/plans/2026-07-26-model-catalog-service.md
@@ -1510,17 +1510,22 @@ func commit(repo string, count int) error {
 		"-c", "user.email=bot@codexisland.dev",
 		"-c", "user.name=codexisland-catalog-bot",
 	}
-	steps := [][]string{
-		{"add", catalogPath},
-		append(append([]string{}, ident...),
-			"commit", "-m", fmt.Sprintf("chore: refresh model catalog (%d models)", count)),
-		{"push"},
+	// Named rather than derived from args[0]: the commit step leads with the
+	// identity flags, so args[0] would report a failed commit as "git -c".
+	steps := []struct {
+		name string
+		args []string
+	}{
+		{"add", []string{"add", catalogPath}},
+		{"commit", append(append([]string{}, ident...),
+			"commit", "-m", fmt.Sprintf("chore: refresh model catalog (%d models)", count))},
+		{"push", []string{"push"}},
 	}
-	for _, args := range steps {
-		cmd := exec.Command("git", append([]string{"-C", repo}, args...)...)
+	for _, step := range steps {
+		cmd := exec.Command("git", append([]string{"-C", repo}, step.args...)...)
 		cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr
 		if err := cmd.Run(); err != nil {
-			return fmt.Errorf("git %s: %w", args[0], err)
+			return fmt.Errorf("git %s: %w", step.name, err)
 		}
 	}
 	return nil

--- a/docs/superpowers/plans/2026-07-26-model-catalog-service.md
+++ b/docs/superpowers/plans/2026-07-26-model-catalog-service.md
@@ -1613,10 +1613,17 @@ Create `.dockerignore`:
 
 ```
 .git
+.superpowers
 README.md
+k8s/secret.yaml
 ```
 
-`k8s/` stays copyable — Step 3 adds an entrypoint script that lives there.
+`k8s/` stays copyable — Step 3 adds an entrypoint script that lives there — but
+`k8s/secret.yaml` must not be. `Dockerfile`'s `COPY . .` would otherwise sweep
+the live PAT the repo instructs you to create there into the build-stage layer
+and the local BuildKit cache. It never reaches CI (the file is gitignored, so a
+CI checkout has no copy) or the published image (the final stage copies only
+the binary), but a credential in a build cache is still a credential at rest.
 
 - [ ] **Step 2: Build the image locally to verify it compiles**
 
@@ -1631,8 +1638,7 @@ The CronJob starts from an empty filesystem, so it must clone first. Create `k8s
 Append to `Dockerfile` before the `ENTRYPOINT` line:
 
 ```dockerfile
-COPY k8s/entrypoint.sh /usr/local/bin/entrypoint.sh
-RUN chmod +x /usr/local/bin/entrypoint.sh
+COPY --chmod=0755 k8s/entrypoint.sh /usr/local/bin/entrypoint.sh
 ```
 
 and change the last line to:
@@ -1678,6 +1684,11 @@ on:
   push:
     branches: [main]
   pull_request:
+
+# The default is whatever the repo is configured for, which on a public repo
+# may be write-all. The image job widens this for itself; nothing else needs to.
+permissions:
+  contents: read
 
 jobs:
   test:
@@ -1754,14 +1765,25 @@ metadata:
 spec:
   schedule: "17 */6 * * *"
   concurrencyPolicy: Forbid
+  # Unset, the controller counts missed schedules from lastScheduleTime and
+  # permanently stops scheduling past 100 — 25 days of Pi downtime at this
+  # interval, after which the CronJob silently never fires again.
+  startingDeadlineSeconds: 3600
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3
   jobTemplate:
     spec:
       backoffLimit: 2
+      # A run that hangs rather than fails would block every later run forever
+      # under Forbid. git has no default network timeout, so a stalled clone
+      # waits on TCP keepalive — over two hours on Linux defaults.
+      activeDeadlineSeconds: 900
       template:
         spec:
-          restartPolicy: OnFailure
+          # Never, not OnFailure: OnFailure restarts in place and all three
+          # attempts share one container-log slot, so the first two are lost.
+          # This job is unattended and logs are its only failure signal.
+          restartPolicy: Never
           containers:
             - name: sync
               image: ghcr.io/ericjypark/codex-island-model-catalog:REPLACE_WITH_SHA
@@ -1785,7 +1807,11 @@ Create `.gitignore`:
 
 ```
 k8s/secret.yaml
+.superpowers/
 ```
+
+`.superpowers/` holds scratch review artifacts. It is untracked either way, but
+this repo is about to be public and `git add -A` should not be able to sweep it in.
 
 - [ ] **Step 8: Write the README**
 

--- a/docs/superpowers/plans/2026-07-26-model-catalog-service.md
+++ b/docs/superpowers/plans/2026-07-26-model-catalog-service.md
@@ -1615,7 +1615,8 @@ Create `.dockerignore`:
 .git
 .superpowers
 README.md
-k8s/secret.yaml
+k8s/secret*.yaml
+!k8s/secret.example.yaml
 ```
 
 `k8s/` stays copyable — Step 3 adds an entrypoint script that lives there — but
@@ -1767,7 +1768,9 @@ spec:
   concurrencyPolicy: Forbid
   # Unset, the controller counts missed schedules from lastScheduleTime and
   # permanently stops scheduling past 100 — 25 days of Pi downtime at this
-  # interval, after which the CronJob silently never fires again.
+  # interval, after which the CronJob silently never fires again. The trade:
+  # a tick missed by more than an hour is now skipped rather than run late,
+  # which is right for a job that is idempotent and runs again in six hours.
   startingDeadlineSeconds: 3600
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3
@@ -1778,6 +1781,12 @@ spec:
       # under Forbid. git has no default network timeout, so a stalled clone
       # waits on TCP keepalive — over two hours on Linux defaults.
       activeDeadlineSeconds: 900
+      # restartPolicy: Never retains a pod per failed attempt, and a retained
+      # pod keeps its container snapshot — including /tmp/repo/.git/config,
+      # which holds the PAT interpolated into the remote URL. A day is enough
+      # to debug four six-hourly runs; weeks of a credential at rest is not
+      # a trade worth making for logs nobody will read that late.
+      ttlSecondsAfterFinished: 86400
       template:
         spec:
           # Never, not OnFailure: OnFailure restarts in place and all three
@@ -1796,7 +1805,12 @@ spec:
                   memory: 32Mi
                 limits:
                   cpu: 500m
-                  memory: 128Mi
+                  # litellm.Fetch buffers up to 32 MiB and json.Unmarshal's it
+                  # with the raw bytes still live, so 128Mi would OOMKill
+                  # before the code's own ceiling ever tripped. Today's
+                  # upstream file is a few MB; this makes the guard in the
+                  # code the real limit rather than the manifest.
+                  memory: 256Mi
 ```
 
 `17 */6 * * *` rather than `0 */6 * * *` — an off-the-hour minute avoids piling onto the same upstream-fetch spike as every other cron on the internet.
@@ -1806,9 +1820,13 @@ spec:
 Create `.gitignore`:
 
 ```
-k8s/secret.yaml
+k8s/secret*.yaml
+!k8s/secret.example.yaml
 .superpowers/
 ```
+
+The glob rather than the exact name: `secret.example.yaml` tells you to copy it,
+and a maintainer who lands on `secret-prod.yaml` should still be covered.
 
 `.superpowers/` holds scratch review artifacts. It is untracked either way, but
 this repo is about to be public and `git add -A` should not be able to sweep it in.

--- a/docs/superpowers/plans/2026-07-26-model-catalog-service.md
+++ b/docs/superpowers/plans/2026-07-26-model-catalog-service.md
@@ -1984,10 +1984,12 @@ Then, from `~/Desktop/Projects/codex-island-infra`:
 cp k8s/secret.example.yaml k8s/secret.yaml
 ```
 
-Paste the token into that copy, then:
+Paste the token into that copy, then pipe it over stdin rather than copying it
+to the Pi — this way the token never lands on that filesystem at all, so there
+is no `rm` to forget:
 
 ```bash
-scp k8s/namespace.yaml k8s/secret.yaml ericpark@ericpark:/tmp/ && ssh ericpark@ericpark 'sudo k3s kubectl apply -f /tmp/namespace.yaml -f /tmp/secret.yaml && rm /tmp/secret.yaml'
+cat k8s/namespace.yaml | ssh ericpark@ericpark 'sudo k3s kubectl apply -f -' && cat k8s/secret.yaml | ssh ericpark@ericpark 'sudo k3s kubectl apply -f -'
 ```
 
 - [ ] **Step 7: Pin the image SHA and deploy the CronJob**

--- a/docs/superpowers/plans/2026-07-26-model-catalog-service.md
+++ b/docs/superpowers/plans/2026-07-26-model-catalog-service.md
@@ -522,6 +522,20 @@ func variantLabel(date string) string {
 	return date
 }
 
+// ValidateConfig rejects a malformed pattern up front. path.Match reports a
+// bad pattern only as an error return, so a typo in config.json would
+// otherwise make an entire provider's models vanish from the catalog with no
+// signal at all — and the run-level count check would be the only thing that
+// noticed.
+func ValidateConfig(cfg Config) error {
+	for _, p := range cfg.Patterns {
+		if _, err := path.Match(p, "validate"); err != nil {
+			return fmt.Errorf("config: bad pattern %q: %w", p, err)
+		}
+	}
+	return nil
+}
+
 func tracked(id string, e litellm.Entry, cfg Config) bool {
 	if id == "sample_spec" || strings.Contains(id, "/") {
 		return false
@@ -840,12 +854,36 @@ func TestGateFirstRunNeverAborts(t *testing.T) {
 	if got.Aborted {
 		t.Error("bootstrapping against an empty catalog must not abort")
 	}
+	// Without this, a gate that rejected every baseline-less model would
+	// still pass: the catalog would silently stop accepting new models.
+	if _, ok := got.Models["a"]; !ok {
+		t.Error("a valid brand-new model must be published")
+	}
 }
 
+func TestGateAbortKeepsPublishedRatherThanEmptying(t *testing.T) {
+	published := map[string]Rates{
+		"a": rate(1, 2), "b": rate(1, 2), "c": rate(1, 2), "d": rate(1, 2),
+	}
+	got := Gate(map[string]Rates{"a": rate(1, 2)}, published)
+	if !got.Aborted {
+		t.Fatal("expected abort")
+	}
+	if len(got.Models) != len(published) {
+		t.Errorf("abort returned %d models, want the published %d — an empty "+
+			"map would price everything at $0 for any caller that skips the "+
+			"Aborted check", len(got.Models), len(published))
+	}
+}
+
+// Zero baseline routes past the ratio rule, so the negative check is the
+// only rule that can reject this. Without it the test would pass even with
+// the negative check deleted.
 func TestGateRejectsNegativeRate(t *testing.T) {
-	published := map[string]Rates{"a": rate(1, 2)}
-	got := Gate(map[string]Rates{"a": rate(-1, 2)}, published)
-	if got.Models["a"].InputPerMillion != 1 {
+	published := map[string]Rates{"a": {InputPerMillion: 1, OutputPerMillion: 2, CacheReadPerMillion: 0}}
+	candidate := map[string]Rates{"a": {InputPerMillion: 1, OutputPerMillion: 2, CacheReadPerMillion: -0.1}}
+	got := Gate(candidate, published)
+	if got.Models["a"].CacheReadPerMillion != 0 {
 		t.Errorf("negative rate should keep the published value, got %v", got.Models["a"])
 	}
 	if len(got.Rejections) == 0 {
@@ -853,11 +891,43 @@ func TestGateRejectsNegativeRate(t *testing.T) {
 	}
 }
 
-func TestGateRejectsAbsurdInputRate(t *testing.T) {
+// The cap is checked before the ratio rule (it has to be — the ratio rule is
+// skipped for baseline-less models, and the cap must not be). So this pins
+// the baselined-above-cap path: rejected, but kept at its published value
+// rather than omitted. TestGateRejectsTenfoldJump covers the ratio rule.
+func TestGateRejectsAboveCapKeepsPublished(t *testing.T) {
 	published := map[string]Rates{"a": rate(5, 10)}
 	got := Gate(map[string]Rates{"a": rate(1001, 10)}, published)
 	if got.Models["a"].InputPerMillion != 5 {
-		t.Errorf("absurd rate should keep published value, got %v", got.Models["a"])
+		t.Errorf("above-cap rate should keep published value, got %v", got.Models["a"])
+	}
+}
+
+// The cap is the entire defense for a model with no baseline, so it is
+// tested there — and on a non-input field, since the ratio rule that covers
+// the other three is skipped in exactly this case.
+func TestGateOmitsAbsurdBrandNewModel(t *testing.T) {
+	got := Gate(map[string]Rates{
+		"a":       rate(1, 2),
+		"new":     {InputPerMillion: 5001, OutputPerMillion: 10, CacheCreationPerMillion: 5, CacheReadPerMillion: 0.5},
+		"newout":  {InputPerMillion: 5, OutputPerMillion: 1000000, CacheCreationPerMillion: 5, CacheReadPerMillion: 0.5},
+		"atlimit": {InputPerMillion: 1000, OutputPerMillion: 10, CacheCreationPerMillion: 5, CacheReadPerMillion: 0.5},
+	}, map[string]Rates{"a": rate(1, 2)})
+
+	if _, ok := got.Models["new"]; ok {
+		t.Error("brand-new model above the input cap must be omitted")
+	}
+	if _, ok := got.Models["newout"]; ok {
+		t.Error("brand-new model above the output cap must be omitted")
+	}
+	if _, ok := got.Models["atlimit"]; !ok {
+		t.Error("exactly at the cap must survive — the bound is exclusive")
+	}
+	if _, ok := got.Models["a"]; !ok {
+		t.Error("the valid model must survive; the gate rejected everything")
+	}
+	if len(got.Rejections) != 2 {
+		t.Errorf("want 2 rejections, got %v", got.Rejections)
 	}
 }
 
@@ -929,8 +999,8 @@ package catalog
 import "fmt"
 
 const (
-	maxInputPerMillion = 1000.0
-	maxRatioChange     = 10.0
+	maxPerMillion  = 1000.0
+	maxRatioChange = 10.0
 )
 
 type GateResult struct {
@@ -950,6 +1020,10 @@ func Gate(candidate, published map[string]Rates) GateResult {
 	res := GateResult{Models: make(map[string]Rates, len(candidate)+len(published))}
 
 	if n := len(published); n > 0 && len(candidate)*2 < n {
+		// Hand back what is already published, never an empty map: a caller
+		// that forgets to check Aborted must produce a no-op, not a catalog
+		// of zero models — which would price everything at $0 in the app.
+		res.Models = published
 		res.Aborted = true
 		res.AbortReason = fmt.Sprintf(
 			"model count collapsed: %d candidates against %d published", len(candidate), n)
@@ -991,6 +1065,13 @@ func check(next, prev Rates, hadPrev bool) string {
 		if f.next < 0 {
 			return fmt.Sprintf("%s is negative (%v)", f.name, f.next)
 		}
+		// The absolute ceiling applies to every rate, not just input. For a
+		// brand-new model the ratio rule below is skipped entirely, so this
+		// is the only bound that rule ever sees — and output tokens dominate
+		// the app's spend arithmetic.
+		if f.next > maxPerMillion {
+			return fmt.Sprintf("%s %v exceeds %v", f.name, f.next, maxPerMillion)
+		}
 		if !hadPrev || f.prev <= 0 {
 			// No baseline, or a rate legitimately moving off zero — the
 			// ratio test has nothing meaningful to say.
@@ -999,9 +1080,6 @@ func check(next, prev Rates, hadPrev bool) string {
 		if f.next >= f.prev*maxRatioChange || f.next*maxRatioChange <= f.prev {
 			return fmt.Sprintf("%s moved %v -> %v", f.name, f.prev, f.next)
 		}
-	}
-	if next.InputPerMillion > maxInputPerMillion {
-		return fmt.Sprintf("inputPerMillion %v exceeds %v", next.InputPerMillion, maxInputPerMillion)
 	}
 	return ""
 }
@@ -1208,6 +1286,9 @@ func run() error {
 	cfg, err := readJSON[catalog.Config](filepath.Join(repo, "config.json"))
 	if err != nil {
 		return fmt.Errorf("config.json: %w", err)
+	}
+	if err := catalog.ValidateConfig(cfg); err != nil {
+		return err
 	}
 	overrides, err := readJSON[map[string]catalog.Override](filepath.Join(repo, "overrides.json"))
 	if err != nil {

--- a/docs/superpowers/plans/2026-07-26-model-catalog-service.md
+++ b/docs/superpowers/plans/2026-07-26-model-catalog-service.md
@@ -1104,10 +1104,11 @@ git commit -m "feat: add sanity gate guarding published price changes"
 
 **Files:**
 - Create: `internal/catalog/encode.go`
+- Modify: `internal/catalog/overrides.go` (add `ValidateOverrides`)
 - Create: `cmd/sync/main.go`
 - Create: `v1/models.json`
 - Create: `.nojekyll`
-- Test: `internal/catalog/encode_test.go`
+- Test: `internal/catalog/encode_test.go`, `internal/catalog/overrides_test.go`
 
 **Interfaces:**
 - Consumes: everything from Tasks 1–4. The test below reuses the `rate(in, out float64) Rates` helper defined in `gate_test.go` (Task 4) — same package, so Task 4 must land first.
@@ -1203,6 +1204,73 @@ Run: `go test ./internal/catalog/ -run 'TestEncode|TestDecode|TestModelsEqual' -
 
 Expected: FAIL — `undefined: Encode`, `undefined: Decode`, `undefined: ModelsEqual`.
 
+- [ ] **Step 2b: Write the failing test for override validation**
+
+Because `cmd/sync` re-applies overrides *after* the gate, override values never
+pass through `check` — that is what makes them an escape hatch, and it also
+means nothing stands between a typo and the published catalog. Bounding their
+magnitude again would close the hatch, so only the unambiguous error is caught.
+
+Add to `internal/catalog/overrides_test.go`:
+
+```go
+func TestValidateOverrides(t *testing.T) {
+	ok := map[string]Override{
+		"a": {InputPerMillion: f(5), CacheReadPerMillion: f(0)},
+		// Deliberately far above the gate's cap: an override exists so a
+		// legitimately expensive model can exceed it.
+		"b": {OutputPerMillion: f(5000)},
+	}
+	if err := ValidateOverrides(ok); err != nil {
+		t.Errorf("valid overrides rejected: %v", err)
+	}
+
+	bad := map[string]Override{"c": {CacheReadPerMillion: f(-0.1)}}
+	err := ValidateOverrides(bad)
+	if err == nil {
+		t.Fatal("negative override should be rejected")
+	}
+	if !strings.Contains(err.Error(), "c") {
+		t.Errorf("error should name the offending model, got %v", err)
+	}
+}
+```
+
+- [ ] **Step 2c: Implement `ValidateOverrides`**
+
+Append to `internal/catalog/overrides.go`:
+
+```go
+// ValidateOverrides rejects values that cannot be anything but a typo.
+//
+// Magnitude is deliberately unbounded. An override's whole purpose is to let
+// a legitimately expensive model exceed the gate's absolute cap, and it is
+// applied after the gate for that reason — re-bounding it here would close
+// the escape hatch. Review of the public PR that changes overrides.json is
+// the control on magnitude. A negative rate, though, is never intentional.
+func ValidateOverrides(ov map[string]Override) error {
+	for id, o := range ov {
+		fields := []struct {
+			name string
+			val  *float64
+		}{
+			{"inputPerMillion", o.InputPerMillion},
+			{"outputPerMillion", o.OutputPerMillion},
+			{"cacheCreationPerMillion", o.CacheCreationPerMillion},
+			{"cacheReadPerMillion", o.CacheReadPerMillion},
+		}
+		for _, f := range fields {
+			if f.val != nil && *f.val < 0 {
+				return fmt.Errorf("overrides: %s: %s is negative (%v)", id, f.name, *f.val)
+			}
+		}
+	}
+	return nil
+}
+```
+
+`overrides.go` gains a `fmt` import.
+
 - [ ] **Step 3: Write the implementation**
 
 Create `internal/catalog/encode.go`:
@@ -1293,6 +1361,9 @@ func run() error {
 	overrides, err := readJSON[map[string]catalog.Override](filepath.Join(repo, "overrides.json"))
 	if err != nil {
 		return fmt.Errorf("overrides.json: %w", err)
+	}
+	if err := catalog.ValidateOverrides(overrides); err != nil {
+		return err
 	}
 
 	published := map[string]catalog.Rates{}

--- a/docs/superpowers/plans/2026-07-26-model-catalog-service.md
+++ b/docs/superpowers/plans/2026-07-26-model-catalog-service.md
@@ -335,6 +335,31 @@ func TestBuildFilters(t *testing.T) {
 	}
 }
 
+// The rates that expose the residue are the cheap ones — these three inputs
+// are exactly the values that produced 0.049999999999999996,
+// 0.39999999999999997 and 0.19999999999999998 in the first bootstrap.
+func TestBuildRoundsFloatResidue(t *testing.T) {
+	got, _ := Build(map[string]litellm.Entry{
+		"gpt-5.9-nano": {
+			Mode:                    "chat",
+			InputCostPerToken:       f(0.00000005),
+			OutputCostPerToken:      f(0.0000004),
+			CacheReadInputTokenCost: f(0.0000002),
+		},
+	}, testCfg)
+
+	r := got["gpt-5.9-nano"]
+	if r.InputPerMillion != 0.05 {
+		t.Errorf("input = %v, want exactly 0.05", r.InputPerMillion)
+	}
+	if r.OutputPerMillion != 0.4 {
+		t.Errorf("output = %v, want exactly 0.4", r.OutputPerMillion)
+	}
+	if r.CacheReadPerMillion != 0.2 {
+		t.Errorf("cacheRead = %v, want exactly 0.2", r.CacheReadPerMillion)
+	}
+}
+
 func TestBuildRequiresBothBaseRates(t *testing.T) {
 	got, _ := Build(map[string]litellm.Entry{
 		"gpt-5.9": {Mode: "chat", InputCostPerToken: f(0.000005)},
@@ -450,6 +475,7 @@ package catalog
 
 import (
 	"fmt"
+	"math"
 	"path"
 	"strings"
 
@@ -554,19 +580,29 @@ func tracked(id string, e litellm.Entry, cfg Config) bool {
 	return false
 }
 
+// perMillion converts a per-token price and rounds off the binary-float
+// residue the multiplication leaves behind: 2e-7 * 1e6 lands on
+// 0.19999999999999998, which would be published verbatim into a file whose
+// entire point is that a human can read a price and check it against the
+// vendor's page. Eight decimals is far finer than any real rate and coarse
+// enough to erase the artifact.
+func perMillion(perToken float64) float64 {
+	return math.Round(perToken*1e6*1e8) / 1e8
+}
+
 func convert(canonical string, e litellm.Entry) Rates {
-	input := *e.InputCostPerToken * 1e6
+	input := perMillion(*e.InputCostPerToken)
 	r := Rates{
 		DisplayName:             DisplayName(canonical),
 		InputPerMillion:         input,
-		OutputPerMillion:        *e.OutputCostPerToken * 1e6,
+		OutputPerMillion:        perMillion(*e.OutputCostPerToken),
 		CacheCreationPerMillion: input,
 	}
 	if e.CacheCreationInputTokenCost != nil {
-		r.CacheCreationPerMillion = *e.CacheCreationInputTokenCost * 1e6
+		r.CacheCreationPerMillion = perMillion(*e.CacheCreationInputTokenCost)
 	}
 	if e.CacheReadInputTokenCost != nil {
-		r.CacheReadPerMillion = *e.CacheReadInputTokenCost * 1e6
+		r.CacheReadPerMillion = perMillion(*e.CacheReadInputTokenCost)
 	}
 	return r
 }

--- a/docs/superpowers/plans/2026-07-26-model-catalog-service.md
+++ b/docs/superpowers/plans/2026-07-26-model-catalog-service.md
@@ -14,7 +14,22 @@
 
 ## Global Constraints
 
-- **Working repo:** `ericjypark/codex-island-model-catalog`. This plan does **not** touch the `codex-island` app repo.
+> **Repo split, decided after Task 6.** Tasks 1–6 were built in a single repo
+> and then split, because publishing the k8s manifests would expose the shape
+> of a personal deployment — namespace, secret name, schedule, image path —
+> which the app repo's own `CLAUDE.md` says belongs in maintainer-only
+> storage. The code needed no change: `cmd/sync` already reads everything from
+> `REPO_DIR`, and the entrypoint already clones that directory by URL. Task
+> text below still reads as one repo; the file lists are what matter.
+>
+> - **`ericjypark/codex-island-model-catalog`** (public) — `v1/models.json`,
+>   `overrides.json`, `config.json`, `.nojekyll`, `README.md`. The audit
+>   surface and the PR surface.
+> - **`ericjypark/codex-island-infra`** (private) — Go module
+>   `github.com/ericjypark/codex-island-infra`, `Dockerfile`, CI, `k8s/`.
+>   Builds `ghcr.io/ericjypark/codex-island-infra:<sha>`.
+
+- **Working repos:** the two above. This plan does **not** touch the `codex-island` app repo.
 - **Go standard library only.** No third-party modules. `go.mod` must have an empty `require` block.
 - **Schema version is 1.** Any breaking payload change ships at `/v2/models.json`; `/v1/` keeps its shape forever.
 - **The bot never removes a model.** If LiteLLM drops an entry, the published value stays.
@@ -1902,23 +1917,37 @@ The manual, out-of-band steps. Everything before this was local.
 - Consumes: everything from Tasks 1–6.
 - Produces: a live URL the companion app plan consumes.
 
-- [ ] **Step 1: Push and make the repo public**
+- [ ] **Step 1: Push the private infra repo**
 
 ```bash
-git push -u origin main
+cd ~/Desktop/Projects/codex-island-infra && git push -u origin main
+```
+
+- [ ] **Step 2: Push the catalog repo and make it public**
+
+```bash
+cd ~/Desktop/Projects/codex-island-model-catalog && git push -u origin main
+```
+
+```bash
 gh repo edit ericjypark/codex-island-model-catalog --visibility public --accept-visibility-change-consequences
 ```
 
-- [ ] **Step 2: Verify CI built and pushed the image**
+- [ ] **Step 3: Verify CI built and pushed the image**
+
+CI lives in the infra repo, and so does the image.
 
 ```bash
-gh run watch --exit-status -R ericjypark/codex-island-model-catalog
-gh api /users/ericjypark/packages/container/codex-island-model-catalog/versions --jq '.[0].metadata.container.tags'
+gh run watch --exit-status -R ericjypark/codex-island-infra
+```
+
+```bash
+gh api /users/ericjypark/packages/container/codex-island-infra/versions --jq '.[0].metadata.container.tags'
 ```
 
 Expected: the workflow succeeds and the package lists the head commit SHA as a tag.
 
-- [ ] **Step 3: Enable GitHub Pages**
+- [ ] **Step 4: Enable GitHub Pages on the catalog repo**
 
 ```bash
 gh api -X POST repos/ericjypark/codex-island-model-catalog/pages \
@@ -1942,42 +1971,59 @@ curl -sS -o /dev/null -w '%{http_code}\n' -H "If-None-Match: $ETAG" https://eric
 
 Expected: `304`. The app's daily refresh depends on this.
 
-- [ ] **Step 5: Mint the PAT and create the secret**
+- [ ] **Step 6: Mint the PAT and create the secret**
 
-Create a fine-grained PAT at https://github.com/settings/personal-access-tokens/new with **Repository access:** only `ericjypark/codex-island-model-catalog`, **Permissions:** Contents → Read and write. Then:
+**The maintainer does this step, not an agent.** Create a fine-grained PAT at
+https://github.com/settings/personal-access-tokens/new with **Repository
+access:** only `ericjypark/codex-island-model-catalog` (the data repo — the bot
+never writes to the infra repo), **Permissions:** Contents → Read and write.
+
+Then, from `~/Desktop/Projects/codex-island-infra`:
 
 ```bash
 cp k8s/secret.example.yaml k8s/secret.yaml
-# edit k8s/secret.yaml, paste the token
-scp k8s/namespace.yaml k8s/secret.yaml ericpark@ericpark:/tmp/
-ssh ericpark@ericpark 'sudo k3s kubectl apply -f /tmp/namespace.yaml -f /tmp/secret.yaml && rm /tmp/secret.yaml'
 ```
 
-- [ ] **Step 6: Pin the image SHA and deploy the CronJob**
+Paste the token into that copy, then:
 
 ```bash
-SHA=$(git rev-parse HEAD)
-sed -i '' "s|REPLACE_WITH_SHA|$SHA|" k8s/cronjob.yaml
-scp k8s/cronjob.yaml ericpark@ericpark:/tmp/
-ssh ericpark@ericpark 'sudo k3s kubectl apply -f /tmp/cronjob.yaml'
+scp k8s/namespace.yaml k8s/secret.yaml ericpark@ericpark:/tmp/ && ssh ericpark@ericpark 'sudo k3s kubectl apply -f /tmp/namespace.yaml -f /tmp/secret.yaml && rm /tmp/secret.yaml'
 ```
 
-- [ ] **Step 7: Trigger a manual run and verify it succeeds**
+- [ ] **Step 7: Pin the image SHA and deploy the CronJob**
+
+The SHA is the infra repo's head, since that is what CI built the image from.
+
+```bash
+cd ~/Desktop/Projects/codex-island-infra && sed -i '' "s|REPLACE_WITH_SHA|$(git rev-parse HEAD)|" k8s/cronjob.yaml
+```
+
+```bash
+scp k8s/cronjob.yaml ericpark@ericpark:/tmp/ && ssh ericpark@ericpark 'sudo k3s kubectl apply -f /tmp/cronjob.yaml'
+```
+
+- [ ] **Step 8: Trigger a manual run and verify it succeeds**
 
 ```bash
 ssh ericpark@ericpark 'sudo k3s kubectl -n codexisland create job --from=cronjob/model-catalog-sync manual-1'
-sleep 45
-ssh ericpark@ericpark 'sudo k3s kubectl -n codexisland logs job/manual-1'
 ```
 
-Expected: `no change (NN models)` — the catalog was already bootstrapped in Task 5, so a healthy run finds nothing to do. Any other outcome means the clone, the token, or the gate is misconfigured. Clean up: `ssh ericpark@ericpark 'sudo k3s kubectl -n codexisland delete job manual-1'`
+```bash
+sleep 60 && ssh ericpark@ericpark 'sudo k3s kubectl -n codexisland logs job/manual-1'
+```
 
-- [ ] **Step 8: Commit the pinned manifest**
+Expected: `no change (78 models)` — the catalog was bootstrapped in Task 5 and pushed in Step 2, so a healthy run finds nothing to do. Any other outcome means the clone, the token, or the gate is misconfigured. `restartPolicy: Never` means each failed attempt is its own pod, so `kubectl -n codexisland get pods` lists them all if you need to read more than one.
+
+Clean up:
 
 ```bash
-git add k8s/cronjob.yaml
-git commit -m "chore: pin sync image to released sha"
-git push
+ssh ericpark@ericpark 'sudo k3s kubectl -n codexisland delete job manual-1'
+```
+
+- [ ] **Step 9: Commit the pinned manifest**
+
+```bash
+cd ~/Desktop/Projects/codex-island-infra && git commit -qam "chore: pin sync image to released sha" && git push
 ```
 
 ---
@@ -1986,6 +2032,7 @@ git push
 
 - `https://ericjypark.github.io/codex-island-model-catalog/v1/models.json` returns 200 with an ETag, and 304 on conditional GET.
 - Every model in `Sources/Cost/Pricing.swift` appears in the payload with matching rates.
-- `go test ./...` passes.
+- `go test ./...` passes in the infra repo.
 - A manual CronJob run completes and reports `no change`.
-- `k8s/secret.yaml` is untracked; no token appears anywhere in git history.
+- The public catalog repo contains only `v1/models.json`, `overrides.json`, `config.json`, `.nojekyll`, `README.md`, `.gitignore` — no deployment shape.
+- `k8s/secret.yaml` is untracked; no token appears anywhere in either repo's history.

--- a/docs/superpowers/plans/2026-07-26-model-catalog-service.md
+++ b/docs/superpowers/plans/2026-07-26-model-catalog-service.md
@@ -341,10 +341,11 @@ func TestBuildFilters(t *testing.T) {
 func TestBuildRoundsFloatResidue(t *testing.T) {
 	got, _ := Build(map[string]litellm.Entry{
 		"gpt-5.9-nano": {
-			Mode:                    "chat",
-			InputCostPerToken:       f(0.00000005),
-			OutputCostPerToken:      f(0.0000004),
-			CacheReadInputTokenCost: f(0.0000002),
+			Mode:                        "chat",
+			InputCostPerToken:           f(0.00000005),
+			OutputCostPerToken:          f(0.0000004),
+			CacheCreationInputTokenCost: f(0.0000004),
+			CacheReadInputTokenCost:     f(0.0000002),
 		},
 	}, testCfg)
 
@@ -354,6 +355,12 @@ func TestBuildRoundsFloatResidue(t *testing.T) {
 	}
 	if r.OutputPerMillion != 0.4 {
 		t.Errorf("output = %v, want exactly 0.4", r.OutputPerMillion)
+	}
+	// Set explicitly, so this covers the assignment inside the
+	// CacheCreationInputTokenCost branch rather than the "= input" fallback.
+	// That branch is live for every Anthropic model in the catalog.
+	if r.CacheCreationPerMillion != 0.4 {
+		t.Errorf("cacheCreation = %v, want exactly 0.4", r.CacheCreationPerMillion)
 	}
 	if r.CacheReadPerMillion != 0.2 {
 		t.Errorf("cacheRead = %v, want exactly 0.2", r.CacheReadPerMillion)
@@ -1362,7 +1369,9 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io/fs"
 	"log"
 	"os"
 	"os/exec"
@@ -1403,12 +1412,23 @@ func run() error {
 	}
 
 	published := map[string]catalog.Rates{}
-	if raw, err := os.ReadFile(filepath.Join(repo, catalogPath)); err == nil {
-		prev, err := catalog.Decode(raw)
-		if err != nil {
-			return fmt.Errorf("%s: %w", catalogPath, err)
+	raw, err := os.ReadFile(filepath.Join(repo, catalogPath))
+	switch {
+	case err == nil:
+		prev, decErr := catalog.Decode(raw)
+		if decErr != nil {
+			return fmt.Errorf("%s: %w", catalogPath, decErr)
 		}
 		published = prev.Models
+	case errors.Is(err, fs.ErrNotExist):
+		// Genuine first run — an empty `published` is correct here.
+	default:
+		// Every other read error must stop the run. An empty `published`
+		// silently disables the collapse abort (gated on len > 0), the ratio
+		// rule (every model looks brand new), and the carry-forward loop that
+		// implements "never remove a model" — so one transient I/O fault
+		// would let a single upstream response overwrite the catalog whole.
+		return fmt.Errorf("%s: %w", catalogPath, err)
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
@@ -1482,11 +1502,18 @@ func readJSON[T any](path string) (T, error) {
 }
 
 func commit(repo string, count int) error {
+	// Identity travels per-invocation rather than through `git config`, which
+	// writes at local scope and would permanently rewrite the bot identity
+	// into whatever clone this runs in — including a maintainer's during
+	// local iteration.
+	ident := []string{
+		"-c", "user.email=bot@codexisland.dev",
+		"-c", "user.name=codexisland-catalog-bot",
+	}
 	steps := [][]string{
-		{"config", "user.email", "bot@codexisland.dev"},
-		{"config", "user.name", "codexisland-catalog-bot"},
 		{"add", catalogPath},
-		{"commit", "-m", fmt.Sprintf("chore: refresh model catalog (%d models)", count)},
+		append(append([]string{}, ident...),
+			"commit", "-m", fmt.Sprintf("chore: refresh model catalog (%d models)", count)),
 		{"push"},
 	}
 	for _, args := range steps {

--- a/docs/superpowers/plans/2026-07-26-model-catalog-service.md
+++ b/docs/superpowers/plans/2026-07-26-model-catalog-service.md
@@ -1329,8 +1329,18 @@ func run() error {
 		return fmt.Errorf("aborted: %s", gated.AbortReason)
 	}
 
-	if catalog.ModelsEqual(gated.Models, published) {
-		log.Printf("no change (%d models)", len(gated.Models))
+	// Overrides are re-asserted after the gate, and this is what makes them a
+	// real escape hatch. The gate exists to stop bad *upstream* data; an
+	// override is hand-written and reviewed in a public PR, so it is trusted
+	// input. Without this second pass, a legitimately expensive model that
+	// trips the absolute cap could not be corrected by hand — the gate would
+	// reject the correction too, and the model would price at $0 forever.
+	// They are also applied before the gate so the ratio rule compares like
+	// with like against the published values.
+	final := catalog.ApplyOverrides(gated.Models, overrides)
+
+	if catalog.ModelsEqual(final, published) {
+		log.Printf("no change (%d models)", len(final))
 		return nil
 	}
 
@@ -1338,7 +1348,7 @@ func run() error {
 		SchemaVersion: catalog.SchemaVersion,
 		GeneratedAt:   time.Now().UTC().Format(time.RFC3339),
 		Source:        "litellm + overrides",
-		Models:        gated.Models,
+		Models:        final,
 	})
 	if err != nil {
 		return err
@@ -1346,12 +1356,12 @@ func run() error {
 	if err := os.WriteFile(filepath.Join(repo, catalogPath), out, 0o644); err != nil {
 		return err
 	}
-	log.Printf("updated: %d models (was %d)", len(gated.Models), len(published))
+	log.Printf("updated: %d models (was %d)", len(final), len(published))
 
 	if os.Getenv("SKIP_COMMIT") != "" {
 		return nil
 	}
-	return commit(repo, len(gated.Models))
+	return commit(repo, len(final))
 }
 
 func readJSON[T any](path string) (T, error) {

--- a/docs/superpowers/specs/2026-07-26-model-list-api-design.md
+++ b/docs/superpowers/specs/2026-07-26-model-list-api-design.md
@@ -73,7 +73,7 @@ overrides ┘    merge + sanity gate          (auditable)      (Fastly CDN)
 
 ## Payload
 
-`https://ericjypark.github.io/codex-island-model-list-api/v1/models.json`
+`https://ericjypark.github.io/codex-island-model-catalog/v1/models.json`
 
 ```json
 {
@@ -153,7 +153,7 @@ user within a day.
 
 ## Repository layout
 
-`ericjypark/codex-island-model-list-api` — **must be switched from private
+`ericjypark/codex-island-model-catalog` — **must be switched from private
 to public**; it is both the audit surface and the serving channel.
 
 ```
@@ -175,7 +175,7 @@ Namespace `codexisland` on the Pi's k3s.
 
 - **`CronJob model-list-sync`** — every 6h, `restartPolicy: OnFailure`,
   `backoffLimit: 2`, `concurrencyPolicy: Forbid`, image
-  `ghcr.io/ericjypark/codex-island-model-list-api:<sha>` — named after the
+  `ghcr.io/ericjypark/codex-island-model-catalog:<sha>` — named after the
   repo, matching the existing `ghcr.io/ericjypark/<name>:<sha>` convention
   on this cluster.
 - **`Secret codexisland-git`** — a fine-grained PAT with `contents: write`
@@ -276,7 +276,7 @@ analytics" both remain true and stay as-is.
 
 These are one-time, manual, and outside the code:
 
-1. Switch `codex-island-model-list-api` from private to public.
+1. Switch `codex-island-model-catalog` from private to public.
 2. Enable GitHub Pages on `main` / root.
 3. Mint the fine-grained PAT and apply it as `codexisland-git` in the
    `codexisland` namespace.

--- a/docs/superpowers/specs/2026-07-26-model-list-api-design.md
+++ b/docs/superpowers/specs/2026-07-26-model-list-api-design.md
@@ -1,0 +1,282 @@
+# Remote Model List & Pricing — Design
+
+**Date:** 2026-07-26
+**Status:** Approved (brainstorm complete)
+
+## Summary
+
+Move the per-model price table out of the app binary and into a public,
+bot-maintained JSON file served by GitHub. A CronJob on the maintainer's
+k3s cluster polls LiteLLM, merges hand-maintained overrides, runs a sanity
+gate, and commits the result. The app fetches it once a day and falls back
+through a disk cache to an embedded seed, so costs never silently collapse
+to $0.
+
+New models stop requiring an app release.
+
+## Problem
+
+`Sources/Cost/Pricing.swift` embeds 32 models × 4 rates as a Swift
+dictionary. Adding a model means editing that file, bumping `VERSION`,
+tagging, and pushing a Sparkle release — and users see correct dollar
+totals only after they take that update. Four of the eight commits that
+have ever touched `Pricing.swift` were pure "add a model" changes.
+
+Unknown models price to $0 (ccusage parity), so the failure is silent:
+between a model's launch and the release that adds it, users see totals
+that are simply wrong.
+
+## Decisions made during brainstorm
+
+- **Distribution channel is GitHub, not the maintainer's server.** The app
+  already contacts `github.com` daily for the Sparkle appcast
+  (`build.sh:35`), so serving pricing from GitHub adds *zero* new trust
+  surface. Routing the app at a personally-operated host would add one, and
+  would contradict README.md:84 ("no proxy service").
+- **The data is public and auditable.** Prices live in a public repo where
+  anyone can verify a value or send a PR. For an open-source cost tracker
+  this is a feature, not a leak — it is the opposite of a private
+  black box quoting numbers users cannot check.
+- **The Raspberry Pi produces data; it never serves users.** The merge bot
+  runs on the Pi's k3s cluster and pushes to GitHub. If the Pi is down,
+  nothing user-facing degrades — the file keeps being served, it just stops
+  getting fresher.
+- **Hybrid data source.** LiteLLM auto-sync plus a hand-maintained
+  `overrides.json`. Pure auto-sync cannot reproduce the deliberate
+  deviations already encoded in `Pricing.swift` (gpt-5.6 cache writes at
+  1.25× input, Sonnet 5 introductory pricing, `gpt-5-pro` cache-read of 0),
+  and LiteLLM has no entry at all for some ids the CLIs emit.
+- **Three-tier fallback in the app.** remote → disk cache → embedded seed.
+  A pod outage, an offline laptop, or a corrupt payload must never turn
+  into $0 costs.
+- **Payload carries `displayName`.** `prettyModelName()` is rule-based and
+  already mis-renders ids that break the pattern (`gpt-5.6-sol` →
+  `GPT-5.6-sol`). Serving the name kills that class of release too.
+- **User counting is not built.** GitHub release DMG download counts
+  already answer "how many people use this" — Sparkle downloads the DMG to
+  update, so per-release counts track active installs (374–745 across
+  recent releases). Adding a persistent identifier or a counted ping
+  endpoint would be app telemetry, which README.md:277 promises does not
+  exist. If finer numbers are ever needed, the honest path is explicit
+  opt-out telemetry in its own release — not a side effect of this work.
+
+## Architecture
+
+```
+LiteLLM ──┐
+          ├─► [Pi k3s CronJob] ──commit──► public repo ──► GitHub Pages ──► app
+overrides ┘    merge + sanity gate          (auditable)      (Fastly CDN)
+   ▲                                                              │
+   └── git is the source of truth for both input and output       ▼
+                                              remote → disk cache → seed
+```
+
+## Payload
+
+`https://ericjypark.github.io/codex-island-model-list-api/v1/models.json`
+
+```json
+{
+  "schemaVersion": 1,
+  "generatedAt": "2026-07-26T01:00:00Z",
+  "source": "litellm@<sha> + overrides",
+  "models": {
+    "claude-opus-4-8": {
+      "displayName": "Opus 4.8",
+      "inputPerMillion": 5,
+      "outputPerMillion": 25,
+      "cacheCreationPerMillion": 6.25,
+      "cacheReadPerMillion": 0.5
+    }
+  }
+}
+```
+
+- Keys are **canonical** model ids — the date suffix is already stripped
+  (`claude-haiku-4-5-20251001` → `claude-haiku-4-5`), matching what
+  `Pricing.canonicalModel` produces before lookup.
+- A map, not an array: decodes straight into `[String: Rates]`.
+- `source` is informational; the app ignores it.
+- The app **rejects any payload whose `schemaVersion` is not 1** and keeps
+  its cache. A breaking change ships at `/v2/models.json`; old installs keep
+  reading `/v1/` forever.
+
+## Sync bot
+
+Go binary, run as a k3s CronJob every 6 hours.
+
+1. Clone the data repo (shallow).
+2. `GET https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json`
+3. **Select** entries where `mode` is `chat` or `responses`, the id contains
+   no `/` (drops `azure/`, `bedrock/`, `vertex_ai/` re-listings), and the id
+   matches a pattern in `config.json` (`claude-*`, `gpt-5*`, `o[0-9]*`).
+4. **Map** to per-million rates (LiteLLM stores per-token):
+   - `input_cost_per_token` × 1e6 → `inputPerMillion`
+   - `output_cost_per_token` × 1e6 → `outputPerMillion`
+   - `cache_creation_input_token_cost` × 1e6 → `cacheCreationPerMillion`,
+     falling back to `inputPerMillion` when absent (OpenAI bills cache
+     writes at the input rate)
+   - `cache_read_input_token_cost` × 1e6 → `cacheReadPerMillion`,
+     falling back to 0
+5. **Canonicalize** ids and dedupe date-pinned variants onto the base id.
+   If two variants disagree on a rate, keep the one from the newest date
+   suffix and log the conflict.
+6. **Apply `overrides.json`** per-model and per-field. An override wins
+   unconditionally, including `displayName`.
+7. **Generate `displayName`** for models without an override, using the same
+   rules as `Pricing.prettyModelName`.
+8. **Sanity gate** (see below).
+9. If the result differs from the committed `v1/models.json`, write it,
+   commit, and push. Otherwise exit 0 without a commit.
+
+### Sanity gate
+
+The app release cycle used to be an implicit review gate on every price
+change. This replaces it. Without it, one bad upstream commit reaches every
+user within a day.
+
+- **Run-level:** if the merged model count is below 50% of the currently
+  published count, reject the entire run — no commit, non-zero exit so the
+  CronJob surfaces as failed.
+- **Model-level:** a rate that is negative, or an `inputPerMillion` above
+  1000, is rejected for that model.
+- **Model-level:** a rate that moved by ≥10× from the published value is
+  rejected for that model. The rule applies only when the published value
+  is greater than zero — a rate legitimately moving off 0 (a model gaining
+  prompt caching, say) has no meaningful ratio.
+- A rejected model **keeps its previously published values** rather than
+  disappearing. Dropping it would price it at $0, which is exactly the
+  outcome this design exists to prevent. A brand-new model with no previous
+  value is omitted instead — identical to today's unknown-model behavior.
+- **Models are never removed by the bot.** If LiteLLM drops an entry, the
+  published value stays. Removal requires an explicit override.
+
+## Repository layout
+
+`ericjypark/codex-island-model-list-api` — **must be switched from private
+to public**; it is both the audit surface and the serving channel.
+
+```
+v1/models.json          generated — the only file the app reads
+overrides.json          hand-maintained; beats LiteLLM
+config.json             id patterns to select
+.nojekyll               keep Pages from processing the tree
+cmd/sync/               the Go bot
+k8s/namespace.yaml
+k8s/cronjob.yaml
+k8s/secret.yaml         (template; real token applied out of band)
+```
+
+GitHub Pages: deploy from `main`, root folder.
+
+## Kubernetes objects
+
+Namespace `codexisland` on the Pi's k3s.
+
+- **`CronJob model-list-sync`** — every 6h, `restartPolicy: OnFailure`,
+  `backoffLimit: 2`, `concurrencyPolicy: Forbid`, image
+  `ghcr.io/ericjypark/codex-island-model-list-api:<sha>` — named after the
+  repo, matching the existing `ghcr.io/ericjypark/<name>:<sha>` convention
+  on this cluster.
+- **`Secret codexisland-git`** — a fine-grained PAT with `contents: write`
+  scoped to this one repo.
+- **`Namespace codexisland`**.
+
+A CronJob rather than a Deployment: the work is periodic, so there is no
+long-running process to keep alive. `OnFailure` retries a failed run, and
+the next scheduled run recovers regardless of what happened to the last one.
+
+No Service, no Ingress, no nginx vhost, no TLS certificate — nothing on the
+Pi is reachable from outside, so the existing shared certbot certificate and
+the hardcoded-ClusterIP nginx pattern are both left untouched.
+
+## App changes
+
+### `Sources/Cost/PricingCatalog.swift` (new)
+
+Holds the resolved catalog and owns the fallback ladder.
+
+- Disk cache at `~/Library/Caches/dev.codexisland.CodexIsland/model-prices.json`,
+  matching the convention in `LogParseCache.cacheURL`. Stores the payload
+  plus the last `ETag` and fetch timestamp. `Caches` is purgeable by macOS;
+  losing it costs one refetch and drops to the seed in the meantime, which
+  is exactly the intended behavior.
+- On launch: load the cache synchronously; if absent or unreadable, the seed
+  stands.
+- Refresh on launch when the cached payload is older than 24h, and every 24h
+  thereafter while running: `GET`
+  with `If-None-Match`. 304 → keep the payload, update the timestamp only.
+  200 → validate `schemaVersion`, decode, atomically swap, persist.
+- Any failure — network error, non-2xx, malformed JSON, wrong
+  `schemaVersion` — leaves the current state untouched. No user-visible
+  error; staleness is already surfaced in Settings.
+
+### `Sources/Cost/Pricing.swift`
+
+- `table` → `seedTable`, unchanged in content. It becomes "last known good
+  at build time" rather than the authority.
+- `cost(for:)`, `isKnown(_:)`, and `prettyModelName(_:)` consult the live
+  catalog first, then fall back to `seedTable` and the existing name rules.
+- `snapshotDate` / `daysSinceSnapshot` are replaced by freshness derived
+  from the catalog's `generatedAt`.
+
+**Call sites do not change.** The build uses plain `swiftc` with no
+`-swift-version 6` and no strict-concurrency flags (`build.sh:60`), so
+`Pricing` can keep its synchronous `static` API and swap an internal
+`static var` on the main actor. `CostSummary` and `StatCardSummary` are
+untouched.
+
+### `Sources/Views/SettingsView.swift`
+
+`costSubtitle()` keeps its "pricing data %dd old" strings and the 60-day
+threshold; the number now means "days since the catalog was generated"
+instead of "days since a hardcoded constant". No new localization keys.
+
+### `README.md`
+
+The Privacy section (README.md:273) currently implies the app talks only to
+`chatgpt.com` and `api.anthropic.com`. Add the new destination: the app
+fetches model pricing from GitHub. "No app telemetry" and "No app
+analytics" both remain true and stay as-is.
+
+## Testing
+
+**Bot (Go, standard `go test`):**
+
+- override precedence beats LiteLLM, per-field
+- each sanity-gate rule: count collapse, negative rate, absurd rate, 10×
+  jump — and that a rejected model retains its previous value
+- a model dropped upstream survives in the output
+- date-pinned variants canonicalize and dedupe
+- no commit when the merge is byte-identical to what is published
+
+**App (Swift, `scripts/run-tests.sh`, bare `swiftc` — no XCTest/SPM):**
+
+- payload decodes into the catalog; `schemaVersion: 2` is rejected
+- fallback order: remote beats cache beats seed
+- corrupt JSON leaves an existing cache intact
+- a 304 preserves the payload and advances the timestamp
+- `cost(for:)` uses a remote rate over a differing seed rate
+
+`Pricing.swift` appears in two existing test targets
+(`stat-card-summary-tests`, `stat-card-render-tests`); both need
+`PricingCatalog.swift` added to their source lists.
+
+## Out of scope
+
+- **Regenerating the app's seed at release time.** A stale seed only affects
+  someone who installs while offline and never connects; the first
+  successful fetch heals it. Not worth a codegen pipeline.
+- **Request counting / user telemetry.** See the decision above.
+- **Serving anything from the Pi.** No public endpoint, no new subdomain.
+- **Context windows, provider taxonomy, alias maps.** The app does not use
+  them; designing fields with no consumer is cost without benefit.
+
+## Operational prerequisites
+
+These are one-time, manual, and outside the code:
+
+1. Switch `codex-island-model-list-api` from private to public.
+2. Enable GitHub Pages on `main` / root.
+3. Mint the fine-grained PAT and apply it as `codexisland-git` in the
+   `codexisland` namespace.

--- a/docs/superpowers/specs/2026-07-26-model-list-api-design.md
+++ b/docs/superpowers/specs/2026-07-26-model-list-api-design.md
@@ -143,8 +143,11 @@ user within a day.
 - **Run-level:** if the merged model count is below 50% of the currently
   published count, reject the entire run — no commit, non-zero exit so the
   CronJob surfaces as failed.
-- **Model-level:** a rate that is negative, or an `inputPerMillion` above
-  1000, is rejected for that model.
+- **Model-level:** a rate that is negative, or **any** of the four rates above
+  1000, is rejected for that model. The ceiling covers every field because the
+  ratio rule below is skipped entirely for a model with no published baseline —
+  so for a brand-new model this is the only bound that applies, and output
+  tokens dominate the app's spend arithmetic.
 - **Model-level:** a rate that moved by ≥10× from the published value is
   rejected for that model. The rule applies only when the published value
   is greater than zero — a rate legitimately moving off 0 (a model gaining

--- a/docs/superpowers/specs/2026-07-26-model-list-api-design.md
+++ b/docs/superpowers/specs/2026-07-26-model-list-api-design.md
@@ -126,8 +126,13 @@ Go binary, run as a k3s CronJob every 6 hours.
 7. **Generate `displayName`** for models without an override, using the same
    rules as `Pricing.prettyModelName`.
 8. **Sanity gate** (see below).
-9. If the result differs from the committed `v1/models.json`, write it,
+9. If the `models` map differs from the committed `v1/models.json`, write it,
    commit, and push. Otherwise exit 0 without a commit.
+
+`generatedAt` therefore advances only when prices actually change — a run
+that confirms nothing changed produces no commit and no new timestamp. The
+comparison deliberately ignores `generatedAt` itself; comparing the whole
+file would make every run differ and commit 1,460 times a year.
 
 ### Sanity gate
 
@@ -217,20 +222,34 @@ Holds the resolved catalog and owns the fallback ladder.
   at build time" rather than the authority.
 - `cost(for:)`, `isKnown(_:)`, and `prettyModelName(_:)` consult the live
   catalog first, then fall back to `seedTable` and the existing name rules.
-- `snapshotDate` / `daysSinceSnapshot` are replaced by freshness derived
-  from the catalog's `generatedAt`.
+- `snapshotDate` → `seedSnapshotDate`, still the build-time constant, now
+  describing only the seed.
 
 **Call sites do not change.** The build uses plain `swiftc` with no
 `-swift-version 6` and no strict-concurrency flags (`build.sh:60`), so
-`Pricing` can keep its synchronous `static` API and swap an internal
-`static var` on the main actor. `CostSummary` and `StatCardSummary` are
-untouched.
+`Pricing` keeps its synchronous `static` API. `CostSummary` and
+`StatCardSummary` are untouched.
+
+The stored catalog is guarded by an `os_unfair_lock`, and that is not
+optional. `CostStore` runs `CostSummary.summarize` inside two concurrent
+`Task.detached` blocks (`CostStore.swift:67`, `CostStore.swift:77`), so
+`cost(for:)` is already read from background threads — installing a new
+catalog from the refresh would otherwise be a live data race. An
+uncontended lock costs tens of nanoseconds per event, which is noise next
+to the JSONL parsing that produced those events.
 
 ### `Sources/Views/SettingsView.swift`
 
 `costSubtitle()` keeps its "pricing data %dd old" strings and the 60-day
-threshold; the number now means "days since the catalog was generated"
-instead of "days since a hardcoded constant". No new localization keys.
+threshold. The number becomes **days since the last successful fetch**
+(200 or 304), falling back to days since `seedSnapshotDate` when no fetch
+has ever succeeded. No new localization keys.
+
+It deliberately is *not* days since `generatedAt`. Because the bot commits
+only on change, a long-stable price table would otherwise trigger a false
+"90d old" warning while the app was in fact checking daily and finding
+nothing new. "How long since I reached the source" is the signal that
+actually indicates the user's numbers might be wrong.
 
 ### `README.md`
 

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -47,3 +47,20 @@ swiftc \
   Tests/PricingTests.swift
 
 "$OUT_DIR/pricing-tests"
+
+swiftc \
+  -parse-as-library \
+  -o "$OUT_DIR/pricing-catalog-tests" \
+  Sources/Cost/PricingCatalog.swift \
+  Tests/PricingCatalogTests.swift
+
+"$OUT_DIR/pricing-catalog-tests"
+
+swiftc \
+  -parse-as-library \
+  -sanitize=thread \
+  -o "$OUT_DIR/pricing-catalog-race-tests" \
+  Sources/Cost/PricingCatalog.swift \
+  Tests/PricingCatalogRaceTests.swift
+
+"$OUT_DIR/pricing-catalog-race-tests"

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -43,6 +43,7 @@ swiftc \
   -parse-as-library \
   -o "$OUT_DIR/pricing-tests" \
   Sources/Cost/TokenEvent.swift \
+  Sources/Cost/PricingCatalog.swift \
   Sources/Cost/Pricing.swift \
   Tests/PricingTests.swift
 
@@ -64,3 +65,23 @@ swiftc \
   Tests/PricingCatalogRaceTests.swift
 
 "$OUT_DIR/pricing-catalog-race-tests"
+
+swiftc \
+  -parse-as-library \
+  -o "$OUT_DIR/pricing-tests" \
+  Sources/Cost/TokenEvent.swift \
+  Sources/Cost/PricingCatalog.swift \
+  Sources/Cost/Pricing.swift \
+  Tests/PricingTests.swift
+
+"$OUT_DIR/pricing-tests"
+
+swiftc \
+  -parse-as-library \
+  -o "$OUT_DIR/pricing-precedence-tests" \
+  Sources/Cost/TokenEvent.swift \
+  Sources/Cost/PricingCatalog.swift \
+  Sources/Cost/Pricing.swift \
+  Tests/PricingPrecedenceTests.swift
+
+"$OUT_DIR/pricing-precedence-tests"


### PR DESCRIPTION
## What this does

Moves the per-model price table out of the app binary and into a public,
bot-maintained JSON file. **A new model no longer needs an app release.**

`Sources/Cost/Pricing.swift` embedded 32 models × 4 rates. Adding one meant
editing that file, bumping `VERSION`, tagging, and shipping a Sparkle release —
and users saw correct dollar totals only after taking that update. Four of the
eight commits that ever touched `Pricing.swift` were pure "add a model" changes.
Unknown models price to $0, so the gap between a model's launch and the release
that adds it showed users totals that were simply wrong.

The catalog is live now and carries **78 models** — 46 of which this app has
never shipped a price for.

**https://ericjypark.github.io/codex-island-model-catalog/v1/models.json**

## How it fits together

```
LiteLLM ──┐
          ├─► sync bot (k3s, every 6h) ──commit──► codex-island-model-catalog
overrides ┘   merge + sanity gate                  (public) ──► GitHub Pages
                                                                    │
                                          remote → disk cache → seed ▼
                                                                   app
```

Two new repos, both outside this one:

- **[codex-island-model-catalog](https://github.com/ericjypark/codex-island-model-catalog)** (public) — the price data, `overrides.json`, and the derivation rules in prose. Anyone can check a value or open a PR against an override.
- **codex-island-infra** (private) — the Go sync bot, container, CI, and k3s manifests. Private because the manifests carry the shape of a personal deployment.

## Why GitHub and not a server

The app already contacts `github.com` daily for the Sparkle appcast
(`build.sh:35`), so serving prices from GitHub adds **zero new trust surface**.
Pointing the app at a personally-operated host would add one, and would
contradict the README's "no proxy service".

It also makes the prices auditable: both inputs — LiteLLM and `overrides.json` —
are public, and the catalog README documents the derivation, so a value can be
verified without reading the bot's source.

## Changes here

| File | What |
|---|---|
| `Sources/Cost/PricingCatalog.swift` | New. Lock-guarded store, payload validation, disk cache, daily conditional refresh with ETag. |
| `Sources/Cost/Pricing.swift` | `table` → `seedTable`, `snapshotDate` → `seedSnapshotDate`. Lookups consult the catalog first. **No call site changed.** |
| `Sources/App.swift` | Loads the disk cache before anything summarizes; starts the refresh alongside the other stores. |
| `Sources/Views/SettingsView.swift` | One line — the staleness figure now counts from the last successful fetch. |
| `README.md` | Discloses the new network destination. "No app telemetry" and "No app analytics" both remain true. |

### Three-tier fallback

remote → disk cache → embedded seed. A pod outage, an offline laptop, a corrupt
payload, a wrong `schemaVersion`, or an empty model map all leave the previous
state in place. Costs collapsing to $0 is the failure this design exists to
prevent, so no path can produce it.

### Staleness is days-since-fetch, not days-since-`generatedAt`

The bot commits only when prices change, so `generatedAt` marks the last real
change. Using it would make a long-stable table read as months stale while the
app was checking daily and finding nothing new.

## Testing

`scripts/run-tests.sh` grows from 5 targets to 8; 97 assertions pass.

`Tests/PricingCatalogRaceTests.swift` is built with `-sanitize=thread` because
`CostStore` reads the catalog from two concurrent `Task.detached` blocks while a
refresh installs. Its header documents exactly which accessors the sanitizer
covers and which it cannot — TSan on this toolchain reports races on heap-backed
storage but not on inline POD, so the two accessors whose only shared state is
`fetchedAt: Date?` are unprovable here and say so.

Every invariant was mutation-checked: delete the rule, confirm the named
assertion fails, restore. That is what caught the ones that mattered — an ETag
that was never restored from disk, and a guard that would have meant a fresh
install never fetches a catalog at all. Both passed the full suite before.

## Verified end to end

- Endpoint: 200 with ETag, 304 on conditional GET
- Bot on the Pi: clone → fetch → merge → gate → commit → push, 9s
- App: cleared its cache, relaunched, fetched and stored 78 models
- `./build.sh` succeeds

## Design record

`docs/superpowers/specs/` and `docs/superpowers/plans/` carry the design and the
two implementation plans. The `docs:` commits on this branch are that record
evolving under review — worth skimming for the reasoning behind the sanity gate
and the fallback ladder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pricing now uses a remotely refreshed model catalog, with cached and built-in fallback data when unavailable.
  * Model names and rates can reflect the latest catalog updates.
  * Pricing refreshes automatically and displays the age of the latest successful update.

* **Documentation**
  * Updated privacy documentation to explain the catalog request and caching behavior.

* **Tests**
  * Added coverage for catalog validation, caching, refresh behavior, precedence, and concurrent access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->