### PR TITLE
fix: distinguish Antigravity and Codex colors

### DIFF
--- a/Sources/Theme/Colors.swift
+++ b/Sources/Theme/Colors.swift
@@ -8,8 +8,13 @@ enum IslandColor {
     /// #CC785C — Anthropic terracotta. Claude logo + ring/bar fills.
     static let claude = Color(red: 204/255, green: 120/255, blue: 92/255)
 
-    /// #5AA8F0 — OpenAI sky blue. Codex logo + ring/bar fills.
+    /// #5AA8F0 — CodexIsland sky blue. Codex logo + ring/bar fills.
     static let codex = Color(red: 90/255, green: 168/255, blue: 240/255)
+
+    static let grok = Color.white
+
+    // App identity tint: separates Antigravity from Codex blue and status colors.
+    static let antigravity = Color(red: 182/255, green: 156/255, blue: 255/255)
 
     /// #3DD68C — live status dot. Sits next to cobalt without clashing.
     static let liveTeal = Color(red: 61/255, green: 214/255, blue: 140/255)

--- a/Sources/Views/ProviderIdentity.swift
+++ b/Sources/Views/ProviderIdentity.swift
@@ -17,8 +17,8 @@ extension IslandProvider {
         switch self {
         case .claude: return IslandColor.claude
         case .codex: return IslandColor.codex
-        case .grok: return .white
-        case .antigravity: return Color(red: 0.55, green: 0.72, blue: 1)
+        case .grok: return IslandColor.grok
+        case .antigravity: return IslandColor.antigravity
         }
     }
     var legacy: AlertEngine.Provider? {

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -97,3 +97,21 @@ provider cancels its pending request, and swapping positions does not fetch.
 Grok's CLI billing response and Antigravity's quota protocol can change.
 Fixture tests cover parsing and selection; validating authentication requires a
 signed-in CLI. Authenticated requests use HTTPS and do not follow redirects.
+
+## Provider colors
+
+Provider identity colors live in `Sources/Theme/Colors.swift` and are routed
+through `IslandProvider.color` for marks, usage charts, cost charts, and peek.
+These are CodexIsland display colors, not claims about official brand palettes.
+
+| Provider | Color | Hex |
+| --- | --- | --- |
+| Claude | Terracotta | `#CC785C` |
+| Codex | Sky blue | `#5AA8F0` |
+| Grok | White | `#FFFFFF` |
+| Antigravity | Lilac | `#B69CFF` |
+
+Antigravity uses a separate hue from Codex so adjacent providers are recognizable
+at a glance. Green, amber, and red remain reserved for status and alerts. Keep
+provider names and distinct marks visible so identification never depends only
+on color.


### PR DESCRIPTION
Codex and Antigravity used similar blues, making adjacent providers difficult to distinguish. Give Antigravity a lilac identity color (#B69CFF) and centralize Grok white alongside the existing Claude and Codex tokens. Logos and charts consume the shared provider colors.

Verified black-background contrast and the installed app's Codex/Antigravity display. These exact changes passed a universal build as part of the combined patch before being separated. No authentication or demo changes are included.
