### PR TITLE
feat(cost): add local Grok and Antigravity usage readers

### DIFF
--- a/Sources/Cost/AntigravityLogReader.swift
+++ b/Sources/Cost/AntigravityLogReader.swift
@@ -1,0 +1,102 @@
+import Foundation
+import SQLite3
+
+enum AntigravityLogReader {
+    struct Record {
+        let id: String
+        let event: TokenEvent
+    }
+
+    static func scan(lookbackDays: Int = 30, root: URL? = nil, now: Date = Date()) -> LocalCostScan {
+        let root = root ?? FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".gemini/antigravity-cli/conversations", isDirectory: true)
+        var result = LocalCostScan()
+        guard FileManager.default.fileExists(atPath: root.path) else { return result }
+        guard let files = try? FileManager.default.contentsOfDirectory(at: root, includingPropertiesForKeys: nil) else {
+            result.unreadableFiles = 1
+            return result
+        }
+        let cutoff = now.addingTimeInterval(-Double(lookbackDays) * 86400)
+        var seen = Set<String>()
+        for file in files.filter({ $0.pathExtension == "db" }).sorted(by: { $0.path < $1.path }) {
+            do {
+                let records = try read(file)
+                result.skippedRecords += records.skipped
+                for record in records.records where record.event.timestamp >= cutoff && record.event.timestamp <= now {
+                    if seen.insert(record.id).inserted { result.events.append(record.event) }
+                }
+            } catch { result.unreadableFiles += 1 }
+        }
+        return result
+    }
+
+    // One gen_metadata row is one model call. A call can produce several steps;
+    // summing steps or transcript/chunk copies would count the same call repeatedly.
+    static func record(generation: Data, stepDates: [Int: Date], fallbackID: String) -> Record? {
+        guard let gen = ProtobufFields(generation), let chat = gen.message(1),
+              let usage = chat.message(4), let indices = gen.integers(2),
+              let date = indices.compactMap({ stepDates[$0] }).min() else { return nil }
+        let input = usage.integer(2) ?? 0
+        let output = usage.integer(3) ?? 0
+        let cacheWrite = usage.integer(4) ?? 0
+        let cacheRead = usage.integer(5) ?? 0
+        // ModelUsageStats already separates cache input and includes thinking in output.
+        guard [input, output, cacheWrite, cacheRead].allSatisfy({ $0 <= 1_000_000_000 }),
+              input + output + cacheWrite + cacheRead > 0 else { return nil }
+        let rawModel = chat.string(19) ?? chat.string(22) ?? chat.string(21)
+        let model = rawModel.flatMap { $0.isEmpty ? nil : $0 } ?? "antigravity-model-\(chat.integer(3) ?? 0)"
+        let messageID = usage.string(12) ?? usage.string(7) ?? usage.string(11)
+        let id = messageID.flatMap { $0.isEmpty ? nil : $0 } ?? fallbackID
+        return Record(id: id, event: TokenEvent(provider: .antigravity, timestamp: date,
+            model: model, inputTokens: input, outputTokens: output,
+            cacheCreationTokens: cacheWrite, cacheReadTokens: cacheRead))
+    }
+
+    private enum ReadError: Error { case database }
+
+    private static func read(_ file: URL) throws -> (records: [Record], skipped: Int) {
+        var pointer: OpaquePointer?
+        let status = sqlite3_open_v2(file.path, &pointer, SQLITE_OPEN_READONLY | SQLITE_OPEN_NOMUTEX, nil)
+        guard status == SQLITE_OK, let db = pointer else {
+            if let pointer { sqlite3_close(pointer) }
+            throw ReadError.database
+        }
+        defer { sqlite3_close(db) }
+        sqlite3_busy_timeout(db, 500)
+        guard sqlite3_exec(db, "BEGIN", nil, nil, nil) == SQLITE_OK else { throw ReadError.database }
+        defer { sqlite3_exec(db, "ROLLBACK", nil, nil, nil) }
+        var dates: [Int: Date] = [:]
+        try rows(db, sql: "SELECT idx, metadata FROM steps") { index, data in
+            if let metadata = ProtobufFields(data), let date = metadata.message(1)?.timestamp {
+                dates[index] = date
+            }
+        }
+        var records: [Record] = []
+        var skipped = 0
+        try rows(db, sql: "SELECT idx, data FROM gen_metadata") { index, data in
+            if let record = record(generation: data, stepDates: dates,
+                                   fallbackID: "\(file.deletingPathExtension().lastPathComponent):\(index)") {
+                records.append(record)
+            } else if ProtobufFields(data)?.message(1) != nil {
+                skipped += 1
+            }
+        }
+        return (records, skipped)
+    }
+
+    private static func rows(_ db: OpaquePointer, sql: String, consume: (Int, Data) -> Void) throws {
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK, let statement else {
+            throw ReadError.database
+        }
+        defer { sqlite3_finalize(statement) }
+        while true {
+            let status = sqlite3_step(statement)
+            if status == SQLITE_DONE { return }
+            guard status == SQLITE_ROW else { throw ReadError.database }
+            let count = Int(sqlite3_column_bytes(statement, 1))
+            guard count <= 16_777_216, let bytes = sqlite3_column_blob(statement, 1) else { continue }
+            consume(Int(sqlite3_column_int64(statement, 0)), Data(bytes: bytes, count: count))
+        }
+    }
+}

--- a/Sources/Cost/CostUsage.swift
+++ b/Sources/Cost/CostUsage.swift
@@ -27,6 +27,11 @@ struct CostWindow {
     /// doesn't silently read as $0.
     let unknownModels: [String]
 
+    static func unavailable(label: String, reason: String) -> CostWindow {
+        CostWindow(dollars: 0, tokens: 0, billableTokens: 0, series: [], label: label,
+                   error: reason, unknownModels: [])
+    }
+
     static let unknown = CostWindow(
         dollars: 0, tokens: 0, billableTokens: 0, series: [], label: "—",
         error: "no data", unknownModels: []

--- a/Sources/Cost/GrokLogReader.swift
+++ b/Sources/Cost/GrokLogReader.swift
@@ -1,0 +1,97 @@
+import Foundation
+
+enum GrokLogReader {
+    struct Record {
+        let id: String
+        let event: TokenEvent
+    }
+
+    static func scan(lookbackDays: Int = 30, root: URL? = nil, now: Date = Date()) -> LocalCostScan {
+        let home = ProcessInfo.processInfo.environment["GROK_HOME"].flatMap { $0.isEmpty ? nil : $0 }
+            .map { URL(fileURLWithPath: $0) }
+            ?? FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".grok")
+        let root = root ?? home.appendingPathComponent("sessions", isDirectory: true)
+        var result = LocalCostScan()
+        guard FileManager.default.fileExists(atPath: root.path) else { return result }
+        let cutoff = now.addingTimeInterval(-Double(lookbackDays) * 86400)
+        var records: [String: TokenEvent] = [:]
+        let files = LogParseCache.jsonlFiles(under: root, modifiedAfter: cutoff) { $0.lastPathComponent == "updates.jsonl" }
+        for file in files {
+            guard FileManager.default.isReadableFile(atPath: file.url.path) else {
+                result.unreadableFiles += 1
+                continue
+            }
+            var found = false
+            LogParseCache.streamLines(at: file.url, maxLineBytes: 2_097_152) { data in
+                for record in parse(data) where record.event.timestamp >= cutoff && record.event.timestamp <= now {
+                    // Final prompt usage can be repeated in persisted ACP updates.
+                    records[record.id] = record.event
+                    found = true
+                }
+            }
+            if !found { result.skippedRecords += 1 }
+        }
+        result.events = Array(records.values)
+        return result
+    }
+
+    static func parse(_ data: Data) -> [Record] {
+        guard let row = try? JSONDecoder().decode(Update.self, from: data) else { return [] }
+        let meta = row._meta ?? row.update?._meta ?? row.params?.update?._meta
+        guard let meta, meta.usageIsIncomplete != true,
+              let prompt = meta.promptId, !prompt.isEmpty,
+              let timestamp = row.timestamp?.date ?? meta.timestamp?.date,
+              let models = meta.modelUsage ?? meta.usage?.modelUsage else { return [] }
+        return models.compactMap { model, usage in
+            guard !model.isEmpty, usage.costIsPartial != true,
+                  let fullInput = usage.inputTokens, let output = usage.outputTokens else { return nil }
+            let cacheRead = usage.cacheReadTokens ?? 0
+            let cacheWrite = usage.cacheCreationTokens ?? 0
+            guard [fullInput, output, cacheRead, cacheWrite].allSatisfy({ $0 >= 0 && $0 <= 1_000_000_000 }),
+                  fullInput >= cacheRead + cacheWrite, fullInput + output > 0 else { return nil }
+            // ACP PromptUsage input includes cache; TokenEvent buckets are disjoint.
+            return Record(id: "\(prompt):\(model)", event: TokenEvent(provider: .grok,
+                timestamp: timestamp, model: model, inputTokens: fullInput - cacheRead - cacheWrite,
+                outputTokens: output, cacheCreationTokens: cacheWrite, cacheReadTokens: cacheRead))
+        }
+    }
+
+    private struct Update: Decodable {
+        let timestamp: Timestamp?
+        let _meta: Meta?
+        let update: NestedUpdate?
+        let params: Parameters?
+    }
+    private struct NestedUpdate: Decodable { let _meta: Meta? }
+    private struct Parameters: Decodable { let update: NestedUpdate? }
+    private struct Meta: Decodable {
+        let timestamp: Timestamp?
+        let promptId: String?
+        let usageIsIncomplete: Bool?
+        let usage: Usage?
+        let modelUsage: [String: ModelUsage]?
+    }
+    private struct Usage: Decodable { let modelUsage: [String: ModelUsage]? }
+    private struct ModelUsage: Decodable {
+        let inputTokens: Int?
+        let outputTokens: Int?
+        let cacheReadTokens: Int?
+        let cacheCreationTokens: Int?
+        let costIsPartial: Bool?
+    }
+    private struct Timestamp: Decodable {
+        let date: Date?
+        init(from decoder: Decoder) throws {
+            let value = try decoder.singleValueContainer()
+            if let text = try? value.decode(String.self) {
+                let formatter = ISO8601DateFormatter()
+                formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+                if let parsed = formatter.date(from: text) { date = parsed; return }
+                formatter.formatOptions = [.withInternetDateTime]
+                date = formatter.date(from: text)
+            } else if let number = try? value.decode(Double.self), number.isFinite, number > 0 {
+                date = Date(timeIntervalSince1970: number > 100_000_000_000 ? number / 1000 : number)
+            } else { date = nil }
+        }
+    }
+}

--- a/Sources/Cost/LocalCostScan.swift
+++ b/Sources/Cost/LocalCostScan.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+struct LocalCostScan {
+    var events: [TokenEvent] = []
+    var unreadableFiles = 0
+    var skippedRecords = 0
+
+    var notice: String? {
+        if unreadableFiles > 0 { return "Some local records could not be read" }
+        if skippedRecords > 0 { return "Some local records have no usage data" }
+        if events.isEmpty { return "No local usage records yet" }
+        return nil
+    }
+}

--- a/Sources/Cost/Pricing.swift
+++ b/Sources/Cost/Pricing.swift
@@ -184,7 +184,7 @@ enum Pricing {
     /// Claude Code workflows. ccusage's per-bucket threshold check would
     /// disagree with Anthropic's per-position-in-context billing anyway.
     static func cost(for event: TokenEvent) -> Double {
-        guard let rates = resolvedRates(for: canonicalModel(event.model)) else { return 0 }
+        guard let rates = resolvedRates(for: canonicalModel(event.model), at: event.timestamp) else { return 0 }
 
         let input = Double(event.inputTokens) / 1_000_000 * rates.inputPerMillion
         let output = Double(event.outputTokens) / 1_000_000 * rates.outputPerMillion
@@ -203,7 +203,14 @@ enum Pricing {
 
     /// Remote catalog first, embedded seed second. The seed is what keeps a
     /// catalog that omits a model from silently pricing it at $0.
-    private static func resolvedRates(for canonical: String) -> Rates? {
+    private static func resolvedRates(for canonical: String, at date: Date = Date()) -> Rates? {
+        // Published Gemini introductory pricing expires on 2027-01-01 UTC.
+        // Use event time so importing older CLI records keeps their historical rate.
+        if ["gemini-3.6-flash", "gemini-3.7-flash", "gemini-3.8-flash"].contains(canonical) {
+            let factor = date.timeIntervalSince1970 < 1_798_761_600 ? 1.0 : 2.0
+            return Rates(inputPerMillion: 0.75 * factor, outputPerMillion: 3.75 * factor,
+                         cacheCreationPerMillion: 0.75 * factor, cacheReadPerMillion: 0.075 * factor)
+        }
         if let remote = PricingCatalog.rates(for: canonical) {
             return Rates(
                 inputPerMillion: remote.inputPerMillion,
@@ -258,6 +265,8 @@ enum Pricing {
     }
 
     private static func canonicalModel(_ raw: String) -> String {
+        let raw = raw.hasPrefix("claude-") && raw.hasSuffix("-thinking")
+            ? String(raw.dropLast("-thinking".count)) : raw
         guard raw.count > 9 else { return raw }
         let suffixStart = raw.index(raw.endIndex, offsetBy: -9)
         let suffix = raw[suffixStart...]

--- a/Sources/Cost/ProtobufFields.swift
+++ b/Sources/Cost/ProtobufFields.swift
@@ -1,0 +1,99 @@
+import Foundation
+
+// agy's SQLite metadata uses protobuf. Decode only wire fields needed for usage;
+// reject truncated messages instead of interpreting partial bytes as zero tokens.
+struct ProtobufFields {
+    enum Value {
+        case integer(UInt64)
+        case bytes(Data)
+        case fixed32(UInt32)
+        case fixed64(UInt64)
+    }
+    let fields: [Int: [Value]]
+
+    init?(_ data: Data) {
+        let bytes = Array(data)
+        var offset = 0
+        var fields: [Int: [Value]] = [:]
+        while offset < bytes.count {
+            guard let tag = Self.varint(bytes, offset: &offset), tag >> 3 > 0,
+                  tag >> 3 <= 536_870_911 else { return nil }
+            let number = Int(tag >> 3)
+            let value: Value
+            switch tag & 7 {
+            case 0:
+                guard let n = Self.varint(bytes, offset: &offset) else { return nil }
+                value = .integer(n)
+            case 2:
+                guard let length = Self.varint(bytes, offset: &offset),
+                      length <= UInt64(bytes.count - offset) else { return nil }
+                let end = offset + Int(length)
+                value = .bytes(Data(bytes[offset..<end]))
+                offset = end
+            case 1, 5:
+                let length = tag & 7 == 1 ? 8 : 4
+                guard bytes.count - offset >= length else { return nil }
+                var n: UInt64 = 0
+                for i in 0..<length { n |= UInt64(bytes[offset + i]) << (8 * i) }
+                offset += length
+                value = length == 8 ? .fixed64(n) : .fixed32(UInt32(n))
+            default: return nil
+            }
+            fields[number, default: []].append(value)
+        }
+        self.fields = fields
+    }
+
+    func integer(_ field: Int) -> Int? {
+        guard case .integer(let value) = fields[field]?.last, value <= UInt64(Int.max) else { return nil }
+        return Int(value)
+    }
+
+    func data(_ field: Int) -> Data? {
+        guard case .bytes(let data) = fields[field]?.last else { return nil }
+        return data
+    }
+
+    func message(_ field: Int) -> ProtobufFields? { data(field).flatMap(ProtobufFields.init) }
+    func string(_ field: Int) -> String? { data(field).flatMap { String(data: $0, encoding: .utf8) } }
+
+    func integers(_ field: Int) -> [Int]? {
+        var result: [Int] = []
+        for value in fields[field] ?? [] {
+            switch value {
+            case .integer(let n):
+                guard n <= UInt64(Int.max) else { return nil }
+                result.append(Int(n))
+            case .bytes(let data):
+                let bytes = Array(data)
+                var offset = 0
+                while offset < bytes.count {
+                    guard let n = Self.varint(bytes, offset: &offset), n <= UInt64(Int.max) else { return nil }
+                    result.append(Int(n))
+                }
+            default: return nil
+            }
+        }
+        return result
+    }
+
+    var timestamp: Date? {
+        guard let seconds = integer(1), seconds > 0 else { return nil }
+        let nanos = integer(2) ?? 0
+        guard nanos < 1_000_000_000 else { return nil }
+        return Date(timeIntervalSince1970: Double(seconds) + Double(nanos) / 1_000_000_000)
+    }
+
+    private static func varint(_ bytes: [UInt8], offset: inout Int) -> UInt64? {
+        var result: UInt64 = 0
+        for shift in stride(from: 0, through: 63, by: 7) {
+            guard offset < bytes.count else { return nil }
+            let byte = bytes[offset]
+            offset += 1
+            if shift == 63 && byte > 1 { return nil }
+            result |= UInt64(byte & 127) << shift
+            if byte < 128 { return result }
+        }
+        return nil
+    }
+}

--- a/Sources/Cost/TokenEvent.swift
+++ b/Sources/Cost/TokenEvent.swift
@@ -7,6 +7,8 @@ struct TokenEvent {
     enum Provider {
         case claude
         case codex
+        case grok
+        case antigravity
     }
 
     let provider: Provider

--- a/Sources/Views/CostBlock.swift
+++ b/Sources/Views/CostBlock.swift
@@ -249,6 +249,7 @@ struct CostTile: View {
             switch provider {
             case .claude: return usageStore.claude.plan?.lowercased()
             case .codex:  return usageStore.codex.plan?.lowercased()
+            case .grok, .antigravity: return nil
             }
         }()
         guard let plan else { return nil }
@@ -269,6 +270,7 @@ struct CostTile: View {
             switch provider {
             case .claude: return usageStore.claude.plan?.lowercased()
             case .codex:  return usageStore.codex.plan?.lowercased()
+            case .grok, .antigravity: return nil
             }
         }()
         guard let plan else { return nil }

--- a/Tests/LocalProviderCostTests.swift
+++ b/Tests/LocalProviderCostTests.swift
@@ -1,0 +1,90 @@
+import Foundation
+import SQLite3
+
+enum L10n {
+    static let locale = Locale(identifier: "en_US")
+    static func tr(_ text: String, _ args: CVarArg...) -> String { String(format: text, arguments: args) }
+}
+
+@main
+struct LocalProviderCostTests {
+    static func expect(_ result: Bool, _ label: String) {
+        guard result else { print("FAIL \(label)"); exit(1) }
+        print("PASS \(label)")
+    }
+    static func varint(_ n: UInt64) -> Data {
+        var n = n, out = Data()
+        while n >= 128 { out.append(UInt8(n & 127) | 128); n >>= 7 }
+        out.append(UInt8(n)); return out
+    }
+    static func integer(_ field: Int, _ value: Int) -> Data {
+        varint(UInt64(field << 3)) + varint(UInt64(value))
+    }
+    static func bytes(_ field: Int, _ value: Data) -> Data {
+        varint(UInt64(field << 3 | 2)) + varint(UInt64(value.count)) + value
+    }
+    static func generation(id: String = "call-1", model: String = "gemini-3.8-flash") -> Data {
+        let usage = integer(2, 1000) + integer(3, 200) + integer(5, 4000)
+            + integer(9, 120) + integer(10, 80) + bytes(7, Data(id.utf8))
+        let chat = bytes(4, usage) + bytes(19, Data(model.utf8))
+        return bytes(1, chat) + bytes(2, Data([1, 2]))
+    }
+    static func createDB(_ path: URL, date: Date) {
+        var db: OpaquePointer?
+        expect(sqlite3_open(path.path, &db) == SQLITE_OK, "create isolated fixture")
+        defer { sqlite3_close(db) }
+        let metadata = bytes(1, integer(1, Int(date.timeIntervalSince1970)))
+        func hex(_ data: Data) -> String { data.map { String(format: "%02x", $0) }.joined() }
+        let sql = """
+        CREATE TABLE steps(idx INTEGER, metadata BLOB);
+        CREATE TABLE gen_metadata(idx INTEGER, data BLOB);
+        INSERT INTO steps VALUES(1, X'\(hex(metadata))'),(2, X'\(hex(metadata))');
+        INSERT INTO gen_metadata VALUES(0, X'\(hex(generation()))');
+        """
+        expect(sqlite3_exec(db, sql, nil, nil, nil) == SQLITE_OK, "write metadata fixture")
+    }
+    static func main() throws {
+        let now = ISO8601DateFormatter().date(from: "2026-09-08T18:00:00Z") ?? Date()
+        let record = AntigravityLogReader.record(generation: generation(), stepDates: [1: now, 2: now], fallbackID: "fallback")
+        expect(record?.event.inputTokens == 1000 && record?.event.cacheReadTokens == 4000, "agy cache and uncached input stay disjoint")
+        expect(record?.event.outputTokens == 200, "thinking is not added to output twice")
+        expect(record?.event.model == "gemini-3.8-flash", "model identity comes from response")
+        expect(AntigravityLogReader.record(generation: generation(), stepDates: [:], fallbackID: "x") == nil, "missing timestamp never assigned to today")
+        expect(ProtobufFields(Data([10, 8, 1])) == nil, "truncated protobuf rejected")
+        expect(ProtobufFields(Data(repeating: 255, count: 12)) == nil, "overflowing varint rejected")
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        createDB(dir.appendingPathComponent("a.db"), date: now.addingTimeInterval(-3600))
+        try FileManager.default.copyItem(at: dir.appendingPathComponent("a.db"), to: dir.appendingPathComponent("fork.db"))
+        let scan = AntigravityLogReader.scan(lookbackDays: 10, root: dir, now: now)
+        expect(scan.events.count == 1, "forked database and multiple steps count one model call")
+        expect(scan.notice == nil, "successful local scan is complete")
+        let summary = CostSummary.summarize(events: scan.events, now: now)
+        expect(summary.today.tokens == 5200 && summary.month.tokens == 5200, "new provider feeds existing today and month totals")
+        expect(summary.dailyTokens.reduce(0) { $0 + $1.tokens } == 5200, "new provider feeds activity history")
+        expect(summary.recentByModel.first?.tokens == 1200, "model breakdown uses common billable token rule")
+        expect(abs(summary.today.dollars - 0.0018) < 0.0000001, "Gemini public rates include cache discount")
+        let future = AntigravityLogReader.scan(lookbackDays: 10, root: dir, now: now.addingTimeInterval(-7200))
+        expect(future.events.isEmpty, "future-dated calls excluded")
+        try Data("not sqlite".utf8).write(to: dir.appendingPathComponent("broken.db"))
+        let partial = AntigravityLogReader.scan(lookbackDays: 10, root: dir, now: now)
+        expect(partial.events.count == 1 && partial.unreadableFiles == 1, "unreadable database keeps readable records with warning")
+        let grok = Data("""
+        {"timestamp":"2026-09-08T17:00:00Z","_meta":{"promptId":"prompt-1","modelUsage":{"grok-test":{"inputTokens":5000,"outputTokens":200,"cacheReadTokens":4000,"cacheCreationTokens":0}}}}
+        """.utf8)
+        let parsed = GrokLogReader.parse(grok)
+        expect(parsed.first?.event.inputTokens == 1000 && parsed.first?.event.cacheReadTokens == 4000, "ACP full prompt is normalized to disjoint buckets")
+        let stream = dir.appendingPathComponent("updates.jsonl")
+        try (grok + Data([10]) + grok + Data([10])).write(to: stream)
+        expect(GrokLogReader.scan(root: dir, now: now).events.count == 1, "repeated Grok prompt totals deduplicated")
+        let incomplete = Data(String(decoding: grok, as: UTF8.self).replacingOccurrences(of: "\"promptId\"", with: "\"usageIsIncomplete\":true,\"promptId\"").utf8)
+        expect(GrokLogReader.parse(incomplete).isEmpty, "incomplete Grok aggregate never presented as complete cost")
+        expect(Pricing.canonicalModelName("claude-opus-4-6-thinking") == "claude-opus-4-6", "Antigravity thinking alias shares base model pricing")
+        if let event = record?.event {
+            let later = TokenEvent(provider: .antigravity, timestamp: Date(timeIntervalSince1970: 1_798_761_600), model: event.model,
+                inputTokens: event.inputTokens, outputTokens: event.outputTokens, cacheCreationTokens: 0, cacheReadTokens: event.cacheReadTokens)
+            expect(abs(Pricing.cost(for: later) - 0.0036) < 0.0000001, "Gemini introductory rate ends at documented boundary")
+        }
+    }
+}

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -108,3 +108,21 @@ swiftc \
   Tests/PricingPrecedenceTests.swift
 
 "$OUT_DIR/pricing-precedence-tests"
+
+swiftc \
+  -parse-as-library \
+  -o "$OUT_DIR/local-provider-cost-tests" \
+  Sources/Cost/TokenEvent.swift \
+  Sources/Cost/LocalCostScan.swift \
+  Sources/Cost/ProtobufFields.swift \
+  Sources/Cost/AntigravityLogReader.swift \
+  Sources/Cost/GrokLogReader.swift \
+  Sources/Cost/LogParseCache.swift \
+  Sources/Cost/CostUsage.swift \
+  Sources/Cost/CostBucketing.swift \
+  Sources/Cost/CostSummary.swift \
+  Sources/Cost/PricingCatalog.swift \
+  Sources/Cost/Pricing.swift \
+  Tests/LocalProviderCostTests.swift
+
+"$OUT_DIR/local-provider-cost-tests"


### PR DESCRIPTION
Adds local usage readers for Grok and Antigravity so their CLI records can feed the existing cost, token, model, and activity summaries. This is the data layer; the next PR connects it to the app.

- Read Antigravity SQLite/WAL records in read-only transactions, decode per-call protobuf usage, and deduplicate calls without double-counting cache or thinking tokens.
- Parse timestamped Grok ACP usage with disjoint token buckets and omit incomplete records.
- Preserve unknown/unreadable states and apply historical Gemini Flash pricing and Claude thinking-model aliases.

Validation: standalone universal macOS build and 233 passing test assertions, including SQLite/protobuf fixtures, deduplication, malformed data, incomplete usage, and the Gemini pricing cutoff. Antigravity was also checked against local CLI records during development.

Grok's persisted usage format is fixture-tested only; a real Grok session log is still needed before treating that reader as verified. This PR remains a draft for that review.

Stack order: this PR → #83 (provider accounts and shared UI) → #84 (reported limit windows and compact charts). No release/version change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added local cost tracking for Grok and Antigravity usage.
  - Token usage now includes input, output, and cached-token accounting.
  - Added scan status information for unavailable files or records without usage data.

- **Improvements**
  - Historical usage uses rates applicable to its event date.
  - Improved model name recognition, including Claude thinking variants.
  - Grok and Antigravity usage displays cost totals without subscription plan pricing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->