### PR TITLE
perf: improve expanded frame pacing and history rendering

### DIFF
--- a/Sources/Model/ExpandedFrameRate.swift
+++ b/Sources/Model/ExpandedFrameRate.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+// A pacing request, not a guarantee: macOS still schedules presentation.
+enum ExpandedFrameRate {
+    static func preferred(maximum: Int, lowPower: Bool) -> Int {
+        let supported = maximum > 0 ? maximum : 60
+        return min(supported, lowPower ? 30 : 120)
+    }
+}

--- a/Sources/Views/CompositedPageStrip.swift
+++ b/Sources/Views/CompositedPageStrip.swift
@@ -1,0 +1,92 @@
+import AppKit
+import QuartzCore
+import SwiftUI
+
+// Animate the hosting layer so horizontal movement does not invalidate SwiftUI layout per frame.
+struct CompositedPageStrip<Content: View>: NSViewRepresentable {
+    let pageIndex: Int
+    let feedbackOffset: CGFloat
+    let pageSize: CGSize
+    let lowPower: Bool
+    let content: Content
+
+    func makeNSView(context: Context) -> PageStripHost<Content> {
+        PageStripHost(content: content)
+    }
+
+    func updateNSView(_ view: PageStripHost<Content>, context: Context) {
+        view.update(content: content, pageIndex: pageIndex, feedbackOffset: feedbackOffset, pageSize: pageSize,
+                    lowPower: lowPower, animated: !context.transaction.disablesAnimations)
+    }
+}
+
+final class PageStripHost<Content: View>: NSView {
+    private let host: PageStripHostingView<Content>
+    private var previousPage: Int?
+    private var previousFeedback: CGFloat = 0
+    private var lowPower = false
+
+    override var isFlipped: Bool { true }
+
+    init(content: Content) {
+        host = PageStripHostingView(rootView: content)
+        super.init(frame: .zero)
+        wantsLayer = true
+        layer?.masksToBounds = true
+        host.wantsLayer = true
+        host.sizingOptions = []
+        addSubview(host)
+    }
+
+    required init?(coder: NSCoder) { nil }
+
+    func update(content: Content, pageIndex: Int, feedbackOffset: CGFloat, pageSize: CGSize,
+                lowPower: Bool, animated: Bool) {
+        let changed = previousPage != nil && (previousPage != pageIndex || previousFeedback != feedbackOffset)
+        let offset = -pageSize.width * CGFloat(pageIndex) + feedbackOffset
+        let powerChanged = self.lowPower != lowPower
+        self.lowPower = lowPower
+        let from = host.layer?.presentation()?.position.x ?? host.layer?.position.x
+        host.rootView = content
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        host.frame = CGRect(x: offset, y: 0, width: pageSize.width * 3, height: pageSize.height)
+        CATransaction.commit()
+        previousPage = pageIndex
+        previousFeedback = feedbackOffset
+
+        guard let layer = host.layer else { return }
+        let fps = Float(ExpandedFrameRate.preferred(
+            maximum: window?.screen?.maximumFramesPerSecond ?? 60, lowPower: lowPower))
+        let range = CAFrameRateRange(minimum: fps, maximum: fps, preferred: fps)
+        if (changed || powerChanged), animated, let from, from != layer.position.x {
+            let animation = CABasicAnimation(keyPath: "position.x")
+            animation.fromValue = from
+            animation.toValue = layer.position.x
+            animation.duration = 0.36
+            animation.timingFunction = CAMediaTimingFunction(controlPoints: 0.25, 0.82, 0.25, 1)
+            animation.preferredFrameRateRange = range
+            layer.add(animation, forKey: "pageSlide")
+        } else if !animated {
+            layer.removeAnimation(forKey: "pageSlide")
+        } else if powerChanged, let animation = layer.animation(forKey: "pageSlide")?.copy() as? CAAnimation {
+            animation.preferredFrameRateRange = range
+            layer.add(animation, forKey: "pageSlide")
+        }
+    }
+}
+
+private final class PageStripHostingView<Content: View>: NSHostingView<Content> {
+    override func scrollWheel(with event: NSEvent) {
+        // A nested hosting view must preserve the island's trackpad paging route.
+        var ancestor = superview
+        while let view = ancestor {
+            if let island = view as? IslandHostingView {
+                island.scrollWheel(with: event)
+                return
+            }
+            ancestor = view.superview
+        }
+        super.scrollWheel(with: event)
+    }
+}

--- a/Sources/Views/CountUpDollar.swift
+++ b/Sources/Views/CountUpDollar.swift
@@ -3,7 +3,7 @@ import SwiftUI
 /// Count-up animated dollar number — the slot-machine reveal that gives
 /// the cost screen its dopamine hit. Interpolates from `lastSeenTarget`
 /// (or 0 on first appearance) to `target` over ~0.65s using a cubic
-/// ease-out, driven by a 60Hz TimelineView.
+/// ease-out, paced for the expanded panel and Low Power Mode.
 ///
 /// Visually identical to the previous static text — same 38pt brand-color
 /// monospace digits with the dual-shadow glow whose intensity is locked
@@ -16,19 +16,19 @@ struct CountUpDollar: View {
 
     private static let duration: TimeInterval = 0.65
 
+    @ObservedObject private var lowPower = LowPowerModeStore.shared
+
     @State private var animationStart: Date = Date()
     @State private var startValue: Double = 0
     @State private var lastSeenTarget: Double = 0
-    /// Gates the 60Hz TimelineView. Once the count settles we render a
-    /// plain `Text` so SwiftUI stops re-evaluating this body 60 times per
-    /// second. Four cost cells each running idle TimelineViews adds up.
+    /// Stop scheduling frames once the counter settles.
     @State private var animating: Bool = false
     @State private var animationToken: UUID = UUID()
 
     var body: some View {
         Group {
             if animating {
-                TimelineView(.animation(minimumInterval: 1.0 / 60.0)) { context in
+                TimelineView(.animation(minimumInterval: frameInterval)) { context in
                     let elapsed = context.date.timeIntervalSince(animationStart)
                     digits(formatted(interpolatedValue(elapsed: elapsed)))
                 }
@@ -53,6 +53,13 @@ struct CountUpDollar: View {
             lastSeenTarget = target
             startAnimation()
         }
+    }
+
+    private var frameInterval: TimeInterval {
+        1.0 / Double(ExpandedFrameRate.preferred(
+            maximum: DisplayInfo.currentTarget()?.screen.maximumFramesPerSecond ?? 60,
+            lowPower: lowPower.effectiveEnabled
+        ))
     }
 
     private func displayedValue() -> Double {

--- a/Sources/Views/OverviewView.swift
+++ b/Sources/Views/OverviewView.swift
@@ -1,20 +1,29 @@
 import SwiftUI
 
+struct OverviewView: View {
+    let model: IslandModel
+    @ObservedObject private var costStore = CostStore.shared
+
+    var body: some View {
+        OverviewContent(
+            model: model,
+            allDays: OverviewContent.joinDays(buckets: Dictionary(uniqueKeysWithValues:
+                IslandProvider.allCases.map { ($0, costStore.cost(for: $0).dailyTokens) }
+            )),
+            loading: costStore.loading
+        )
+    }
+}
+
 /// Minimal contribution-style view. Powered by the same local log scan as
 /// the cost page, but framed as usage history: cell intensity is token
 /// volume, and cell hue follows the dominant provider for that day.
-struct OverviewView: View {
-    @ObservedObject var model: IslandModel
-    @ObservedObject private var screenPref = ScreenPref.shared
-    @ObservedObject private var costStore = CostStore.shared
+private struct OverviewContent: View {
+    let model: IslandModel
+    let allDays: [OverviewDay]
+    let loading: Bool
     @State private var selectedDate: Date?
     @State private var selectedProvider: IslandProvider?
-
-    private var allDays: [OverviewDay] {
-        Self.joinDays(buckets: Dictionary(uniqueKeysWithValues:
-            IslandProvider.allCases.map { ($0, costStore.cost(for: $0).dailyTokens) }
-        ))
-    }
 
     private var days: [OverviewDay] {
         guard let selectedProvider else { return allDays }
@@ -76,15 +85,15 @@ struct OverviewView: View {
         .padding(.bottom, 6)
         .animation(.detailExpand, value: selectedDate)
         .onAppear {
-            model.setOverviewDayDetailVisible(screenPref.screen == .overview && selectedDate != nil)
+            model.setOverviewDayDetailVisible(ScreenPref.shared.screen == .overview && selectedDate != nil)
         }
         .onDisappear {
             model.setOverviewDayDetailVisible(false)
         }
         .onChange(of: selectedDate) { _ in
-            model.setOverviewDayDetailVisible(screenPref.screen == .overview && selectedDate != nil)
+            model.setOverviewDayDetailVisible(ScreenPref.shared.screen == .overview && selectedDate != nil)
         }
-        .onChange(of: screenPref.screen) { screen in
+        .onReceive(ScreenPref.shared.$screen.dropFirst()) { screen in
             guard screen != .overview else { return }
             if selectedDate != nil {
                 var transaction = Transaction()
@@ -119,7 +128,7 @@ struct OverviewView: View {
                 Text(summarySubline)
                     .font(Typography.label)
                     .foregroundStyle(.white.opacity(0.50))
-                if costStore.loading {
+                if loading {
                     Text(L10n.tr("Syncing"))
                         .font(Typography.caption)
                         .foregroundStyle(.white.opacity(0.36))
@@ -157,7 +166,7 @@ struct OverviewView: View {
         }.joined(separator: ", ")
     }
 
-    private static func joinDays(buckets: [IslandProvider: [DailyTokenBucket]]) -> [OverviewDay] {
+    static func joinDays(buckets: [IslandProvider: [DailyTokenBucket]]) -> [OverviewDay] {
         var cal = Calendar(identifier: .gregorian)
         cal.timeZone = .current
         let today = cal.startOfDay(for: Date())
@@ -295,7 +304,7 @@ private struct ContributionGrid: View {
         .frame(maxWidth: .infinity, minHeight: gridHeight + 19, maxHeight: gridHeight + 19, alignment: .leading)
         .clipped()
         .accessibilityElement(children: .contain)
-        .accessibilityLabel(L10n.tr("Daily token usage in %@", OverviewView.currentYearString))
+        .accessibilityLabel(L10n.tr("Daily token usage in %@", OverviewContent.currentYearString))
     }
 
     private var weeks: [ContributionWeek] {
@@ -506,12 +515,10 @@ private struct ContributionCell: View {
             provider.color.opacity(opacity)
                 .overlay(alignment: .bottom) {
                     if day.usage.count > 1 {
-                        GeometryReader { geo in
-                            HStack(spacing: 0) {
-                                ForEach(day.usage) { item in
-                                    item.provider.color.opacity(max(0.35, opacity))
-                                        .frame(width: geo.size.width * CGFloat(Double(item.tokens) / Double(day.totalTokens)))
-                                }
+                        HStack(spacing: 0) {
+                            ForEach(day.usage) { item in
+                                item.provider.color.opacity(max(0.35, opacity))
+                                    .frame(width: cellSize * CGFloat(Double(item.tokens) / Double(day.totalTokens)))
                             }
                         }
                         .frame(height: max(2, cellSize * 0.20))
@@ -535,7 +542,7 @@ private struct ContributionCell: View {
         L10n.tr(
             "%@: %@, %@",
             Self.dayFormatter.string(from: day.date),
-            OverviewView.formatTokensSpoken(day.totalTokens),
+            OverviewContent.formatTokensSpoken(day.totalTokens),
             dominanceLabel
         ) + (day.usage.isEmpty ? "" : "\n" + day.usage.map { item in
             let percent = Double(item.tokens) / Double(day.totalTokens) * 100
@@ -662,7 +669,7 @@ private struct DayDetailStrip: View {
                 .foregroundStyle(color.opacity(dimmed ? 0.70 : 0.82))
                 .lineLimit(1)
 
-            Text(OverviewView.formatExactTokens(value))
+            Text(OverviewContent.formatExactTokens(value))
                 .font(Typography.bodyNumber)
                 .foregroundStyle(.white.opacity(0.76))
                 .lineLimit(1)
@@ -670,12 +677,12 @@ private struct DayDetailStrip: View {
                 .allowsTightening(true)
         }
         .frame(width: 82, alignment: .trailing)
-        .help(L10n.tr("%@: %@ tokens", spokenLabel ?? label, OverviewView.formatExactTokens(value)))
+        .help(L10n.tr("%@: %@ tokens", spokenLabel ?? label, OverviewContent.formatExactTokens(value)))
     }
 
     private var accessibilityLabel: String {
-        "\(Self.detailFormatter.string(from: day.date)), all tokens. Total \(OverviewView.formatTokensSpoken(day.totalTokens)), " + day.usage.map {
-            "\($0.provider.name) \(OverviewView.formatTokensSpoken($0.tokens))"
+        "\(Self.detailFormatter.string(from: day.date)), all tokens. Total \(OverviewContent.formatTokensSpoken(day.totalTokens)), " + day.usage.map {
+            "\($0.provider.name) \(OverviewContent.formatTokensSpoken($0.tokens))"
         }.joined(separator: ", ")
     }
 

--- a/Sources/Views/PagedContent.swift
+++ b/Sources/Views/PagedContent.swift
@@ -1,8 +1,9 @@
 import SwiftUI
+import AppKit
 
 /// Three-page horizontal carousel: live usage (page 0), cost (page 1), and
 /// history overview (page 2). Each page renders at the full content width;
-/// the HStack slides via `.offset` based on
+/// the hosting layer slides in Core Animation based on
 /// `ScreenPref.screen`. Horizontal movement gets its own drawer-style curve
 /// so page navigation does not inherit the island shape's spring bounce.
 ///
@@ -16,27 +17,40 @@ import SwiftUI
 struct PagedContent: View {
     @ObservedObject var model: IslandModel
     @ObservedObject private var screenPref = ScreenPref.shared
+    @ObservedObject private var lowPower = LowPowerModeStore.shared
     @State private var peekOffset: CGFloat = 0
     @State private var bumpOffset: CGFloat = 0
 
     var body: some View {
         GeometryReader { geo in
             let pageWidth = geo.size.width
-            HStack(alignment: .top, spacing: 0) {
-                UsageView()
-                    .frame(width: pageWidth, height: geo.size.height, alignment: .top)
-                    .accessibilityHidden(screenPref.screen != .usage)
-                CostView()
-                    .frame(width: pageWidth, height: geo.size.height, alignment: .top)
-                    .accessibilityHidden(screenPref.screen != .cost)
-                OverviewView(model: model)
-                    .frame(width: pageWidth, height: geo.size.height, alignment: .top)
-                    .accessibilityHidden(screenPref.screen != .overview)
-            }
-            .frame(width: pageWidth, height: geo.size.height, alignment: .topLeading)
-            .offset(x: (-pageWidth * CGFloat(screenPref.screen.pageIndex)) + peekOffset + bumpOffset)
-            .animation(.pageSwipe, value: screenPref.screen)
-            .clipped()
+            CompositedPageStrip(
+                pageIndex: screenPref.screen.pageIndex,
+                feedbackOffset: peekOffset + bumpOffset,
+                pageSize: geo.size,
+                lowPower: lowPower.effectiveEnabled,
+                content: HStack(alignment: .top, spacing: 0) {
+                    UsageView()
+                        .frame(width: pageWidth, height: geo.size.height, alignment: .top)
+                        .accessibilityHidden(screenPref.screen != .usage)
+                    CostView()
+                        .frame(width: pageWidth, height: geo.size.height, alignment: .top)
+                        .accessibilityHidden(screenPref.screen != .cost)
+                    OverviewView(model: model)
+                        .frame(width: pageWidth, height: geo.size.height, alignment: .top)
+                        .accessibilityHidden(screenPref.screen != .overview)
+                }
+                .onTapGesture {
+                    guard NSEvent.modifierFlags.contains(.command) else { return }
+                    switch screenPref.screen {
+                    case .usage: StylePref.shared.cycle()
+                    case .cost: CostStylePref.shared.cycle()
+                    case .overview: break
+                    }
+                }
+                .frame(width: pageWidth * 3, height: geo.size.height, alignment: .topLeading)
+            )
+            .frame(width: pageWidth, height: geo.size.height)
             .onAppear {
                 // Discoverability cue, not decorative motion — fires even
                 // when @Environment(\.accessibilityReduceMotion) is on,

--- a/Tests/PageStripTests.swift
+++ b/Tests/PageStripTests.swift
@@ -1,0 +1,37 @@
+import AppKit
+import QuartzCore
+import SwiftUI
+
+@main
+@MainActor
+struct PageStripTests {
+    static func main() {
+        _ = NSApplication.shared
+        for (maximum, lowPower, expected) in [(120, false, 120), (60, false, 60), (120, true, 30), (60, true, 30), (24, true, 24), (144, false, 120), (0, false, 60)] {
+            precondition(ExpandedFrameRate.preferred(maximum: maximum, lowPower: lowPower) == expected)
+        }
+        let view = PageStripHost(content: Color.black)
+        let size = CGSize(width: 800, height: 180)
+        view.update(content: Color.black, pageIndex: 0, feedbackOffset: 0,
+                    pageSize: size, lowPower: false, animated: true)
+        guard let host = view.subviews.first, let layer = host.layer else { fatalError("Missing hosting layer") }
+        precondition(layer.animation(forKey: "pageSlide") == nil)
+        view.update(content: Color.black, pageIndex: 1, feedbackOffset: 0,
+                    pageSize: size, lowPower: false, animated: true)
+        guard let slide = layer.animation(forKey: "pageSlide") as? CABasicAnimation else { fatalError("Missing page animation") }
+        precondition(slide.preferredFrameRateRange.preferred == 60)
+        precondition(host.frame.origin.x == -800)
+        view.update(content: Color.black, pageIndex: 1, feedbackOffset: 0,
+                    pageSize: size, lowPower: true, animated: true)
+        precondition(layer.animation(forKey: "pageSlide")?.preferredFrameRateRange.maximum == 30)
+        view.update(content: Color.black, pageIndex: 2, feedbackOffset: 0,
+                    pageSize: size, lowPower: true, animated: true)
+        precondition(layer.animation(forKey: "pageSlide")?.preferredFrameRateRange.maximum == 30)
+        precondition(host.frame.origin.x == -1600)
+        view.update(content: Color.black, pageIndex: 0, feedbackOffset: 0,
+                    pageSize: size, lowPower: false, animated: false)
+        precondition(layer.animation(forKey: "pageSlide") == nil)
+        precondition(host.frame.origin.x == 0)
+        print("PASS refresh policy, initial placement, page animation, low-power cap, and nonanimated placement")
+    }
+}

--- a/Tests/RenderingBenchmark.swift
+++ b/Tests/RenderingBenchmark.swift
@@ -1,0 +1,71 @@
+import AppKit
+import SwiftUI
+
+// Run only through scripts/benchmark-rendering.sh: demo data and a separate
+// bundle isolate the benchmark from credentials, polling, and app preferences.
+@main
+@MainActor
+struct RenderingBenchmark {
+    static func main() {
+        let app = NSApplication.shared
+        app.setActivationPolicy(.accessory)
+        ScreenPref.shared.screen = .usage
+        ScreenPref.shared.hasSwipedScreen = true
+        UsageStore.shared.refresh()
+        StylePref.shared.style = .ring
+        CostStylePref.shared.style = .dollar
+        let model = IslandModel(notch: NotchInfo(width: 180, height: 32, hasNotch: false))
+        model.setState(.expanded)
+        let window = NSWindow(contentRect: NSRect(x: 100, y: 200, width: 840, height: 400),
+                              styleMask: [.borderless], backing: .buffered, defer: false)
+        window.contentView = NSHostingView(rootView: BenchmarkPanel(model: model))
+        window.orderFrontRegardless()
+        if ProcessInfo.processInfo.environment["RENDER_BENCHMARK_PREVIEW"] == "1" {
+            model.showScreen(.overview)
+            app.run()
+            return
+        }
+        var intervals: [Double] = []
+        var previous = ProcessInfo.processInfo.systemUptime
+        let start = previous
+        var step = -1
+        let timer = Timer(timeInterval: 1.0 / 120, repeats: true) { _ in
+            MainActor.assumeIsolated {
+                let now = ProcessInfo.processInfo.systemUptime
+                let elapsed = now - start
+                if elapsed > 2 { intervals.append((now - previous) * 1000) }
+                previous = now
+                let nextStep = Int(elapsed / 0.7)
+                if nextStep != step {
+                    step = nextStep
+                    model.showScreen(ScreenPref.Screen.allCases[nextStep % 3])
+                    StylePref.shared.cycle()
+                    CostStylePref.shared.cycle()
+                }
+                if elapsed >= 12 {
+                    intervals.sort()
+                    let p95 = intervals[Int(Double(intervals.count - 1) * 0.95)]
+                    let p99 = intervals[Int(Double(intervals.count - 1) * 0.99)]
+                    print(String(format: "main-loop samples=%d p95=%.2fms p99=%.2fms max=%.2fms gaps>25ms=%d",
+                                 intervals.count, p95, p99, intervals.last ?? 0,
+                                 intervals.filter { $0 > 25 }.count))
+                    exit(EXIT_SUCCESS)
+                }
+            }
+        }
+        RunLoop.main.add(timer, forMode: .common)
+        app.run()
+        timer.invalidate()
+        window.orderOut(nil)
+    }
+}
+
+private struct BenchmarkPanel: View {
+    @ObservedObject var model: IslandModel
+    var body: some View {
+        ExpandedView(model: model)
+            .frame(width: model.size.width, height: model.size.height)
+            .background(.black)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+    }
+}

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -1,0 +1,71 @@
+# Rendering performance
+
+## Keep history preparation outside interaction updates
+
+`OverviewView` observes cost data and constructs the current-year snapshot.
+`OverviewContent` receives that snapshot as a value and owns provider/day
+selection. Its model reference is used for actions, not observation: resizing
+the island should not invalidate the history summary. Page changes are received
+as events to clear day details without rebuilding the grid when no day is selected.
+
+Do not put the calendar join back in a computed property read by each summary,
+accessibility label, and grid. That repeats date arithmetic and provider aggregation
+several times within a single view update. Cost publications still refresh the
+snapshot, including new dates and provider records.
+
+Contribution cells have a fixed width. Their provider segments use that width
+directly, avoiding a geometry reader and an extra layout pass for each active day.
+Keep per-day hover, selection, help text, and accessibility intact when changing
+how the grid is drawn.
+
+## Reproduce transition stalls
+
+Run `scripts/benchmark-rendering.sh` from a logged-in graphical macOS session.
+It builds a separate demo app, mounts the real `ExpandedView`, and repeatedly
+changes pages and both chart styles for twelve seconds. The first two seconds
+are warm-up. It does not start application polling, scan session logs, or start
+the updater; preferences belong to a separate benchmark bundle.
+
+The output reports main-run-loop timer intervals: p95, p99, maximum, and the
+number of gaps over 25 ms. These are a signal for main-thread stalls, **not
+measured display FPS or GPU presentation times**. The timer requests 120 Hz;
+macOS scheduling and other running apps affect the results. Compare repeated
+runs on the same machine with the same workload, and do not run other builds
+or tests during the measurement.
+
+For before/after comparison of history changes, set
+`RENDER_BENCHMARK_OVERVIEW_SOURCE` to a saved copy of `OverviewView.swift`.
+Both versions then use the same harness and compiler options. Use
+`RENDER_BENCHMARK_PREVIEW=1 scripts/benchmark-rendering.sh` to leave the demo
+window open for manual checks; stop the process afterward.
+
+The benchmark covers content transitions, not the outer island glow, material
+halo, mouse tracking, or Settings. Profile those separately before attributing
+cost to them. Remaining candidates include the continuously shaded glow,
+blurred chart transitions, and keeping offscreen carousel pages mounted.
+Any page-unmounting optimization must preserve provider selection, outgoing
+transition content, rapid navigation, and the first-use carousel cue.
+
+## Expanded panel frame pacing
+
+The carousel uses `CompositedPageStrip`: one native hosting layer moves with
+Core Animation while its SwiftUI page layout stays in place. The animation
+requests the window's display maximum, up to 120 FPS; effective Low Power Mode
+(app preference or system mode) requests a maximum of 30 FPS. The rate is read
+from the actual window screen on each movement. Interrupted navigation starts
+from the presentation layer's current position. Geometry-only changes do not
+start new page animations.
+
+The cost count-up timeline uses the same 120/60/30 policy and stops when settled.
+This policy is scoped to expanded content. The compact/peek glow schedule is
+unchanged, and no persistent display-link loop is added to boost idle refresh.
+Command-click chart cycling is handled inside the nested hosting view.
+
+Core Animation frame-rate ranges are scheduling requests, not guarantees of
+physical presentation. Other SwiftUI animations (such as chart-style fades)
+remain system-paced; this is not a global rendering throttle for all UI.
+
+Run `scripts/benchmark-rendering.sh Tests/PageStripTests.swift` to verify rate
+selection, initial placement, page movement, low-power changes, and disabled
+animation placement. The navigation benchmark now seeds usage demo data too,
+so results from before that change are not a like-for-like chart workload.

--- a/scripts/benchmark-rendering.sh
+++ b/scripts/benchmark-rendering.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+./scripts/setup-sparkle.sh
+OUT_DIR=$(mktemp -d "${TMPDIR:-/tmp}/codexisland-render-benchmark.XXXXXX")
+trap 'rm -rf "$OUT_DIR"' EXIT
+APP="$OUT_DIR/RenderingBenchmark.app"
+mkdir -p "$APP/Contents/MacOS" "$APP/Contents/Resources"
+cp Resources/*_logo.* "$APP/Contents/Resources/"
+cat > "$APP/Contents/Info.plist" <<'PLIST'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+<key>CFBundleIdentifier</key><string>dev.codexisland.RenderingBenchmark</string>
+<key>CFBundleExecutable</key><string>RenderingBenchmark</string>
+<key>LSUIElement</key><true/>
+</dict></plist>
+PLIST
+swiftc -O -whole-module-optimization -target "$(uname -m)-apple-macos13.0" -parse-as-library -F Vendor/Sparkle \
+  -framework SwiftUI -framework AppKit -framework ServiceManagement -framework Sparkle \
+  -Xlinker -rpath -Xlinker "$PWD/Vendor/Sparkle" \
+  -o "$APP/Contents/MacOS/RenderingBenchmark" \
+  $(find Sources -name '*.swift' ! -name 'App.swift' ! -name 'OverviewView.swift' | sort) \
+  "${RENDER_BENCHMARK_OVERVIEW_SOURCE:-Sources/Views/OverviewView.swift}" "${1:-Tests/RenderingBenchmark.swift}"
+CODEXISLAND_DEMO=1 "$APP/Contents/MacOS/RenderingBenchmark"


### PR DESCRIPTION
Page changes currently animate a SwiftUI offset while the mounted history grid repeatedly prepares calendar data. Move the expanded carousel through a Core Animation hosting layer and prepare history data once at the cost-observation boundary to reduce work during interaction.

The carousel requests the current display's refresh rate up to 120 FPS, or at most 30 FPS under app/system Low Power Mode. Cost count-up numbers follow the same policy. Preserve notch-mode rendering, page state, scroll routing, command-click cycling, and interrupted navigation. Remove fixed-width history cells' redundant geometry readers.

Frame-rate ranges are scheduling requests, not a guarantee of sustained presentation FPS. Other SwiftUI effects, including chart-style fades, remain system-paced; this is not a global 30 FPS throttle.

Validation:
- Universal arm64/x86_64 build.
- Existing regression suite.
- Native hosting-layer tests for frame-rate selection, first placement, page movement, power-mode changes during animation, and disabled animation.
- Demo inspection of page alignment, history filtering, and selected-day details. Physical-trackpad cadence still needs device review; timer benchmarks do not measure presentation FPS.

Adds a reproducible native demo benchmark and contributor performance notes.

Stacked on #90 (`codex/calendar-provider-history`) so the diff excludes its calendar feature changes. Merge #90 first, then retarget this PR to `main`.
