### PR TITLE
fix: size expanded carousel to selected page content

### DIFF
--- a/Sources/Model/IslandModel.swift
+++ b/Sources/Model/IslandModel.swift
@@ -38,26 +38,14 @@ final class IslandModel: ObservableObject {
     /// Visible expanded panel width.
     private let expandedWidth: CGFloat = 800
 
-    /// Visible expanded panel content height. The shape sits flush with the
-    /// top of the screen, so we add notch.height of "filler" so visible
-    /// content sits BELOW the notch line.
-    private let expandedBaseContentHeight: CGFloat = 188
-
-    /// Overview needs room for the full-year contribution grid. Keep this
-    /// page-specific so usage/cost preserve their compact original height.
-    private let overviewBaseContentHeight: CGFloat = 244
-
-    /// Extra room for the overview's selected-day details. Kept below the
-    /// fixed host window height on standard notch/menu-bar sizes.
-    private let overviewDetailContentHeight: CGFloat = 52
+    // Mirrors measured content for hit testing; it does not constrain expanded layout.
+    private var expandedHeight: CGFloat = 0
 
     /// Detection-pure notch from `NotchInfo.detect`. Kept separate from
     /// `notch` (which has the user's spacing override applied) so
     /// `updateNotch`'s diff guard isn't confused by override-induced
     /// width changes that originate from the store, not the screen.
     private var rawNotch: NotchInfo
-    private var activeScreen = ScreenPref.shared.screen
-    private var overviewDayDetailVisible = false
 
     private var subs: Set<AnyCancellable> = []
 
@@ -66,7 +54,6 @@ final class IslandModel: ObservableObject {
         self.notch = Self.applyOverride(to: notch, width: IslandSpacingStore.shared.width)
         recomputeSize()
         subscribeToSpacingStore()
-        subscribeToScreenPref()
     }
 
     func setState(_ new: State) {
@@ -84,12 +71,10 @@ final class IslandModel: ObservableObject {
         recomputeSize()
     }
 
-    func setOverviewDayDetailVisible(_ visible: Bool) {
-        guard overviewDayDetailVisible != visible else { return }
-        overviewDayDetailVisible = visible
-        withAnimation(visible ? .detailExpand : .detailCollapse) {
-            recomputeSize()
-        }
+    func updateExpandedHeight(_ height: CGFloat) {
+        guard height > 0, abs(expandedHeight - height) > 0.5 else { return }
+        expandedHeight = height
+        if state == .expanded { recomputeSize() }
     }
 
     func advanceScreen() {
@@ -115,18 +100,9 @@ final class IslandModel: ObservableObject {
     func showScreen(_ screen: ScreenPref.Screen) {
         guard ScreenPref.shared.screen != screen else { return }
 
-        if shouldCollapseDetailBeforeShowing(screen) {
-            withAnimation(.pageSwipe) {
-                overviewDayDetailVisible = false
-                activeScreen = screen
-                ScreenPref.shared.screen = screen
-                recomputeSize()
-            }
-            return
+        withAnimation(.pageSwipe) {
+            ScreenPref.shared.screen = screen
         }
-
-        activeScreen = screen
-        ScreenPref.shared.screen = screen
     }
 
     /// Substitutes the user's chosen non-notch width for the detected
@@ -162,23 +138,6 @@ final class IslandModel: ObservableObject {
             .store(in: &subs)
     }
 
-    private func subscribeToScreenPref() {
-        ScreenPref.shared.$screen
-            .dropFirst()
-            .sink { [weak self] screen in
-                guard let self, self.state == .expanded else { return }
-                let wasShowingOverviewDetail = self.overviewDayDetailVisible
-                self.activeScreen = screen
-                if screen != .overview {
-                    self.overviewDayDetailVisible = false
-                }
-                withAnimation(wasShowingOverviewDetail ? .pageSwipe : .detailCollapse) {
-                    self.recomputeSize()
-                }
-            }
-            .store(in: &subs)
-    }
-
     private func recomputeSize() {
         switch state {
         case .compact:
@@ -194,24 +153,8 @@ final class IslandModel: ObservableObject {
         case .expanded:
             size = CGSize(
                 width: expandedWidth,
-                height: expandedContentHeight + notch.height
+                height: max(notch.height, expandedHeight)
             )
         }
-    }
-
-    private var expandedContentHeight: CGFloat {
-        let baseHeight = activeScreen == .overview
-            ? overviewBaseContentHeight
-            : expandedBaseContentHeight
-        let detailHeight = activeScreen == .overview && overviewDayDetailVisible
-            ? overviewDetailContentHeight
-            : 0
-        return baseHeight + detailHeight
-    }
-
-    private func shouldCollapseDetailBeforeShowing(_ screen: ScreenPref.Screen) -> Bool {
-        activeScreen == .overview
-            && screen != .overview
-            && overviewDayDetailVisible
     }
 }

--- a/Sources/Views/ContentSizedPageLayout.swift
+++ b/Sources/Views/ContentSizedPageLayout.swift
@@ -1,0 +1,34 @@
+import SwiftUI
+
+struct ContentSizedPageLayout: Layout {
+    let selectedPage: Int
+    var position: CGFloat
+    var feedbackOffset: CGFloat = 0
+
+    var animatableData: AnimatablePair<CGFloat, CGFloat> {
+        get { AnimatablePair(position, feedbackOffset) }
+        set {
+            position = newValue.first
+            feedbackOffset = newValue.second
+        }
+    }
+
+    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
+        guard subviews.indices.contains(selectedPage) else { return .zero }
+        let width = proposal.width ?? 800
+        // The target page owns height even while horizontal position is between pages.
+        let content = subviews[selectedPage].sizeThatFits(ProposedViewSize(width: width, height: nil))
+        return CGSize(width: width, height: content.height)
+    }
+
+    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {
+        for index in subviews.indices {
+            subviews[index].place(
+                at: CGPoint(x: bounds.minX + (CGFloat(index) - position) * bounds.width + feedbackOffset,
+                            y: bounds.minY),
+                anchor: .topLeading,
+                proposal: ProposedViewSize(width: bounds.width, height: nil)
+            )
+        }
+    }
+}

--- a/Sources/Views/ExpandedView.swift
+++ b/Sources/Views/ExpandedView.swift
@@ -17,6 +17,7 @@ struct ExpandedView: View {
             PagedContent(model: model)
             PanelFooter(model: model)
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .frame(maxWidth: .infinity)
+        .fixedSize(horizontal: false, vertical: true)
     }
 }

--- a/Sources/Views/IslandRootView.swift
+++ b/Sources/Views/IslandRootView.swift
@@ -22,11 +22,6 @@ struct IslandRootView: View {
             // with the spring for main-thread budget and showing up as
             // hover-spring jank.
             ZStack {
-                GlowLayer(
-                    isExpanded: model.state == .expanded,
-                    hovering: hovering
-                )
-
                 if model.state == .expanded {
                     ExpandedView(model: model)
                         .opacity(contentVisible ? 1 : 0)
@@ -36,10 +31,20 @@ struct IslandRootView: View {
                         // content fully fades before the shape shrinks.
                         .offset(y: contentVisible ? 0 : -8)
                         .allowsHitTesting(contentVisible)
-                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                        .background {
+                            GeometryReader { geometry in
+                                Color.clear.preference(key: ExpandedHeightKey.self, value: geometry.size.height)
+                            }
+                        }
+                } else {
+                    Color.clear.frame(height: model.notch.height)
                 }
             }
-            .frame(width: model.size.width, height: model.size.height)
+            .frame(width: model.size.width)
+            .onPreferenceChange(ExpandedHeightKey.self) { model.updateExpandedHeight($0) }
+            .background {
+                GlowLayer(isExpanded: model.state == .expanded, hovering: hovering)
+            }
             .background {
                     // Frosted halo. ultraThinMaterial is a backdrop blur of
                     // whatever desktop content is behind the window. Lives
@@ -563,5 +568,12 @@ private struct LoadingSweep: View {
                     .blur(radius: 3)
             }
         }
+    }
+}
+
+private struct ExpandedHeightKey: PreferenceKey {
+    static var defaultValue: CGFloat = 0
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = max(value, nextValue())
     }
 }

--- a/Sources/Views/OverviewView.swift
+++ b/Sources/Views/OverviewView.swift
@@ -1,12 +1,10 @@
 import SwiftUI
 
 struct OverviewView: View {
-    let model: IslandModel
     @ObservedObject private var costStore = CostStore.shared
 
     var body: some View {
         OverviewContent(
-            model: model,
             allDays: OverviewContent.joinDays(buckets: Dictionary(uniqueKeysWithValues:
                 IslandProvider.allCases.map { ($0, costStore.cost(for: $0).dailyTokens) }
             )),
@@ -19,7 +17,6 @@ struct OverviewView: View {
 /// the cost page, but framed as usage history: cell intensity is token
 /// volume, and cell hue follows the dominant provider for that day.
 private struct OverviewContent: View {
-    let model: IslandModel
     let allDays: [OverviewDay]
     let loading: Bool
     @State private var selectedDate: Date?
@@ -84,15 +81,6 @@ private struct OverviewContent: View {
         .padding(.top, 4)
         .padding(.bottom, 6)
         .animation(.detailExpand, value: selectedDate)
-        .onAppear {
-            model.setOverviewDayDetailVisible(ScreenPref.shared.screen == .overview && selectedDate != nil)
-        }
-        .onDisappear {
-            model.setOverviewDayDetailVisible(false)
-        }
-        .onChange(of: selectedDate) { _ in
-            model.setOverviewDayDetailVisible(ScreenPref.shared.screen == .overview && selectedDate != nil)
-        }
         .onReceive(ScreenPref.shared.$screen.dropFirst()) { screen in
             guard screen != .overview else { return }
             if selectedDate != nil {
@@ -102,7 +90,6 @@ private struct OverviewContent: View {
                     selectedDate = nil
                 }
             }
-            model.setOverviewDayDetailVisible(false)
         }
     }
 

--- a/Sources/Views/PagedContent.swift
+++ b/Sources/Views/PagedContent.swift
@@ -1,9 +1,8 @@
 import SwiftUI
-import AppKit
 
 /// Three-page horizontal carousel: live usage (page 0), cost (page 1), and
 /// history overview (page 2). Each page renders at the full content width;
-/// the hosting layer slides in Core Animation based on
+/// the layout slides based on
 /// `ScreenPref.screen`. Horizontal movement gets its own drawer-style curve
 /// so page navigation does not inherit the island shape's spring bounce.
 ///
@@ -17,74 +16,56 @@ import AppKit
 struct PagedContent: View {
     @ObservedObject var model: IslandModel
     @ObservedObject private var screenPref = ScreenPref.shared
-    @ObservedObject private var lowPower = LowPowerModeStore.shared
     @State private var peekOffset: CGFloat = 0
     @State private var bumpOffset: CGFloat = 0
 
     var body: some View {
-        GeometryReader { geo in
-            let pageWidth = geo.size.width
-            CompositedPageStrip(
-                pageIndex: screenPref.screen.pageIndex,
-                feedbackOffset: peekOffset + bumpOffset,
-                pageSize: geo.size,
-                lowPower: lowPower.effectiveEnabled,
-                content: HStack(alignment: .top, spacing: 0) {
-                    UsageView()
-                        .frame(width: pageWidth, height: geo.size.height, alignment: .top)
-                        .accessibilityHidden(screenPref.screen != .usage)
-                    CostView()
-                        .frame(width: pageWidth, height: geo.size.height, alignment: .top)
-                        .accessibilityHidden(screenPref.screen != .cost)
-                    OverviewView(model: model)
-                        .frame(width: pageWidth, height: geo.size.height, alignment: .top)
-                        .accessibilityHidden(screenPref.screen != .overview)
-                }
-                .onTapGesture {
-                    guard NSEvent.modifierFlags.contains(.command) else { return }
-                    switch screenPref.screen {
-                    case .usage: StylePref.shared.cycle()
-                    case .cost: CostStylePref.shared.cycle()
-                    case .overview: break
-                    }
-                }
-                .frame(width: pageWidth * 3, height: geo.size.height, alignment: .topLeading)
-            )
-            .frame(width: pageWidth, height: geo.size.height)
-            .onAppear {
-                // Discoverability cue, not decorative motion — fires even
-                // when @Environment(\.accessibilityReduceMotion) is on,
-                // because without it reduce-motion users have no path to
-                // learn the second screen exists. The motion is brief
-                // (~1s total) and slow-eased.
-                guard !screenPref.hasSwipedScreen,
-                      screenPref.screen == .usage
-                else { return }
-                schedulePeek()
+        ContentSizedPageLayout(selectedPage: screenPref.screen.pageIndex,
+                               position: CGFloat(screenPref.screen.pageIndex),
+                               feedbackOffset: peekOffset + bumpOffset) {
+            UsageView()
+                .padding(.vertical, 24)
+                .accessibilityHidden(screenPref.screen != .usage)
+            CostView()
+                .padding(.vertical, 24)
+                .accessibilityHidden(screenPref.screen != .cost)
+            OverviewView()
+                .accessibilityHidden(screenPref.screen != .overview)
+        }
+        .clipped()
+        .onAppear {
+            // Discoverability cue, not decorative motion — fires even
+            // when @Environment(\.accessibilityReduceMotion) is on,
+            // because without it reduce-motion users have no path to
+            // learn the second screen exists. The motion is brief
+            // (~1s total) and slow-eased.
+            guard !screenPref.hasSwipedScreen,
+                  screenPref.screen == .usage
+            else { return }
+            schedulePeek()
+        }
+        .onChange(of: screenPref.hasSwipedScreen) { swiped in
+            // User swiped mid-peek: collapse the peek smoothly so the
+            // composite offset doesn't jump when the real screen
+            // transition fires alongside it.
+            if swiped, peekOffset != 0 {
+                withAnimation(.pageSwipe) { peekOffset = 0 }
             }
-            .onChange(of: screenPref.hasSwipedScreen) { swiped in
-                // User swiped mid-peek: collapse the peek smoothly so the
-                // composite offset doesn't jump when the real screen
-                // transition fires alongside it.
-                if swiped, peekOffset != 0 {
-                    withAnimation(.pageSwipe) { peekOffset = 0 }
-                }
+        }
+        .onChange(of: model.edgeBump) { bump in
+            // Rubber-band at the carousel ends: an over-swipe nudges
+            // the row 12pt toward the attempted direction and springs
+            // back, so the dead-end gesture reads as "you're at the
+            // edge" instead of a dropped input. The bumpOffset == 0
+            // guard swallows Shift+wheel tick spam while a bump is
+            // already in flight.
+            guard let bump, bumpOffset == 0 else { return }
+            withAnimation(.easeOut(duration: 0.10)) {
+                bumpOffset = bump.direction > 0 ? -12 : 12
             }
-            .onChange(of: model.edgeBump) { bump in
-                // Rubber-band at the carousel ends: an over-swipe nudges
-                // the row 12pt toward the attempted direction and springs
-                // back, so the dead-end gesture reads as "you're at the
-                // edge" instead of a dropped input. The bumpOffset == 0
-                // guard swallows Shift+wheel tick spam while a bump is
-                // already in flight.
-                guard let bump, bumpOffset == 0 else { return }
-                withAnimation(.easeOut(duration: 0.10)) {
-                    bumpOffset = bump.direction > 0 ? -12 : 12
-                }
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.10) {
-                    withAnimation(.spring(response: 0.32, dampingFraction: 0.62)) {
-                        bumpOffset = 0
-                    }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.10) {
+                withAnimation(.spring(response: 0.32, dampingFraction: 0.62)) {
+                    bumpOffset = 0
                 }
             }
         }

--- a/Tests/PageHeightTests.swift
+++ b/Tests/PageHeightTests.swift
@@ -1,0 +1,55 @@
+import AppKit
+import SwiftUI
+
+@main
+@MainActor
+struct PageHeightTests {
+    static func main() {
+        let app = NSApplication.shared
+        app.setActivationPolicy(.accessory)
+        ScreenPref.shared.hasSwipedScreen = true
+        let model = IslandModel(notch: NotchInfo(width: 180, height: 32, hasNotch: false))
+        let window = NSWindow(contentRect: NSRect(x: 100, y: 200, width: 900, height: 360),
+                              styleMask: [.borderless], backing: .buffered, defer: false)
+        window.contentView = IslandHostingView(rootView: IslandRootView(model: model), model: model)
+        window.orderFrontRegardless()
+        Task { @MainActor in
+            model.setState(.expanded)
+            var heights: [ScreenPref.Screen: CGFloat] = [:]
+            for page in ScreenPref.Screen.allCases {
+                model.showScreen(page)
+                try? await Task.sleep(nanoseconds: 700_000_000)
+                heights[page] = model.size.height
+                print("Measured \(page): \(model.size.height)")
+            }
+            precondition((heights[.overview] ?? 0) > (heights[.cost] ?? 0))
+            for delay: UInt64 in [0, 5_000_000, 20_000_000, 80_000_000] {
+                for destination in ScreenPref.Screen.allCases {
+                    withAnimation(.closeMorph) { model.setState(.compact) }
+                    try? await Task.sleep(nanoseconds: 400_000_000)
+                    withAnimation(.openMorph) { model.setState(.expanded) }
+                    try? await Task.sleep(nanoseconds: delay)
+                    for page in [ScreenPref.Screen.cost, .usage, .cost, .overview, destination] {
+                        model.showScreen(page)
+                        try? await Task.sleep(nanoseconds: 10_000_000)
+                    }
+                    try? await Task.sleep(nanoseconds: 700_000_000)
+                    precondition(abs(model.size.height - (heights[destination] ?? 0)) < 1,
+                                 "Opening interrupted by navigation left the wrong height")
+                }
+            }
+            let fixture = NSHostingView(rootView: ContentSizedPageLayout(selectedPage: 1, position: 0.3) {
+                Color.red.frame(height: 80)
+                Color.blue.frame(height: 217)
+                Color.green.frame(height: 350)
+            }.frame(width: 800).fixedSize(horizontal: false, vertical: true))
+            window.contentView = fixture
+            try? await Task.sleep(nanoseconds: 100_000_000)
+            precondition(abs(fixture.fittingSize.height - 217) < 1,
+                         "Selected content must own height during an interrupted slide")
+            print("PASS intrinsic sizing and all 12 immediate-open navigation sequences")
+            exit(0)
+        }
+        app.run()
+    }
+}

--- a/Tests/RenderingBenchmark.swift
+++ b/Tests/RenderingBenchmark.swift
@@ -64,7 +64,7 @@ private struct BenchmarkPanel: View {
     @ObservedObject var model: IslandModel
     var body: some View {
         ExpandedView(model: model)
-            .frame(width: model.size.width, height: model.size.height)
+            .frame(width: model.size.width)
             .background(.black)
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
     }

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -4,8 +4,7 @@
 
 `OverviewView` observes cost data and constructs the current-year snapshot.
 `OverviewContent` receives that snapshot as a value and owns provider/day
-selection. Its model reference is used for actions, not observation: resizing
-the island should not invalidate the history summary. Page changes are received
+selection. Resizing the island does not invalidate the history summary. Page changes are received
 as events to clear day details without rebuilding the grid when no day is selected.
 
 Do not put the calendar join back in a computed property read by each summary,
@@ -46,26 +45,35 @@ blurred chart transitions, and keeping offscreen carousel pages mounted.
 Any page-unmounting optimization must preserve provider selection, outgoing
 transition content, rapid navigation, and the first-use carousel cue.
 
-## Expanded panel frame pacing
+## Content-sized carousel
 
-The carousel uses `CompositedPageStrip`: one native hosting layer moves with
-Core Animation while its SwiftUI page layout stays in place. The animation
-requests the window's display maximum, up to 120 FPS; effective Low Power Mode
-(app preference or system mode) requests a maximum of 30 FPS. The rate is read
-from the actual window screen on each movement. Interrupted navigation starts
-from the presentation layer's current position. Geometry-only changes do not
-start new page animations.
+`ContentSizedPageLayout` measures the selected page at the available width with
+an unspecified height. Its horizontal position is animatable, but its selected
+page is discrete: a half-finished swipe must not select a different page's height.
+Each page remains mounted, retaining provider selection and transition content.
+Graph pages supply their own vertical padding; calendar details participate in
+normal layout rather than requesting a fixed height increment from the model.
 
-The cost count-up timeline uses the same 120/60/30 policy and stops when settled.
-This policy is scoped to expanded content. The compact/peek glow schedule is
-unchanged, and no persistent display-link loop is added to boost idle refresh.
-Command-click chart cycling is handled inside the nested hosting view.
+The expanded island wraps this intrinsic content. Its shape and background follow
+the resulting bounds. A geometry preference mirrors those bounds into
+`IslandModel.size` for mouse hit testing; that value does not constrain expanded
+layout. There are no graph/calendar height presets or page/height subscriptions.
 
-Core Animation frame-rate ranges are scheduling requests, not guarantees of
-physical presentation. Other SwiftUI animations (such as chart-style fades)
-remain system-paced; this is not a global rendering throttle for all UI.
+The native `CompositedPageStrip` prototype remains available, but the carousel
+no longer uses its separately sized hosting view. SwiftUI owns both page sizing
+and placement. The cost count-up timeline retains its 120/60/30 frame policy;
+carousel motion is system-paced. Recheck transition performance when changing
+this layout, and do not restore a second independent source of height.
 
-Run `scripts/benchmark-rendering.sh Tests/PageStripTests.swift` to verify rate
-selection, initial placement, page movement, low-power changes, and disabled
-animation placement. The navigation benchmark now seeds usage demo data too,
-so results from before that change are not a like-for-like chart workload.
+## Page height regression checks
+
+Run `scripts/benchmark-rendering.sh Tests/PageHeightTests.swift` in a graphical
+macOS session. It measures real page heights, then opens the actual island and
+navigates 0, 5, 20, or 80 ms into its opening animation, including rapid
+cost → usage → cost → overview reversals. It verifies each destination settles
+at its measured content height. A separate layout fixture checks that an
+intermediate horizontal position still uses the selected page's intrinsic height.
+
+Testing only settled page changes misses the opening-animation interruption.
+Live checks should also select a calendar day and confirm that the detail strip
+expands the panel without clipping, then navigate back to a graph.


### PR DESCRIPTION
Swiping immediately after opening the island could leave the calendar clipped to a graph's height, or leave excess space on a graph. Make the expanded panel fit the selected page's intrinsic content height, including calendar day details.

- Add a SwiftUI carousel layout that measures the selected page independently of its animated horizontal position and keeps all pages mounted.
- Remove fixed page heights and calendar-detail size callbacks. Mirror the measured panel height into the model only for hit testing.
- Replace the carousel's separately sized native hosting view with one SwiftUI layout. Carousel motion is now system-paced; the cost count-up frame-rate policy is unchanged.
- Document the layout contract and add regression coverage for navigation 0, 5, 20, and 80 ms into opening, rapid reversals, and intrinsic sizing during an interrupted slide.

Validation:
- `scripts/benchmark-rendering.sh Tests/PageHeightTests.swift` passes on this branch (12 immediate-open navigation sequences).
- Universal arm64/x86_64 build via `./build.sh`.
- Live checks covered calendar sizing, graph resizing, and day-detail expansion. The reporter confirmed the content-sized build resolves the visible issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded panels now automatically size to their visible content.
  - Carousel pages use their intrinsic heights, improving layout across different screens and content states.
  - Page transitions continue to support animated navigation, accessibility behavior, and edge interactions.

- **Bug Fixes**
  - Improved sizing during interrupted openings, navigation, and calendar detail expansion.
  - Prevented unnecessary layout growth when expanded content does not require the available height.

- **Documentation**
  - Updated performance guidance and regression coverage for content sizing and transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->