### PR TITLE
fix(usage): center the ring gauges in the usage column

### DIFF
--- a/Sources/Views/Charts/RingChart.swift
+++ b/Sources/Views/Charts/RingChart.swift
@@ -40,7 +40,6 @@ struct RingChart: View {
                             .foregroundStyle(.white.opacity(0.5))
                     }
                 }
-                if !centered { Spacer() }
             }
             Text(sub)
                 .font(Typography.caption)

--- a/Sources/Views/UsageView.swift
+++ b/Sources/Views/UsageView.swift
@@ -181,13 +181,26 @@ struct UsageChartsRow: View {
     let seed: Int
     let metrics: [UsageChartMetric]
 
+    /// Ring is the only style that draws a fixed-size gauge instead of
+    /// stretching to the tile width. Equal tiles center each ring in its own
+    /// half of the column, which leaves the gap between the two rings about
+    /// twice the gaps at the column edges. Lay the rings against equal
+    /// spacers instead so all three gaps match. A window with no reading
+    /// falls back to NoReadingChart, which does stretch, so it keeps tiles.
+    private var ringsHugContent: Bool {
+        style == .ring && metrics.allSatisfy { $0.window.hasReading }
+    }
+
     var body: some View {
-        HStack(spacing: 18) {
+        HStack(spacing: ringsHugContent ? 0 : 18) {
             ForEach(Array(metrics.enumerated()), id: \.element.id) { index, metric in
+                if ringsHugContent { Spacer(minLength: 18) }
                 ChartTile(style: style, color: color, labelKey: metric.label,
                           window: metric.window, seed: seed + index, historyKey: metric.historyKey,
                           centered: metrics.count == 1)
+                    .frame(maxWidth: ringsHugContent ? nil : .infinity)
             }
+            if ringsHugContent { Spacer(minLength: 18) }
         }
         .frame(maxWidth: metrics.count == 1 ? (style == .numeric ? 180 : 240) : .infinity)
         .frame(maxWidth: .infinity, alignment: .center)
@@ -240,7 +253,9 @@ struct ChartTile: View {
         // The blur masks the geometric mismatch between Ring and Bar so the
         // crossfade reads as one morph instead of two stacked objects.
         .transition(.chartSwap.animation(.chartSwap))
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: centered ? .top : .topLeading)
+        // Width is decided by UsageChartsRow: tiled styles get an infinite
+        // max there, rings hug their content so the row can space them.
+        .frame(maxHeight: .infinity, alignment: .center)
         .frame(height: Self.tileHeight)
         .accessibilityElement(children: .combine)
         .accessibilityLabel(


### PR DESCRIPTION
Fixes #94.

The ring gauges sat in the top-left of their tiles. `ChartTile` pinned its content to `.topLeading` inside a locked 96pt tile, and ring is the only style that draws at a fixed size instead of stretching, so the slack collected below and to the right of each ring.

- Vertical: the tile now centers its content. `UsageView` already asked for this a level up, but since 3b6121f `ContentSizedPageLayout` proposes an unspecified height, so `maxHeight: .infinity` resolves to the row's ideal 96pt and that centering has nothing left to distribute.
- Horizontal: `UsageChartsRow` now owns the width. Tiled styles keep the infinite max width they had; a pair of rings hugs its content and sits against three equal spacers. Equal tiles with centered content cannot even out the gaps here — across the column they measured 29 / 80 / 33 pt, and evening them that way would take negative `HStack` spacing. Measured off a build of this branch they now come out equal.

A window with no reading falls back to `NoReadingChart`, which does stretch, so it keeps the tiled layout.

`./scripts/verify.sh` passes. BAR / STEPPED / NUMERIC / SPARK take the unchanged path.

### Before
<img width="817" height="228" alt="Screenshot 2026-09-09 at 8 39 50 PM" src="https://github.com/user-attachments/assets/48640d24-0789-46da-a164-7d3122fcfdba" />


### After
<img width="817" height="229" alt="Screenshot 2026-09-09 at 8 39 20 PM" src="https://github.com/user-attachments/assets/c27d6fda-51b4-423d-a443-a88721bcb7d2" />