### PR TITLE
fix: stop rendering the loading sweep while idle

### DIFF
--- a/Sources/Model/LowPowerModeStore.swift
+++ b/Sources/Model/LowPowerModeStore.swift
@@ -1,13 +1,12 @@
 import Foundation
 import Combine
 
-/// User preference for the ambient halo + loading sweep.
+/// User preference for the ambient halo.
 ///
-/// Default off: both the halo glow and the cobalt orbit run continuously.
-/// With low-power mode on, both surfaces are gated on a "glow event"
-/// predicate — they appear only while a fetch is in flight, the cursor is
-/// hovering the island, or an alert is active. At rest the island goes
-/// dark, saving the per-frame angular-gradient + blur work.
+/// Default off: the halo glow remains visible at rest. With low-power mode
+/// on, it appears only while a fetch is in flight, the cursor is hovering the
+/// island, or an alert is active. The cobalt loading sweep is limited to
+/// in-flight refreshes regardless of this preference.
 ///
 /// `effectiveEnabled` ORs the user toggle with macOS's system-wide Low
 /// Power Mode. When the user enables battery saving in System Settings,

--- a/Sources/Views/IslandRootView.swift
+++ b/Sources/Views/IslandRootView.swift
@@ -359,7 +359,7 @@ private struct GlowLayer: View {
         ZStack {
             LoadingSweep(
                 active: !occlusion.isOccluded
-                    && (lowPower.effectiveEnabled ? glowEventActive : true),
+                    && (usageStore.loading || costStore.loading),
                 tint: glowColor
             )
 
@@ -393,10 +393,10 @@ private struct GlowLayer: View {
         }
     }
 
-    /// Under Low Power Mode the halo + sweep are gated on this predicate:
+    /// Under Low Power Mode the ambient halo is gated on this predicate:
     /// the user sees glow only when something is happening (a fetch is in
-    /// flight, the cursor is hovering, or an alert is active). Off-LPM it's
-    /// ignored — both surfaces run continuously.
+    /// flight, the cursor is hovering, or an alert is active). The loading
+    /// sweep is independently limited to in-flight refreshes in all modes.
     private var glowEventActive: Bool {
         hovering
             || usageStore.loading
@@ -528,10 +528,9 @@ private struct PeekPillOverlay: View {
 ///
 /// Tick rate is 30Hz (was 120Hz). 3.6s/revolution at 30Hz = 12° per frame,
 /// indistinguishable from 120Hz to the eye for a slow continuous orbit but
-/// 4× cheaper on the main thread. The bigger CPU saving comes from gating
-/// `active` on `!isWindowOccluded` upstream — when a fullscreen app or
-/// another window covers the menu bar entirely, the sweep stops rendering
-/// (the user can't see it anyway), dropping idle CPU to ~0%.
+/// 4× cheaper on the main thread. `active` is true only during an in-flight
+/// refresh and while the island is visible, so this per-frame work has no
+/// idle cost.
 ///
 /// Earlier attempts to push rotation into Core Animation (CAGradientLayer or
 /// `.rotationEffect` over a static gradient) all subtly changed the glow

--- a/Sources/Window/IslandWindowController.swift
+++ b/Sources/Window/IslandWindowController.swift
@@ -195,11 +195,9 @@ final class IslandWindowController {
         }
     }
 
-    /// Pauses the LoadingSweep when the user can't see the island —
+    /// Pauses an active LoadingSweep when the user can't see the island —
     /// fullscreen apps on a separate Space, the screen going to sleep,
     /// or anything else macOS reports as making the window invisible.
-    /// The 30Hz TimelineView is the dominant idle-CPU cost; pausing it
-    /// while occluded drops idle to ~0%.
     private func observeOcclusion() {
         // Seed the initial state — the notification doesn't fire on launch.
         WindowOcclusionStore.shared.update(


### PR DESCRIPTION
The visible island kept its 30 Hz angular-gradient `TimelineView` running whenever Low Power Mode was off, including between refreshes. On the current Mac that held CodexIsland around 19–22% CPU while idle.

Limit the rotating sweep to active usage or cost refreshes while preserving the steady cobalt halo, alert tint, occlusion behavior, and Low Power Mode treatment. In the same idle UI state, the changed build measured 0.1–0.3% CPU; manual refresh still showed the sweep state and returned to the normal synced state.

Validation:
- `./scripts/run-tests.sh`
- `SU_FEED_URL= ./build.sh`
- Compact and expanded UI smoke test
- Manual refresh smoke test
- Before/after idle CPU sampling on the same Mac


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated loading visuals so the cobalt loading sweep appears only while usage or cost data is actively refreshing.
  - Low Power Mode now controls the ambient halo independently, while active refreshes continue to display the loading sweep.
  - Loading animations remain paused when the island is occluded, reducing unnecessary visual activity and resource usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->