### PR TITLE
fix: increase settings window opening height

### DIFF
--- a/Sources/Views/SettingsView.swift
+++ b/Sources/Views/SettingsView.swift
@@ -66,7 +66,7 @@ struct SettingsView: View {
 
             SettingsFooter()
         }
-        .frame(minWidth: 440, minHeight: 420)
+        .frame(minWidth: 440, minHeight: 560)
         .background(Color(red: 0.020, green: 0.020, blue: 0.027))
         .preferredColorScheme(.dark)
     }

--- a/Sources/Views/SettingsWindowController.swift
+++ b/Sources/Views/SettingsWindowController.swift
@@ -5,7 +5,7 @@ import SwiftUI
 /// The Scene-based approach refused to actually hide the title bar on macOS
 /// 13 (`.windowStyle(.hiddenTitleBar)` left a divider + title text behind),
 /// and we want full control of the chrome anyway: transparent title bar,
-/// traffic lights inset over our own header, fixed size, dark canvas.
+/// traffic lights inset over our own header, resizable window, dark canvas.
 @MainActor
 final class SettingsWindowController: NSWindowController, NSWindowDelegate {
     static let shared = SettingsWindowController()
@@ -13,7 +13,7 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
     private init() {
         let hosting = NSHostingController(rootView: SettingsView())
         let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 480, height: 620),
+            contentRect: NSRect(x: 0, y: 0, width: 480, height: 720),
             styleMask: [.titled, .closable, .resizable, .fullSizeContentView],
             backing: .buffered,
             defer: false
@@ -26,7 +26,9 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
         window.backgroundColor = NSColor(
             calibratedRed: 0.075, green: 0.077, blue: 0.090, alpha: 1
         )
-        window.minSize = NSSize(width: 440, height: 420)
+        window.contentMinSize = NSSize(width: 440, height: 560)
+        // Apply after attaching SwiftUI, which can replace the initial content size.
+        window.setContentSize(NSSize(width: 480, height: 720))
         // Hide the dock-stow button (we have no dock icon) but keep zoom
         // alongside resize handles so the user controls size.
         window.standardWindowButton(.miniaturizeButton)?.isHidden = true


### PR DESCRIPTION
Settings opens with too little vertical space. Increase the initial content height from 620 to 720 points and apply it after attaching the SwiftUI hosting controller so hosting layout cannot replace the intended opening size. Raise the minimum content height from 420 to 560 points in both AppKit and SwiftUI while keeping the window resizable.

Validation: `./build.sh` passed for arm64 and x86_64 in the working checkout; that checkout also contained unrelated in-progress changes excluded from this PR. `git diff --check` passed. Live window appearance has not yet been verified.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **UI Improvements**
  - Increased the Settings window’s minimum height.
  - Increased the Settings window’s default height to provide more space for its content.
  - Improved resizing behavior so the window maintains appropriate content dimensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->