### PR TITLE
fix(usage): adapt charts to reported limit windows

### DIFF
--- a/Sources/Usage/AppUsage.swift
+++ b/Sources/Usage/AppUsage.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// The two rate-limit windows every provider reports. Named here rather than
+/// Standard rate-limit windows. A provider may report only one. Named here rather than
 /// beside the history store because they name `AppUsage`'s own two fields —
 /// and so the pure value layer stays free of store dependencies.
 enum UsageWindow: String, Codable {
@@ -72,19 +72,38 @@ struct AppUsage {
     /// or Codex's `plan_type` (free/plus/pro). nil when unknown.
     var plan: String?
 
-    init(fiveHour: WindowUsage, weekly: WindowUsage, plan: String? = nil) {
+    // nil means no successful window discovery yet, not a two-window plan.
+    var reportedWindows: [UsageWindow]?
+
+    init(fiveHour: WindowUsage, weekly: WindowUsage, plan: String? = nil,
+         reportedWindows: [UsageWindow]? = nil) {
         self.fiveHour = fiveHour
         self.weekly = weekly
         self.plan = plan
+        self.reportedWindows = reportedWindows
     }
 
     static let empty = AppUsage(fiveHour: .unknown, weekly: .unknown)
 
-    var peekWindow: WindowUsage { fiveHour.hasReading ? fiveHour : weekly }
+    var visibleWindows: [UsageWindow] {
+        let order: [UsageWindow] = [.fiveHour, .weekly]
+        if let reportedWindows { return order.filter { reportedWindows.contains($0) } }
+        return order.filter { !window($0).isUnreported }
+    }
+
+    func window(_ kind: UsageWindow) -> WindowUsage {
+        kind == .fiveHour ? fiveHour : weekly
+    }
+
+    var peekWindow: WindowUsage { peekWindowIsWeekly ? weekly : fiveHour }
 
     /// Which window `peekWindow` selected — the peek chrome (VoiceOver label,
     /// window-length fallback glyph) must describe the same window it shows.
-    var peekWindowIsWeekly: Bool { !fiveHour.hasReading }
+    var peekWindowIsWeekly: Bool {
+        if visibleWindows == [.fiveHour] { return false }
+        if visibleWindows == [.weekly] { return true }
+        return !fiveHour.hasReading
+    }
 
     /// Fold a fetch result into the values currently on screen.
     ///
@@ -105,7 +124,8 @@ struct AppUsage {
             weekly: carryForward(fetched.weekly, prior: prior.weekly, at: now),
             // Plan tier is read from the credential store, not the usage
             // response, so a failed fetch shouldn't blank the chip's badge.
-            plan: fetched.plan ?? prior.plan
+            plan: fetched.plan ?? prior.plan,
+            reportedWindows: fetched.reportedWindows ?? prior.reportedWindows
         )
     }
 

--- a/Sources/Usage/UsageFetcher.swift
+++ b/Sources/Usage/UsageFetcher.swift
@@ -36,7 +36,8 @@ enum UsageFetcher {
             return AppUsage(
                 fiveHour: windows.fiveHour,
                 weekly: windows.weekly,
-                plan: obj["plan_type"] as? String
+                plan: obj["plan_type"] as? String,
+                reportedWindows: windows.reported
             )
         } catch {
             return errorPair(error.localizedDescription)
@@ -66,7 +67,7 @@ enum UsageFetcher {
     /// each reported window by its advertised span instead — a day cleanly
     /// separates 5h (18000s) from weekly (604800s) — and fall back to slot
     /// order for older shapes that omit `limit_window_seconds`.
-    static func routeCodexWindows(_ rl: [String: Any]) -> (fiveHour: WindowUsage, weekly: WindowUsage) {
+    static func routeCodexWindows(_ rl: [String: Any]) -> (fiveHour: WindowUsage, weekly: WindowUsage, reported: [UsageWindow]) {
         var fiveHour: WindowUsage?
         var weekly: WindowUsage?
         let slots: [(key: String, fallback: UsageWindow)] = [
@@ -85,7 +86,10 @@ enum UsageFetcher {
             case .weekly:   if weekly == nil { weekly = parseCodexWindow(d) }
             }
         }
-        return (fiveHour ?? .unknown, weekly ?? .unknown)
+        var reported: [UsageWindow] = []
+        if fiveHour != nil { reported.append(.fiveHour) }
+        if weekly != nil { reported.append(.weekly) }
+        return (fiveHour ?? .unknown, weekly ?? .unknown, reported)
     }
 
     private static func parseCodexWindow(_ obj: Any?) -> WindowUsage {

--- a/Sources/Usage/UsageStore.swift
+++ b/Sources/Usage/UsageStore.swift
@@ -265,6 +265,7 @@ final class UsageStore: ObservableObject {
                                fillUnreported: Bool) -> AppUsage {
         func fill(_ kind: UsageWindow, _ existing: WindowUsage,
                   _ priorWindow: WindowUsage?) -> WindowUsage {
+            if let reported = current.reportedWindows, !reported.contains(kind) { return .unknown }
             guard !existing.hasReading else { return existing }
             if !fillUnreported {
                 if existing.isUnreported { return existing }
@@ -280,7 +281,8 @@ final class UsageStore: ObservableObject {
         return AppUsage(
             fiveHour: fill(.fiveHour, current.fiveHour, prior?.fiveHour),
             weekly: fill(.weekly, current.weekly, prior?.weekly),
-            plan: current.plan
+            plan: current.plan,
+            reportedWindows: current.reportedWindows
         )
     }
 

--- a/Sources/Views/Charts/RingChart.swift
+++ b/Sources/Views/Charts/RingChart.swift
@@ -5,9 +5,10 @@ struct RingChart: View {
     let color: Color
     let label: String
     let sub: String
+    var centered = false
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
+        VStack(alignment: centered ? .center : .leading, spacing: 8) {
             HStack(spacing: 14) {
                 ZStack {
                     Circle().stroke(.white.opacity(0.07), lineWidth: 3)
@@ -21,7 +22,7 @@ struct RingChart: View {
                         // without ever flashing 0%.
                         .animation(.strongEaseOut, value: value)
                 }
-                .frame(width: 56, height: 56)
+                .frame(width: centered ? 64 : 56, height: centered ? 64 : 56)
 
                 VStack(alignment: .leading, spacing: 4) {
                     Text(label)
@@ -39,7 +40,7 @@ struct RingChart: View {
                             .foregroundStyle(.white.opacity(0.5))
                     }
                 }
-                Spacer()
+                if !centered { Spacer() }
             }
             Text(sub)
                 .font(Typography.caption)

--- a/Sources/Views/UsageView.swift
+++ b/Sources/Views/UsageView.swift
@@ -79,17 +79,24 @@ struct ChartsBlock: View {
                 ReauthState(color: color, usage: usage)
                     .transition(.chartSwap.animation(.chartSwap))
             } else {
-                UsageChartsRow(color: color, style: style, seed: seed,
-                    metrics: [UsageWindow.fiveHour, .weekly].map { kind in
-                        UsageChartMetric(id: kind.rawValue, label: kind == .fiveHour ? "5h" : "week",
-                            window: kind == .fiveHour ? usage.fiveHour : usage.weekly,
-                            historyKey: "\(provider.rawValue).\(kind.rawValue)")
-                    })
+                Group {
+                    if usage.visibleWindows.isEmpty {
+                        ProviderDataUnavailable(message: "Usage limits are not available yet.")
+                    } else {
+                        UsageChartsRow(color: color, style: style, seed: seed,
+                            metrics: usage.visibleWindows.map { kind in
+                                UsageChartMetric(id: kind.rawValue, label: kind == .fiveHour ? "5h" : "week",
+                                                 window: usage.window(kind),
+                                                 historyKey: "\(provider.rawValue).\(kind.rawValue)")
+                            })
+                    }
+                }
                 .transition(.chartSwap.animation(.chartSwap))
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
         .padding(.horizontal, IslandPanelLayout.columnInset)
+        .animation(.chartSwap, value: usage.visibleWindows)
     }
 }
 
@@ -178,9 +185,12 @@ struct UsageChartsRow: View {
         HStack(spacing: 18) {
             ForEach(Array(metrics.enumerated()), id: \.element.id) { index, metric in
                 ChartTile(style: style, color: color, labelKey: metric.label,
-                          window: metric.window, seed: seed + index, historyKey: metric.historyKey)
+                          window: metric.window, seed: seed + index, historyKey: metric.historyKey,
+                          centered: metrics.count == 1)
             }
         }
+        .frame(maxWidth: metrics.count == 1 ? (style == .numeric ? 180 : 240) : .infinity)
+        .frame(maxWidth: .infinity, alignment: .center)
     }
 }
 
@@ -191,6 +201,7 @@ struct ChartTile: View {
     let window: WindowUsage
     let seed: Int
     let historyKey: String
+    var centered = false
     @ObservedObject private var usageDisplay = UsageDisplayModeStore.shared
     @ObservedObject private var historyStore = UsageHistoryStore.shared
 
@@ -213,7 +224,7 @@ struct ChartTile: View {
         Group {
             if let value {
                 switch style {
-                case .ring:    RingChart(value: value, color: color, label: label, sub: sub)
+                case .ring:    RingChart(value: value, color: color, label: label, sub: sub, centered: centered)
                 case .bar:     BarChart(value: value, color: color, label: label, sub: sub)
                 case .stepped: SteppedChart(value: value, color: color, label: label, sub: sub)
                 case .numeric: NumericChart(value: value, color: color, label: label, sub: compactSubCaption())
@@ -229,7 +240,7 @@ struct ChartTile: View {
         // The blur masks the geometric mismatch between Ring and Bar so the
         // crossfade reads as one morph instead of two stacked objects.
         .transition(.chartSwap.animation(.chartSwap))
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: centered ? .top : .topLeading)
         .frame(height: Self.tileHeight)
         .accessibilityElement(children: .combine)
         .accessibilityLabel(

--- a/Tests/CodexWindowRoutingTests.swift
+++ b/Tests/CodexWindowRoutingTests.swift
@@ -142,6 +142,32 @@ struct CodexWindowRoutingTests {
         expect(collision.weekly.usedPercent == 0.90, "primary's weekly reading survives the collision")
         expect(!collision.fiveHour.hasReading, "the colliding sibling doesn't leak into 5h")
 
+        let weeklyDisplay = AppUsage(fiveHour: weeklyOnly.fiveHour, weekly: weeklyOnly.weekly,
+            plan: "prolite", reportedWindows: weeklyOnly.reported)
+        expect(weeklyDisplay.visibleWindows == [.weekly], "weekly-only plan renders one tile")
+        let twoDisplay = AppUsage(fiveHour: both.fiveHour, weekly: both.weekly,
+            plan: "pro", reportedWindows: both.reported)
+        expect(twoDisplay.visibleWindows == [.fiveHour, .weekly], "API windows override plan-name assumptions")
+        let zero = WindowUsage(usedPercent: 0, resetAt: nil, error: nil)
+        let zeroWeekly = AppUsage(fiveHour: .unknown, weekly: zero, reportedWindows: [.weekly])
+        expect(zeroWeekly.visibleWindows == [.weekly], "genuine zero-percent weekly limit remains visible")
+        expect(zeroWeekly.peekWindowIsWeekly && zeroWeekly.peekWindow.hasReading, "zero-percent weekly peek keeps its identity")
+        let error = WindowUsage(usedPercent: 0, resetAt: nil, error: "offline")
+        let failed = AppUsage(fiveHour: error, weekly: error)
+        let merged = AppUsage.merged(fetched: failed, retaining: weeklyDisplay, at: Date())
+        expect(merged.visibleWindows == [.weekly], "offline refresh cannot resurrect the absent 5h tile")
+        expect(merged.peekWindowIsWeekly, "offline weekly plan keeps weekly peek and alert routing")
+        let failedAgain = AppUsage.merged(fetched: failed, retaining: merged, at: Date())
+        expect(failedAgain.visibleWindows == [.weekly], "repeated failures retain the discovered windows")
+        let changed = AppUsage.merged(fetched: twoDisplay, retaining: merged, at: Date())
+        expect(changed.visibleWindows == [.fiveHour, .weekly], "a newly reported 5h limit returns automatically")
+        let removed = AppUsage.merged(fetched: weeklyDisplay, retaining: twoDisplay, at: Date())
+        expect(removed.visibleWindows == [.weekly], "a removed limit does not remain as a placeholder")
+        let fiveOnlyDisplay = AppUsage(fiveHour: zero, weekly: .unknown, reportedWindows: [.fiveHour])
+        expect(fiveOnlyDisplay.visibleWindows == [.fiveHour] && !fiveOnlyDisplay.peekWindowIsWeekly,
+               "five-hour-only plans keep the correct label")
+        expect(AppUsage.empty.visibleWindows.isEmpty, "cold-start unknown does not invent limit windows")
+
         print(failures == 0 ? "ALL PASS" : "\(failures) FAILURE(S)")
         exit(failures == 0 ? 0 : 1)
     }

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -9,6 +9,15 @@ All providers use the same Ring, Bar, Stepped, Numeric, and Sparkline views,
 used/remaining preference, peek pills, and threshold alerts. A provider's data
 selects the metrics; changing providers does not change the chart style.
 
+## Codex limit windows
+
+Codex charts follow the windows reported by the usage API, not the plan name.
+A weekly-only response displays one compact chart centered in the provider column.
+Two reported windows retain the 5h/week pair. The discovered window list survives
+failed refreshes, so an offline request cannot bring back a removed 5h tile.
+Zero-percent windows remain visible. Peek and alerts select the same available
+window, and chart styles and history keys remain unchanged.
+
 ## Grok subscriptions
 
 Sign in with the official Grok CLI (`grok login`) using your Grok subscription.


### PR DESCRIPTION
When Codex reports only a weekly limit, hide the absent 5-hour tile and use a compact chart centered in the provider column. The visible windows follow the API response rather than the subscription name, so zero usage remains visible and a failed refresh cannot reintroduce a removed limit.

Builds on #83 (which builds on #82). Merge in that order, retargeting the next PR after its base lands.

- Preserve discovered windows through refresh failures and history seeding; keep peek and alerts on the available window.
- Use a bounded width for a single bar, stepped chart, numeric chart, or sparkline. Center the ring composition with a slightly larger ring.
- Keep the numeric percentage left-aligned with its label and meter, and retain the existing two-limit layout.

Validation: the complete stack passes 297 test assertions, including 11 added checks for weekly-only responses, true zeroes, plan-name independence, missing data, failures, and changing window lists. Universal macOS build verified. Native previews checked all five chart styles side-by-side with two-limit data and the transition from one limit to two. The final numeric left-alignment correction was separately rebuilt and visually checked.

No release or version bump is included.
