### PR TITLE
fix: clear Sparkle xattrs without following symlinks

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -111,10 +111,14 @@ XPC_DIR="$FRAMEWORKS_DIR/Sparkle.framework/Versions/Current/XPCServices"
 for xpc in Installer.xpc Downloader.xpc; do
   XPC_PATH="$XPC_DIR/$xpc"
   if [[ -d "$XPC_PATH" ]]; then
+    # File Provider may reattach FinderInfo to package directories after a
+    # recursive xattr pass, so clear every entry immediately before signing.
+    find "$XPC_PATH" -exec xattr -cs {} \;
     codesign --force --sign - --timestamp=none \
       --preserve-metadata=identifier,entitlements,flags "$XPC_PATH"
   fi
 done
+find "$FRAMEWORKS_DIR/Sparkle.framework" -exec xattr -cs {} \;
 codesign --force --sign - --timestamp=none "$FRAMEWORKS_DIR/Sparkle.framework"
 
 echo "✓ built $APP_DIR ($VERSION)"


### PR DESCRIPTION
## What

Changes both build-time cleanup calls from xattr -c to xattr -cs.

## Why

Sparkle contains symlinked framework paths. Avoiding symlink traversal prevents resource-fork metadata from surviving or being reintroduced during signing.

## Validation

- Bash syntax check
- Diff whitespace checks

Split from #67 following maintainer feedback.