### PR TITLE
fix: show subscription empty state on Usage and Cost

### DIFF
--- a/Sources/Usage/ConnectedUsage.swift
+++ b/Sources/Usage/ConnectedUsage.swift
@@ -40,6 +40,11 @@ struct ConnectedUsage {
 
     var primary: ConnectedLimit? { limits.first { $0.usedFraction != nil } }
 
+    var hasNoActiveSubscription: Bool {
+        guard !needsLogin, updatedAt != nil, primary == nil else { return false }
+        return plan?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "free"
+    }
+
     func storageScope(provider: IslandProvider) -> String {
         let identity = accountID ?? account ?? "local-session"
         let hash = SHA256.hash(data: Data(identity.utf8)).map { String(format: "%02x", $0) }.joined()

--- a/Sources/Views/ConnectedUsageBlock.swift
+++ b/Sources/Views/ConnectedUsageBlock.swift
@@ -10,7 +10,7 @@ struct ConnectedUsageBlock: View {
         let snapshot = connections.snapshot(provider)
         let limits = connections.limits(provider)
         Group {
-            if !snapshot.limits.isEmpty && !limits.isEmpty {
+            if !snapshot.needsLogin && limits.contains(where: { $0.usedFraction != nil }) {
                 UsageChartsRow(color: provider.color, style: style.style, seed: provider == .grok ? 5 : 7,
                     metrics: limits.map { limit in
                         UsageChartMetric(id: limit.id, label: limit.label, window: limit.window,
@@ -18,28 +18,53 @@ struct ConnectedUsageBlock: View {
                     })
                     .help(limits.first?.groupLabel ?? provider.name)
             } else {
-                VStack(spacing: 8) {
-                    if connections.loading.contains(provider) {
-                        ProgressView().controlSize(.small)
-                    }
-                    Text(L10n.tr(snapshot.needsLogin ? "Connect your account" : "Usage unavailable"))
-                        .font(Typography.label).foregroundStyle(.white.opacity(0.65))
-                    Button(L10n.tr("Open provider settings")) {
-                        UserDefaults.standard.set("providers", forKey: "Settings.activeTab")
-                        SettingsWindowController.shared.show()
-                    }
-                    .font(Typography.label)
-                    .foregroundStyle(.white.opacity(0.8))
-                    .buttonStyle(PressableButtonStyle(scale: 0.97))
-                    .padding(.horizontal, 8)
-                    .padding(.vertical, 4)
-                    .background(.white.opacity(0.06), in: RoundedRectangle(cornerRadius: 5))
-                }
-                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+                ProviderUsageEmptyState(provider: provider, snapshot: snapshot,
+                                        loading: connections.loading.contains(provider))
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
         .padding(.horizontal, IslandPanelLayout.columnInset)
+    }
+}
+
+struct ProviderUsageEmptyState: View {
+    let provider: IslandProvider
+    let snapshot: ConnectedUsage
+    var loading = false
+
+    var body: some View {
+        VStack(spacing: 5) {
+            if loading {
+                ProgressView().controlSize(.small)
+            } else {
+                Image(systemName: snapshot.hasNoActiveSubscription ? "creditcard" : "chart.bar.xaxis")
+                    .font(.system(size: 18, weight: .regular))
+                    .foregroundStyle(provider.color.opacity(0.85))
+                    .accessibilityHidden(true)
+            }
+            Text(L10n.tr(snapshot.hasNoActiveSubscription ? "No active subscription"
+                : snapshot.needsLogin ? "Connect your account" : "Usage unavailable"))
+                .font(Typography.rowTitle).foregroundStyle(.white.opacity(0.85))
+            Text(L10n.tr(snapshot.hasNoActiveSubscription
+                ? "Connect a subscribed account or choose another provider."
+                : snapshot.needsLogin ? "Sign in to see your usage limits."
+                : "This provider hasn't reported usage limits."))
+                .font(Typography.label)
+                .foregroundStyle(.white.opacity(0.65))
+                .multilineTextAlignment(.center)
+                .fixedSize(horizontal: false, vertical: true)
+            Button(L10n.tr("Open provider settings")) {
+                UserDefaults.standard.set("providers", forKey: "Settings.activeTab")
+                SettingsWindowController.shared.show()
+            }
+            .font(Typography.label)
+            .foregroundStyle(.white.opacity(0.8))
+            .buttonStyle(PressableButtonStyle(scale: 0.97))
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(.white.opacity(0.06), in: RoundedRectangle(cornerRadius: 5))
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
     }
 }
 

--- a/Sources/Views/CostView.swift
+++ b/Sources/Views/CostView.swift
@@ -6,6 +6,7 @@ import SwiftUI
 struct CostView: View {
     @ObservedObject private var store = CostStore.shared
     @ObservedObject private var visibility = ProviderVisibilityStore.shared
+    @ObservedObject private var connections = ProviderConnectionStore.shared
     @ObservedObject private var stylePref = CostStylePref.shared
 
     var body: some View {
@@ -27,10 +28,20 @@ struct CostView: View {
 
     @ViewBuilder
     private func providerBlock(_ provider: IslandProvider) -> some View {
-        CostBlock(color: provider.color, cost: store.cost(for: provider),
-                      loading: store.isLoading(provider), provider: provider.costProvider,
-                      centerWhenSingle: visibility.right == nil)
-        .help(store.localNotices[provider] ?? "Estimated API-equivalent cost from local CLI records; not a subscription charge.")
+        let cost = store.cost(for: provider)
+        let snapshot = connections.snapshot(provider)
+        if !provider.usesLegacyUsage && snapshot.hasNoActiveSubscription
+            && cost.today.error != nil && cost.month.error != nil
+            && cost.today.tokens == 0 && cost.month.tokens == 0
+            && cost.today.dollars == 0 && cost.month.dollars == 0 {
+            ProviderUsageEmptyState(provider: provider, snapshot: snapshot)
+                .padding(.horizontal, IslandPanelLayout.columnInset)
+        } else {
+            CostBlock(color: provider.color, cost: cost,
+                          loading: store.isLoading(provider), provider: provider.costProvider,
+                          centerWhenSingle: visibility.right == nil)
+            .help(store.localNotices[provider] ?? "Estimated API-equivalent cost from local CLI records; not a subscription charge.")
+        }
     }
 
     /// Cost-page breakdown swaps metric to follow the visible tile: when

--- a/Tests/ProviderConnectionTests.swift
+++ b/Tests/ProviderConnectionTests.swift
@@ -10,6 +10,21 @@ struct ProviderConnectionTests {
 
     @MainActor
     static func main() throws {
+        var unsubscribed = ConnectedUsage(limits: [
+            ConnectedLimit(id: "credits", label: "Credits", usedFraction: nil, resetAt: Date())
+        ], plan: " FREE ", updatedAt: Date())
+        expect(unsubscribed.hasNoActiveSubscription, "free account without a reading shows subscription state")
+        unsubscribed.limits[0] = ConnectedLimit(id: "credits", label: "Credits", usedFraction: 0, resetAt: nil)
+        expect(!unsubscribed.hasNoActiveSubscription, "real zero usage remains visible even on free plans")
+        unsubscribed.limits = []
+        unsubscribed.plan = "SuperGrok"
+        expect(!unsubscribed.hasNoActiveSubscription, "missing paid-plan data is not an inactive subscription")
+        unsubscribed.plan = nil
+        expect(!unsubscribed.hasNoActiveSubscription, "unknown plans are not treated as unsubscribed")
+        unsubscribed.plan = "free"
+        unsubscribed.needsLogin = true
+        expect(!unsubscribed.hasNoActiveSubscription, "sign-in failures take precedence over subscription state")
+        expect(!ConnectedUsage(plan: "free").hasNoActiveSubscription, "subscription state requires a successful fetch")
         let suite = "CodexIsland.ProviderTests.\(UUID().uuidString)"
         guard let defaults = UserDefaults(suiteName: suite) else { fatalError("Cannot create test defaults") }
         defer { defaults.removePersistentDomain(forName: suite) }

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -30,6 +30,14 @@ credit usage from the Grok CLI billing service. It never refreshes or writes the
 CLI's tokens. The default metric is Credits. Missing percentages remain unknown;
 a billing period alone is not interpreted as zero usage.
 
+When a connected provider reports no readings, its column shows an actionable
+empty state instead of an empty chart and reset timer. A successfully fetched
+Free plan shows “No active subscription”; paid or unknown plans show “Usage
+unavailable.” Both link to provider settings. Actual readings, including 0%,
+remain visible regardless of the plan label. The Cost page reuses the same
+subscription state when both cost windows are unavailable and contain no usage;
+existing cost records remain visible.
+
 ## Google Antigravity
 
 Sign in with the official `agy` CLI. The desktop app is not required and does


### PR DESCRIPTION
A connected Free account without usage readings previously showed an empty credits chart and reset timer. Usage now shows “No active subscription” with a provider-settings action; Cost reuses the same state when both cost windows are unavailable and contain no usage.

Real readings, including 0%, and existing cost records remain visible. Paid or unknown plans without readings show a separate unavailable state, and sign-in failures retain their connection prompt.

Validation:
- Full `scripts/run-tests.sh` suite passed on the isolated PR branch, including six subscription-state regression checks.
- Universal macOS build passed on the isolated PR branch.
- Verified the shared state on the running Usage and Cost pages during development.
