### PR TITLE
fix(usage): route Codex rate-limit windows by span, not slot position

### DIFF
--- a/Sources/Usage/AppUsage.swift
+++ b/Sources/Usage/AppUsage.swift
@@ -40,6 +40,15 @@ struct WindowUsage {
     /// attached. That still counts as a reading.
     var hasReading: Bool { !(error != nil && usedPercent == 0) }
 
+    /// True for the passive sentinel a successfully parsed response leaves on
+    /// a window it doesn't include (`WindowUsage.unknown`) — the provider
+    /// affirmatively not offering the window, as opposed to a fetch failure,
+    /// whose error carries the failure message. `merged` treats the two
+    /// differently: a failure preserves the prior reading; an unreported
+    /// window displaces it. A history seed also wears the "no data" caption
+    /// but with a real percentage, so it stays a reading, not this.
+    var isUnreported: Bool { !hasReading && error == WindowUsage.unknown.error }
+
     var percentInt: Int { Int((usedPercent * 100).rounded()) }
 
     func displayedFraction(mode: UsageDisplayMode) -> Double {
@@ -98,6 +107,12 @@ struct AppUsage {
         _ fetched: WindowUsage, prior: WindowUsage, at now: Date
     ) -> WindowUsage {
         guard !fetched.hasReading, prior.hasReading else { return fetched }
+        // A parsed response that omits the window is the provider saying the
+        // plan doesn't have one (single-window Codex plans, mid-2026) —
+        // displace the prior reading rather than papering over it. Carrying
+        // here froze a mislabeled history seed forever: seeds have no
+        // resetAt, so the release below could never fire.
+        if fetched.isUnreported { return fetched }
         if let reset = prior.resetAt, reset <= now { return fetched }
         return WindowUsage(
             usedPercent: prior.usedPercent, resetAt: prior.resetAt, error: fetched.error

--- a/Sources/Usage/UsageFetcher.swift
+++ b/Sources/Usage/UsageFetcher.swift
@@ -67,8 +67,8 @@ enum UsageFetcher {
     /// separates 5h (18000s) from weekly (604800s) — and fall back to slot
     /// order for older shapes that omit `limit_window_seconds`.
     static func routeCodexWindows(_ rl: [String: Any]) -> (fiveHour: WindowUsage, weekly: WindowUsage) {
-        var fiveHour = WindowUsage.unknown
-        var weekly = WindowUsage.unknown
+        var fiveHour: WindowUsage?
+        var weekly: WindowUsage?
         let slots: [(key: String, fallback: UsageWindow)] = [
             ("primary_window", .fiveHour),
             ("secondary_window", .weekly),
@@ -77,12 +77,15 @@ enum UsageFetcher {
             guard let d = rl[key] as? [String: Any] else { continue }
             let span = d["limit_window_seconds"] as? Double
             let kind = span.map { $0 >= 86400 ? UsageWindow.weekly : .fiveHour } ?? fallback
+            // Same-kind collision: the earlier slot wins. Primary is the
+            // provider's headline window — a trailing sibling silently
+            // overwriting it would drop the real reading.
             switch kind {
-            case .fiveHour: fiveHour = parseCodexWindow(d)
-            case .weekly:   weekly = parseCodexWindow(d)
+            case .fiveHour: if fiveHour == nil { fiveHour = parseCodexWindow(d) }
+            case .weekly:   if weekly == nil { weekly = parseCodexWindow(d) }
             }
         }
-        return (fiveHour, weekly)
+        return (fiveHour ?? .unknown, weekly ?? .unknown)
     }
 
     private static func parseCodexWindow(_ obj: Any?) -> WindowUsage {

--- a/Sources/Usage/UsageFetcher.swift
+++ b/Sources/Usage/UsageFetcher.swift
@@ -32,9 +32,10 @@ enum UsageFetcher {
                   let rl = obj["rate_limit"] as? [String: Any] else {
                 return errorPair("parse error")
             }
+            let windows = routeCodexWindows(rl)
             return AppUsage(
-                fiveHour: parseCodexWindow(rl["primary_window"]),
-                weekly: parseCodexWindow(rl["secondary_window"]),
+                fiveHour: windows.fiveHour,
+                weekly: windows.weekly,
                 plan: obj["plan_type"] as? String
             )
         } catch {
@@ -56,6 +57,32 @@ enum UsageFetcher {
               let tokens = json["tokens"] as? [String: Any],
               let token = tokens["access_token"] as? String else { return nil }
         return token
+    }
+
+    /// The window slots stopped being positional in mid-2026: plans with a
+    /// single weekly limit report it as `primary_window` with
+    /// `limit_window_seconds: 604800` and `secondary_window: null`, so
+    /// primary→5h / secondary→weekly mislabels the only real reading. Route
+    /// each reported window by its advertised span instead — a day cleanly
+    /// separates 5h (18000s) from weekly (604800s) — and fall back to slot
+    /// order for older shapes that omit `limit_window_seconds`.
+    static func routeCodexWindows(_ rl: [String: Any]) -> (fiveHour: WindowUsage, weekly: WindowUsage) {
+        var fiveHour = WindowUsage.unknown
+        var weekly = WindowUsage.unknown
+        let slots: [(key: String, fallback: UsageWindow)] = [
+            ("primary_window", .fiveHour),
+            ("secondary_window", .weekly),
+        ]
+        for (key, fallback) in slots {
+            guard let d = rl[key] as? [String: Any] else { continue }
+            let span = d["limit_window_seconds"] as? Double
+            let kind = span.map { $0 >= 86400 ? UsageWindow.weekly : .fiveHour } ?? fallback
+            switch kind {
+            case .fiveHour: fiveHour = parseCodexWindow(d)
+            case .weekly:   weekly = parseCodexWindow(d)
+            }
+        }
+        return (fiveHour, weekly)
     }
 
     private static func parseCodexWindow(_ obj: Any?) -> WindowUsage {

--- a/Sources/Views/NotchPeekPill.swift
+++ b/Sources/Views/NotchPeekPill.swift
@@ -90,10 +90,6 @@ struct NotchPeekPill: View {
         }
     }
 
-    private var hasValue: Bool {
-        usage.usedPercent > 0 || usage.error == nil
-    }
-
     /// Spinner only fires for the cold-start case (loading AND we have nothing
     /// to show). If we have a prior value, keep showing it during refresh —
     /// same principle as UsageStore.isErrorOnly's "don't blank the panel" rule.

--- a/Sources/Views/NotchPeekPill.swift
+++ b/Sources/Views/NotchPeekPill.swift
@@ -102,12 +102,13 @@ struct NotchPeekPill: View {
     }
 
     private var showDash: Bool {
-        // "no data" is our sentinel for "API returned null for this window"
-        // (typically a fresh 5h period before the first OAuth call lands).
-        // Treat it as a passive non-error so the pill still renders with
-        // the 5h window-length fallback instead of collapsing to "—%".
-        guard let err = usage.error, err != "no data" else { return false }
-        return usage.usedPercent == 0
+        // No measurement to show — a failed fetch, or a window the parsed
+        // response doesn't report at all (permanent on single-window Codex
+        // plans since mid-2026). The old "no data" carve-out rendered the
+        // sentinel as a value, which fabricated a steady "0% · 5h" — a full
+        // budget under the `remaining` toggle — for a window the plan
+        // doesn't have.
+        !usage.hasReading
     }
 
     private var percentText: String {

--- a/Sources/Views/SettingsView.swift
+++ b/Sources/Views/SettingsView.swift
@@ -770,6 +770,9 @@ struct SettingsView: View {
     }
 
     private func windowCaption(_ w: WindowUsage) -> String {
+        // The parse-omission sentinel is a plan shape, not a fault — no
+        // warning glyph for a window the provider doesn't offer.
+        if w.isUnreported { return "—" }
         if let err = w.error, w.percentInt == 0 { return "⚠ \(err)" }
         return "\(w.displayedPercentInt(mode: usageDisplay.mode))%"
     }

--- a/Tests/CodexWindowRoutingTests.swift
+++ b/Tests/CodexWindowRoutingTests.swift
@@ -1,0 +1,115 @@
+import Foundation
+
+/// Regression cover for the dead Codex "week" tile (2026-07 onward).
+///
+/// `wham/usage` stopped being positional: plans with a single weekly limit
+/// report it as `primary_window` with `limit_window_seconds: 604800` and
+/// `secondary_window: null`. The old primary→5h / secondary→weekly mapping
+/// rendered the weekly reading in the 5h tile and a permanent "—" in the
+/// weekly one. Routing must go by the window's advertised span, with slot
+/// order as the fallback for older shapes that omit `limit_window_seconds`.
+@main
+struct CodexWindowRoutingTests {
+    static var failures = 0
+
+    static func expect(_ condition: Bool, _ label: String) {
+        if condition { print("PASS \(label)") } else { print("FAIL \(label)"); failures += 1 }
+    }
+
+    /// All fixtures go through JSONSerialization — production numbers arrive
+    /// as NSNumber, whose `as? Double` bridging native Swift literals don't share.
+    static func parse(_ json: String) -> [String: Any] {
+        try! JSONSerialization.jsonObject(with: Data(json.utf8)) as! [String: Any]
+    }
+
+    static func rateLimit(fromResponse json: String) -> [String: Any] {
+        parse(json)["rate_limit"] as! [String: Any]
+    }
+
+    /// The live response observed 2026-08-04 (identifiers redacted): one
+    /// window, weekly span, in the primary slot.
+    static let weeklyOnlyResponse = """
+    {
+      "plan_type": "plus",
+      "rate_limit": {
+        "allowed": true,
+        "limit_reached": false,
+        "primary_window": {
+          "used_percent": 40,
+          "limit_window_seconds": 604800,
+          "reset_after_seconds": 332661,
+          "reset_at": 1786161248
+        },
+        "secondary_window": null
+      },
+      "credits": { "has_credits": false, "unlimited": false }
+    }
+    """
+
+    /// The original two-window shape older accounts may still get.
+    static let twoWindowResponse = """
+    {
+      "plan_type": "plus",
+      "rate_limit": {
+        "primary_window": {
+          "used_percent": 12,
+          "limit_window_seconds": 18000,
+          "reset_at": 1786000000
+        },
+        "secondary_window": {
+          "used_percent": 34,
+          "limit_window_seconds": 604800,
+          "reset_at": 1786161248
+        }
+      }
+    }
+    """
+
+    static func main() {
+        // MARK: the live 2026-08 shape — weekly lives in the primary slot
+
+        let weeklyOnly = UsageFetcher.routeCodexWindows(rateLimit(fromResponse: weeklyOnlyResponse))
+        expect(weeklyOnly.weekly.usedPercent == 0.40, "weekly takes the 604800s primary window")
+        expect(
+            weeklyOnly.weekly.resetAt == Date(timeIntervalSince1970: 1_786_161_248),
+            "weekly keeps the window's reset_at"
+        )
+        expect(weeklyOnly.weekly.hasReading, "weekly counts as a real reading")
+        expect(!weeklyOnly.fiveHour.hasReading, "unreported 5h window has no reading")
+        expect(
+            weeklyOnly.fiveHour.error == "no data",
+            "unreported 5h carries the passive `no data` sentinel, not a fetch error"
+        )
+
+        // MARK: the original two-window shape still routes by span
+
+        let both = UsageFetcher.routeCodexWindows(rateLimit(fromResponse: twoWindowResponse))
+        expect(both.fiveHour.usedPercent == 0.12, "18000s primary window lands in 5h")
+        expect(both.weekly.usedPercent == 0.34, "604800s secondary window lands in weekly")
+
+        // MARK: shapes without limit_window_seconds fall back to slot order
+
+        let legacy = UsageFetcher.routeCodexWindows(parse("""
+        {
+          "primary_window": { "used_percent": 7, "reset_at": 1786000000 },
+          "secondary_window": { "used_percent": 21 }
+        }
+        """))
+        expect(legacy.fiveHour.usedPercent == 0.07, "spanless primary defaults to 5h")
+        expect(legacy.weekly.usedPercent == 0.21, "spanless secondary defaults to weekly")
+
+        // MARK: a lone 5h-span window leaves weekly unreported, not errored
+
+        let fiveHourOnly = UsageFetcher.routeCodexWindows(parse("""
+        {
+          "primary_window": { "used_percent": 55, "limit_window_seconds": 18000 },
+          "secondary_window": null
+        }
+        """))
+        expect(fiveHourOnly.fiveHour.usedPercent == 0.55, "lone 18000s window lands in 5h")
+        expect(!fiveHourOnly.weekly.hasReading, "weekly stays a no-reading window")
+
+        print(failures == 0 ? "ALL PASS" : "\(failures) FAILURE(S)")
+        exit(failures == 0 ? 0 : 1)
+    }
+}

--- a/Tests/CodexWindowRoutingTests.swift
+++ b/Tests/CodexWindowRoutingTests.swift
@@ -109,6 +109,19 @@ struct CodexWindowRoutingTests {
         expect(fiveHourOnly.fiveHour.usedPercent == 0.55, "lone 18000s window lands in 5h")
         expect(!fiveHourOnly.weekly.hasReading, "weekly stays a no-reading window")
 
+        // MARK: same-kind collision — the earlier slot wins, never a silent overwrite
+
+        // Speculative shape (a daily 86400s window classifies as weekly):
+        // the primary slot's real weekly reading must survive the sibling.
+        let collision = UsageFetcher.routeCodexWindows(parse("""
+        {
+          "primary_window": { "used_percent": 90, "limit_window_seconds": 604800 },
+          "secondary_window": { "used_percent": 10, "limit_window_seconds": 86400 }
+        }
+        """))
+        expect(collision.weekly.usedPercent == 0.90, "primary's weekly reading survives the collision")
+        expect(!collision.fiveHour.hasReading, "the colliding sibling doesn't leak into 5h")
+
         print(failures == 0 ? "ALL PASS" : "\(failures) FAILURE(S)")
         exit(failures == 0 ? 0 : 1)
     }

--- a/Tests/UsageMergeTests.swift
+++ b/Tests/UsageMergeTests.swift
@@ -94,6 +94,46 @@ struct UsageMergeTests {
         expect(mixed.fiveHour.usedPercent == 0.16, "failed 5h carries forward")
         expect(mixed.weekly.usedPercent == 0.44, "successful weekly takes the fresh value")
 
+        // MARK: unreported windows — a parsed omission displaces, a failure carries
+
+        // The sentinel is only the zero-percent "no data" shape. A history
+        // seed wears the same caption over a real percentage — still a
+        // reading — and fetch failures carry their own messages.
+        expect(WindowUsage.unknown.isUnreported, "the parse-omission sentinel is unreported")
+        expect(
+            !WindowUsage(usedPercent: 0.40, resetAt: nil, error: "no data").isUnreported,
+            "a history seed is a reading, not an unreported window"
+        )
+        expect(!errored("rate limited").isUnreported, "a failed fetch is not an unreported window")
+
+        // Single-window Codex plans (mid-2026): the parsed response reports
+        // only weekly; the 5h slot comes back as the sentinel. A prior 5h
+        // seed — mislabeled weekly data recorded by pre-fix builds, with no
+        // resetAt to ever release it — must be displaced, not carried. This
+        // was the frozen "40% · 5h" tile on the upgrade path (#69 review).
+        let seeded = pair(
+            WindowUsage(usedPercent: 0.40, resetAt: nil, error: "no data"),
+            reading(0.11, resetIn: 5 * 86400)
+        )
+        let weeklyOnly = pair(.unknown, reading(0.40, resetIn: 3 * 86400))
+        let displaced = AppUsage.merged(fetched: weeklyOnly, retaining: seeded, at: now)
+        expect(!displaced.fiveHour.hasReading, "unreported 5h displaces the stale seed")
+        expect(
+            displaced.fiveHour.error == WindowUsage.unknown.error,
+            "displaced window keeps the passive sentinel caption"
+        )
+        expect(displaced.weekly.usedPercent == 0.40, "reported weekly takes the fresh value")
+
+        // The displacement must not weaken failure retention: the same
+        // seeded value still survives a genuinely failed fetch.
+        let seedThroughFailure = AppUsage.merged(
+            fetched: pair(errored("http 500"), errored("http 500")), retaining: seeded, at: now
+        )
+        expect(
+            seedThroughFailure.fiveHour.usedPercent == 0.40,
+            "a real failure still carries the seeded reading"
+        )
+
         // MARK: window spans bound how long a recorded reading stays usable
 
         expect(UsageWindow.fiveHour.span == 5 * 3600, "5h span is five hours")

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -52,6 +52,18 @@ swiftc \
 
 swiftc \
   -parse-as-library \
+  -o "$OUT_DIR/codex-window-routing-tests" \
+  Sources/Model/UsageDisplayModeStore.swift \
+  Sources/Usage/AppUsage.swift \
+  Sources/Usage/ClaudeCredentials.swift \
+  Sources/Usage/CodexResetCredits.swift \
+  Sources/Usage/UsageFetcher.swift \
+  Tests/CodexWindowRoutingTests.swift
+
+"$OUT_DIR/codex-window-routing-tests"
+
+swiftc \
+  -parse-as-library \
   -o "$OUT_DIR/pricing-tests" \
   Sources/Cost/TokenEvent.swift \
   Sources/Cost/PricingCatalog.swift \


### PR DESCRIPTION
## What this does

Puts the Codex weekly reading back in the week tile. **The wham/usage window slots stopped being positional in mid-2026 — windows are now routed by their advertised span.**

The week tile had shown "—" since 2026-07-13 (last persisted `codex.weekly` sample), while the 5h tile showed a reading whose reset countdown was days out — a 5-hour window resetting in 3d 21h. Live response for a `plus` plan, observed 2026-08-04:

```json
"rate_limit": {
  "primary_window": {
    "used_percent": 40,
    "limit_window_seconds": 604800,
    "reset_after_seconds": 332661,
    "reset_at": 1786161248
  },
  "secondary_window": null
}
```

The plan's single weekly limit now ships in `primary_window` (`limit_window_seconds: 604800`) with `secondary_window` explicitly null. `fetchCodex()`'s positional mapping (primary→5h, secondary→weekly) therefore rendered the weekly reading in the 5h tile and left the week tile at "—" forever.

## The fix

`routeCodexWindows(_:)` classifies each reported window by `limit_window_seconds` — a day cleanly separates 5h (18000s) from weekly (604800s) — and falls back to slot order for older shapes that omit the field, so two-window accounts keep parsing exactly as before. `parseCodexWindow` is unchanged.

No UI change: with data routed to the right tile, the existing vocabulary already covers both cases — a window the API genuinely doesn't report keeps the passive `"no data"` sentinel (dash, no error caption), fetch failures keep their visible captions. On single-window plans the 5h tile now honestly shows "—" and the week tile shows the live reading.

## Tests

`Tests/CodexWindowRoutingTests.swift` — 11 assertions over 4 fixtures, all parsed through `JSONSerialization` to match production NSNumber bridging: the verbatim 2026-08 single-weekly response, the original two-window shape, spanless slot-order fallback, and a lone 5h window leaving weekly unreported rather than errored. Full suite passes (174 PASS / 0 FAIL); `./build.sh` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Codex usage-window detection using advertised durations, with fallback support for older responses.
  * Correctly handles weekly-only, short-window-only, and multi-window usage data.
  * Preserves reset information and displays “no data” or an em dash when usage details are unavailable.
  * Prevents stale readings when a provider omits a window, while retaining readings after genuine fetch errors.

* **Tests**
  * Added regression coverage for routing, missing data, reset details, and usage-history merging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->