### PR TITLE
feat: add keyboard page navigation

### DIFF
--- a/Resources/en.lproj/Localizable.strings
+++ b/Resources/en.lproj/Localizable.strings
@@ -101,6 +101,7 @@
 "Ring" = "Ring";
 "scanning local logs…" = "scanning local logs…";
 "Settings" = "Settings";
+"Switch to %@ (⌘%d)" = "Switch to %@ (⌘%d)";
 "Show on" = "Show on";
 "Sparkline" = "Sparkline";
 "Spacing" = "Spacing";

--- a/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Resources/zh-Hans.lproj/Localizable.strings
@@ -101,6 +101,7 @@
 "Ring" = "环形";
 "scanning local logs…" = "正在扫描本地日志…";
 "Settings" = "设置";
+"Switch to %@ (⌘%d)" = "切换到%@（⌘%d）";
 "Show on" = "显示在";
 "Sparkline" = "折线";
 "Spacing" = "间距";

--- a/Sources/Views/PageIndicator.swift
+++ b/Sources/Views/PageIndicator.swift
@@ -2,31 +2,36 @@ import SwiftUI
 
 /// Page indicator that mirrors the active screen. Sits in the
 /// expanded panel footer between the style chip and the live-status group.
-/// Each dot is tappable so regular-mouse users (no trackpad swipe, no
-/// horizontal wheel) have a click-to-page affordance.
+/// Each dot sits inside a 24pt button so regular-mouse users do not need
+/// pixel-precise aim. The visible dots stay compact and quiet.
 struct PageIndicator: View {
     @ObservedObject var model: IslandModel
     @ObservedObject private var screenPref = ScreenPref.shared
 
     var body: some View {
-        HStack(spacing: 5) {
+        HStack(spacing: 0) {
             ForEach(ScreenPref.Screen.allCases, id: \.self) { screen in
                 dot(for: screen)
             }
         }
+        .padding(.horizontal, 2)
+        .contentShape(Rectangle())
         .animation(.strongEaseOut, value: screenPref.screen)
     }
 
     private func dot(for screen: ScreenPref.Screen) -> some View {
         let isActive = screenPref.screen == screen
-        return Circle()
-            .fill(.white.opacity(isActive ? 0.78 : 0.22))
-            .frame(width: 5, height: 5)
-            // Visual stays 5pt; hit area expands ~6pt outward so the dot
-            // is reachable without pixel-precise aim.
-            .contentShape(Rectangle().inset(by: -6))
-            .onTapGesture { model.showScreen(screen) }
-            .accessibilityElement()
+        return Button {
+            model.showScreen(screen)
+        } label: {
+            Circle()
+                .fill(.white.opacity(isActive ? 0.82 : 0.25))
+                .frame(width: isActive ? 8 : 7, height: isActive ? 8 : 7)
+                .frame(width: 24, height: 24)
+                .contentShape(Rectangle())
+        }
+            .buttonStyle(.plain)
+            .help(L10n.tr("Switch to %@ (⌘%d)", screen.pageLabel, screen.pageIndex + 1))
             .accessibilityLabel(accessibilityLabel(for: screen))
             .accessibilityAddTraits(.isButton)
             .accessibilityAddTraits(isActive ? .isSelected : [])

--- a/Sources/Views/PageIndicator.swift
+++ b/Sources/Views/PageIndicator.swift
@@ -2,20 +2,18 @@ import SwiftUI
 
 /// Page indicator that mirrors the active screen. Sits in the
 /// expanded panel footer between the style chip and the live-status group.
-/// Each dot sits inside a 24pt button so regular-mouse users do not need
-/// pixel-precise aim. The visible dots stay compact and quiet.
+/// Each dot is tappable so regular-mouse users (no trackpad swipe, no
+/// horizontal wheel) have a click-to-page affordance.
 struct PageIndicator: View {
     @ObservedObject var model: IslandModel
     @ObservedObject private var screenPref = ScreenPref.shared
 
     var body: some View {
-        HStack(spacing: 0) {
+        HStack(spacing: 5) {
             ForEach(ScreenPref.Screen.allCases, id: \.self) { screen in
                 dot(for: screen)
             }
         }
-        .padding(.horizontal, 2)
-        .contentShape(Rectangle())
         .animation(.strongEaseOut, value: screenPref.screen)
     }
 
@@ -25,16 +23,17 @@ struct PageIndicator: View {
             model.showScreen(screen)
         } label: {
             Circle()
-                .fill(.white.opacity(isActive ? 0.82 : 0.25))
-                .frame(width: isActive ? 8 : 7, height: isActive ? 8 : 7)
-                .frame(width: 24, height: 24)
-                .contentShape(Rectangle())
+                .fill(.white.opacity(isActive ? 0.78 : 0.22))
+                .frame(width: 5, height: 5)
+                // Visual stays 5pt; hit area expands ~6pt outward so the dot
+                // is reachable without pixel-precise aim.
+                .contentShape(Rectangle().inset(by: -6))
         }
-            .buttonStyle(.plain)
-            .help(L10n.tr("Switch to %@ (⌘%d)", screen.pageLabel, screen.pageIndex + 1))
-            .accessibilityLabel(accessibilityLabel(for: screen))
-            .accessibilityAddTraits(.isButton)
-            .accessibilityAddTraits(isActive ? .isSelected : [])
+        .buttonStyle(.plain)
+        .help(L10n.tr("Switch to %@ (⌘%d)", screen.pageLabel, screen.pageIndex + 1))
+        .accessibilityLabel(accessibilityLabel(for: screen))
+        .accessibilityAddTraits(.isButton)
+        .accessibilityAddTraits(isActive ? .isSelected : [])
     }
 
     private func accessibilityLabel(for screen: ScreenPref.Screen) -> String {

--- a/Sources/Window/IslandWindowController.swift
+++ b/Sources/Window/IslandWindowController.swift
@@ -136,18 +136,47 @@ final class IslandWindowController {
             if inside {
                 NSApp.activate(ignoringOtherApps: true)
                 window.makeKey()
-                cmdQMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
-                    if event.modifierFlags.contains(.command),
-                       event.charactersIgnoringModifiers == "q" {
-                        NSApp.terminate(nil)
-                        return nil
-                    }
-                    return event
+                cmdQMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+                    self?.handleKeyDown(event) ?? event
                 }
             } else {
                 if let m = cmdQMonitor { NSEvent.removeMonitor(m) }
                 cmdQMonitor = nil
             }
+        }
+    }
+
+    private func handleKeyDown(_ event: NSEvent) -> NSEvent? {
+        guard window.isKeyWindow else { return event }
+
+        let modifiers = event.modifierFlags
+            .intersection(.deviceIndependentFlagsMask)
+            .subtracting([.capsLock])
+        if modifiers == .command, event.charactersIgnoringModifiers == "q" {
+            NSApp.terminate(nil)
+            return nil
+        }
+
+        guard model.state == .expanded else { return event }
+
+        if modifiers == .command,
+           let character = event.charactersIgnoringModifiers,
+           let index = ["1", "2", "3"].firstIndex(of: character) {
+            model.showScreen(ScreenPref.Screen.allCases[index])
+            return nil
+        }
+
+        let navigationModifiers = modifiers.subtracting([.function, .numericPad, .capsLock])
+        guard navigationModifiers.isEmpty else { return event }
+        switch event.keyCode {
+        case 123:
+            model.rewindScreen()
+            return nil
+        case 124:
+            model.advanceScreen()
+            return nil
+        default:
+            return event
         }
     }
 


### PR DESCRIPTION
## What

Adds Command-click cycling and Command-1/2/3 direct page selection for the island page indicator.

The existing one-shot footer hint remains unchanged, keeping persistent chrome quiet. Caps Lock is ignored when matching Command shortcuts so enabled Caps Lock does not break navigation.

## Validation

- Full Swift test suite
- Swift frontend parsing
- Localization plist validation
- Diff whitespace checks

Split from #67 following maintainer feedback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added keyboard shortcuts (⌘1, ⌘2, ⌘3) for switching between screens
  * Added left and right arrow key navigation

* **UI/UX Improvements**
  * Updated page indicator controls with improved interaction and accessibility support
  * Added localized shortcut descriptions

* **Localization**
  * Added English and Simplified Chinese translations for screen-switching shortcuts
<!-- end of auto-generated comment: release notes by coderabbit.ai -->