### PR TITLE
fix(usage): show weekly quota in Codex peek

### DIFF
--- a/Resources/en.lproj/Localizable.strings
+++ b/Resources/en.lproj/Localizable.strings
@@ -140,6 +140,11 @@
 "%@: %d percent of 5-hour window used" = "%@: %d percent of 5-hour window used";
 "%@: %d percent of 5-hour window used, %@" = "%@: %d percent of 5-hour window used, %@";
 "%@: no data for 5-hour window" = "%@: no data for 5-hour window";
+"%@: %d percent of weekly window remaining" = "%@: %d percent of weekly window remaining";
+"%@: %d percent of weekly window remaining, %@" = "%@: %d percent of weekly window remaining, %@";
+"%@: %d percent of weekly window used" = "%@: %d percent of weekly window used";
+"%@: %d percent of weekly window used, %@" = "%@: %d percent of weekly window used, %@";
+"%@: no data for weekly window" = "%@: no data for weekly window";
 "Click to expand. Command-click to cycle visualization." = "Click to expand. Command-click to cycle visualization.";
 "Command-click to cycle visualization." = "Command-click to cycle visualization.";
 "Hover to peek usage. Click to expand. Command-click to cycle visualization." = "Hover to peek usage. Click to expand. Command-click to cycle visualization.";

--- a/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Resources/zh-Hans.lproj/Localizable.strings
@@ -140,6 +140,11 @@
 "%@: %d percent of 5-hour window used" = "%@：已使用 5 小时窗口的 %d%%";
 "%@: %d percent of 5-hour window used, %@" = "%@：已使用 5 小时窗口的 %d%%，%@";
 "%@: no data for 5-hour window" = "%@：5 小时窗口暂无数据";
+"%@: %d percent of weekly window remaining" = "%@：每周窗口剩余 %d%%";
+"%@: %d percent of weekly window remaining, %@" = "%@：每周窗口剩余 %d%%，%@";
+"%@: %d percent of weekly window used" = "%@：已使用每周窗口的 %d%%";
+"%@: %d percent of weekly window used, %@" = "%@：已使用每周窗口的 %d%%，%@";
+"%@: no data for weekly window" = "%@：每周窗口暂无数据";
 "Click to expand. Command-click to cycle visualization." = "点击展开。Command 点击可切换可视化。";
 "Command-click to cycle visualization." = "Command 点击可切换可视化。";
 "Hover to peek usage. Click to expand. Command-click to cycle visualization." = "悬停预览用量。点击展开。Command 点击可切换可视化。";

--- a/Sources/Model/AlertEngine.swift
+++ b/Sources/Model/AlertEngine.swift
@@ -119,7 +119,11 @@ final class AlertEngine: ObservableObject {
             AlertDecision.WindowInput(
                 provider: .codex,
                 visible: visibility.codexVisible,
-                window: usage.codex.fiveHour
+                // peekWindow, not fiveHour: weekly-only Codex plans report no
+                // 5h window, and severity must track the same number the peek
+                // pill and silhouette tint surface. Two-window plans still
+                // alert on 5h (peekWindow prefers it).
+                window: usage.codex.peekWindow
             ),
         ]
 

--- a/Sources/Usage/AppUsage.swift
+++ b/Sources/Usage/AppUsage.swift
@@ -82,6 +82,10 @@ struct AppUsage {
 
     var peekWindow: WindowUsage { fiveHour.hasReading ? fiveHour : weekly }
 
+    /// Which window `peekWindow` selected — the peek chrome (VoiceOver label,
+    /// window-length fallback glyph) must describe the same window it shows.
+    var peekWindowIsWeekly: Bool { !fiveHour.hasReading }
+
     /// Fold a fetch result into the values currently on screen.
     ///
     /// Per window: a fresh reading wins outright. A failed window keeps the

--- a/Sources/Usage/AppUsage.swift
+++ b/Sources/Usage/AppUsage.swift
@@ -80,6 +80,8 @@ struct AppUsage {
 
     static let empty = AppUsage(fiveHour: .unknown, weekly: .unknown)
 
+    var peekWindow: WindowUsage { fiveHour.hasReading ? fiveHour : weekly }
+
     /// Fold a fetch result into the values currently on screen.
     ///
     /// Per window: a fresh reading wins outright. A failed window keeps the

--- a/Sources/Views/IslandRootView.swift
+++ b/Sources/Views/IslandRootView.swift
@@ -547,7 +547,7 @@ private struct PeekPillOverlay: View {
     private var currentWindow: WindowUsage {
         switch provider {
         case .claude: return usageStore.claude.fiveHour
-        case .codex:  return usageStore.codex.fiveHour
+        case .codex:  return usageStore.codex.peekWindow
         }
     }
 

--- a/Sources/Views/IslandRootView.swift
+++ b/Sources/Views/IslandRootView.swift
@@ -518,7 +518,8 @@ private struct PeekPillOverlay: View {
             loading: usageStore.loading,
             tint: tint,
             alignment: provider == .claude ? .leading : .trailing,
-            severity: severity
+            severity: severity,
+            windowLengthFallback: currentWindowIsWeekly ? "7d" : "5h"
         )
         .padding(provider == .claude ? .leading : .trailing, 14)
         .padding(.top, topPadding)
@@ -532,7 +533,7 @@ private struct PeekPillOverlay: View {
         .animation(.openMorph, value: isVisible)
         .offset(x: pillsVisible ? 0 : (provider == .claude ? -6 : 6))
         .allowsHitTesting(false)
-        .accessibilityLabel(peekLabel(for: window, provider: providerLabel))
+        .accessibilityLabel(peekLabel(for: window, provider: providerLabel, weekly: currentWindowIsWeekly))
         // Mirror the visual opacity gate exactly — both `pillsVisible` and
         // `isVisible` must be true for the pill to render. Keying the
         // accessibility hide on only `isVisible` lets VoiceOver reach a
@@ -549,6 +550,10 @@ private struct PeekPillOverlay: View {
         case .claude: return usageStore.claude.fiveHour
         case .codex:  return usageStore.codex.peekWindow
         }
+    }
+
+    private var currentWindowIsWeekly: Bool {
+        provider == .codex && usageStore.codex.peekWindowIsWeekly
     }
 
     private var severity: AlertEngine.Severity {
@@ -572,24 +577,32 @@ private struct PeekPillOverlay: View {
         }
     }
 
-    private func peekLabel(for window: WindowUsage, provider: String) -> String {
+    private func peekLabel(for window: WindowUsage, provider: String, weekly: Bool) -> String {
         if !window.hasReading {
-            return L10n.tr("%@: no data for 5-hour window", provider)
+            return weekly
+                ? L10n.tr("%@: no data for weekly window", provider)
+                : L10n.tr("%@: no data for 5-hour window", provider)
         }
         let mode = UsageDisplayModeStore.shared.mode
         let pct = window.displayedPercentInt(mode: mode)
         guard let resetAt = window.resetAt else {
-            return mode == .used
-                ? L10n.tr("%@: %d percent of 5-hour window used", provider, pct)
-                : L10n.tr("%@: %d percent of 5-hour window remaining", provider, pct)
+            switch (mode, weekly) {
+            case (.used, false):      return L10n.tr("%@: %d percent of 5-hour window used", provider, pct)
+            case (.remaining, false): return L10n.tr("%@: %d percent of 5-hour window remaining", provider, pct)
+            case (.used, true):       return L10n.tr("%@: %d percent of weekly window used", provider, pct)
+            case (.remaining, true):  return L10n.tr("%@: %d percent of weekly window remaining", provider, pct)
+            }
         }
         let remaining = max(0, resetAt.timeIntervalSinceNow)
         let resetPhrase: String = remaining >= 3600
             ? L10n.tr("resets in %d hours", Int((remaining / 3600).rounded(.down)))
             : L10n.tr("resets in %d minutes", max(1, Int((remaining / 60).rounded(.down))))
-        return mode == .used
-            ? L10n.tr("%@: %d percent of 5-hour window used, %@", provider, pct, resetPhrase)
-            : L10n.tr("%@: %d percent of 5-hour window remaining, %@", provider, pct, resetPhrase)
+        switch (mode, weekly) {
+        case (.used, false):      return L10n.tr("%@: %d percent of 5-hour window used, %@", provider, pct, resetPhrase)
+        case (.remaining, false): return L10n.tr("%@: %d percent of 5-hour window remaining, %@", provider, pct, resetPhrase)
+        case (.used, true):       return L10n.tr("%@: %d percent of weekly window used, %@", provider, pct, resetPhrase)
+        case (.remaining, true):  return L10n.tr("%@: %d percent of weekly window remaining, %@", provider, pct, resetPhrase)
+        }
     }
 }
 

--- a/Sources/Views/NotchPeekPill.swift
+++ b/Sources/Views/NotchPeekPill.swift
@@ -18,6 +18,10 @@ struct NotchPeekPill: View {
     let tint: Color
     let alignment: HorizontalAlignment
     var severity: AlertEngine.Severity = .none
+    /// Window-length glyph shown when no active countdown is known — must
+    /// match the window actually displayed ("5h", or "7d" for the Codex
+    /// weekly fallback on weekly-only plans).
+    var windowLengthFallback: String = "5h"
     @ObservedObject private var usageDisplay = UsageDisplayModeStore.shared
 
     var body: some View {
@@ -75,7 +79,7 @@ struct NotchPeekPill: View {
     /// window" label from an active "5h until reset" countdown — same
     /// glyph shape, weaker visual presence.
     private var resetLabel: some View {
-        Text(resetText ?? "5h")
+        Text(resetText ?? windowLengthFallback)
             .font(Typography.bodyNumber)
             .foregroundStyle(.white.opacity(resetText == nil ? 0.45 : 0.70))
     }

--- a/Tests/CodexWindowRoutingTests.swift
+++ b/Tests/CodexWindowRoutingTests.swift
@@ -80,12 +80,24 @@ struct CodexWindowRoutingTests {
             weeklyOnly.fiveHour.error == "no data",
             "unreported 5h carries the passive `no data` sentinel, not a fetch error"
         )
+        let weeklyOnlyUsage = AppUsage(
+            fiveHour: weeklyOnly.fiveHour,
+            weekly: weeklyOnly.weekly
+        )
+        expect(
+            weeklyOnlyUsage.peekWindow.hasReading,
+            "peek selects the reported weekly window instead of rendering an em dash"
+        )
 
         // MARK: the original two-window shape still routes by span
 
         let both = UsageFetcher.routeCodexWindows(rateLimit(fromResponse: twoWindowResponse))
         expect(both.fiveHour.usedPercent == 0.12, "18000s primary window lands in 5h")
         expect(both.weekly.usedPercent == 0.34, "604800s secondary window lands in weekly")
+        expect(
+            AppUsage(fiveHour: both.fiveHour, weekly: both.weekly).peekWindow.usedPercent == 0.12,
+            "peek continues to prefer 5h when both windows are reported"
+        )
 
         // MARK: shapes without limit_window_seconds fall back to slot order
 

--- a/Tests/CodexWindowRoutingTests.swift
+++ b/Tests/CodexWindowRoutingTests.swift
@@ -88,6 +88,10 @@ struct CodexWindowRoutingTests {
             weeklyOnlyUsage.peekWindow.hasReading,
             "peek selects the reported weekly window instead of rendering an em dash"
         )
+        expect(
+            weeklyOnlyUsage.peekWindowIsWeekly,
+            "peek chrome knows the weekly window was selected (a11y label, 7d fallback)"
+        )
 
         // MARK: the original two-window shape still routes by span
 
@@ -97,6 +101,10 @@ struct CodexWindowRoutingTests {
         expect(
             AppUsage(fiveHour: both.fiveHour, weekly: both.weekly).peekWindow.usedPercent == 0.12,
             "peek continues to prefer 5h when both windows are reported"
+        )
+        expect(
+            !AppUsage(fiveHour: both.fiveHour, weekly: both.weekly).peekWindowIsWeekly,
+            "peek chrome describes the 5h window on two-window plans"
         )
 
         // MARK: shapes without limit_window_seconds fall back to slot order


### PR DESCRIPTION
## What changed

- Select the weekly Codex usage window for the Dynamic Island peek when the five-hour window is not reported.
- Keep the five-hour window as the preferred peek value when both windows exist.
- Add regression coverage for weekly-only and two-window responses.

## Why

Codex weekly-only plans report a real weekly quota but no five-hour window. The peek UI always selected the missing five-hour slot, so it rendered `—%` instead of the available remaining percentage.

## User impact

The Dynamic Island now shows the real Codex remaining percentage for weekly-only plans. Claude behavior is unchanged.

## Validation

- `./scripts/run-tests.sh`
- `SU_FEED_URL= ./build.sh`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for displaying weekly usage windows when five-hour usage data is unavailable.
  - Usage indicators now show the applicable window, percentages, reset details, and no-data states.
  - Accessibility labels now clarify whether information applies to the five-hour or weekly window.
  - Added English and Simplified Chinese translations for weekly usage status messages.

- **Bug Fixes**
  - Alerts now evaluate the same usage window shown in the interface, improving severity and threshold-crossing accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->